### PR TITLE
feat(analyzer): add placeholder type

### DIFF
--- a/pkg/analyzer/placeholder.go
+++ b/pkg/analyzer/placeholder.go
@@ -1,0 +1,11 @@
+package analyzer
+
+type Placeholder struct {
+	*PlaceholderType
+}
+
+func NewPlaceholder() *Placeholder {
+	return &Placeholder{
+		PlaceholderType: &PlaceholderType{},
+	}
+}

--- a/pkg/analyzer/value.go
+++ b/pkg/analyzer/value.go
@@ -22,6 +22,8 @@ func valueType(v interface{}) (Type, error) {
 			return nil, err
 		}
 		return &ArrayType{Item: item}, nil
+	case *Placeholder:
+		return v.PlaceholderType, nil
 	case []map[string]interface{}:
 		var fields []*StructField
 		for _, kv := range v {


### PR DESCRIPTION
## Problem

Sometimes one needs to use `@param` without type definition and wants to infer `@param` type from query.

For example one hopes the analyzer infers `@param` type as `STRING` from the below SQL:

```sql
SELECT * FROM Singers WHERE FirstName LIKE @param
```

## Solution

This PR introduces `Placeholder` type and `PlaceholderType` under to `analyzer` package.

- `Placeholder` is *value* type which is typed as `PlaceholderType`.
- `PlaceholderType` is *type* type which can be inferred its type on analyzing phase.

And this implements `PlaceholderType.CoerceTo` sets placeholder type as the target type.

For detailed usage, please see updated `example/analyzer/main.go`.

## TODO

- [ ] Add document
- [ ] Add test
- [ ] Support indirect references like `@param1 = @param2` (is this really needed? Maybe it should be prevented.)

- - -

/cc @kazegusuri