### PR TITLE
fix(all): golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ func main() {
 
 	// Show AST.
 	log.Print("AST")
-	pp.Println(stmt)
+	_, _ = pp.Println(stmt)
 
 	// Unparse AST to SQL source string.
 	log.Print("Unparse")

--- a/example/parse-unparse/main.go
+++ b/example/parse-unparse/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	// Show AST.
 	log.Print("AST")
-	pp.Println(stmt)
+	_, _ = pp.Println(stmt)
 
 	// Unparse AST to SQL source string.
 	log.Print("Unparse")

--- a/tools/analyze/main.go
+++ b/tools/analyze/main.go
@@ -82,7 +82,7 @@ func main() {
 	}
 
 	if *debug {
-		pp.Println(list)
+		_, _ = pp.Println(list)
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)

--- a/tools/parse/main.go
+++ b/tools/parse/main.go
@@ -47,7 +47,7 @@ func main() {
 	log.Printf("finish parsing successfully")
 
 	fmt.Println("--- AST")
-	pp.Println(node)
+	_, _ = pp.Println(node)
 	fmt.Println()
 	fmt.Println("--- SQL")
 	fmt.Println(node.SQL())


### PR DESCRIPTION
### What

Reduce `golangci-lint` warnings.