### PR TITLE
Improve AST definitions and docs

### DIFF
--- a/testdata/result/ddl/alter_table_add_row_deletion_policy.sql.txt
+++ b/testdata/result/ddl/alter_table_add_row_deletion_policy.sql.txt
@@ -13,6 +13,7 @@ alter table foo add row deletion policy ( older_than ( bar, interval 30 day ))
     Add:               16,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
       Row:        20,
+      Rparen:     77,
       ColumnName: &ast.Ident{
         NamePos: 55,
         NameEnd: 58,
@@ -24,7 +25,6 @@ alter table foo add row deletion policy ( older_than ( bar, interval 30 day ))
         Base:     10,
         Value:    "30",
       },
-      Rparen: 77,
     },
   },
 }

--- a/testdata/result/ddl/alter_table_replace_row_deletion_policy.sql.txt
+++ b/testdata/result/ddl/alter_table_replace_row_deletion_policy.sql.txt
@@ -13,6 +13,7 @@ alter table foo replace row deletion policy ( older_than ( bar, interval 30 day 
     Replace:           16,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
       Row:        24,
+      Rparen:     81,
       ColumnName: &ast.Ident{
         NamePos: 59,
         NameEnd: 62,
@@ -24,7 +25,6 @@ alter table foo replace row deletion policy ( older_than ( bar, interval 30 day 
         Base:     10,
         Value:    "30",
       },
-      Rparen: 81,
     },
   },
 }

--- a/testdata/result/ddl/create_table.sql.txt
+++ b/testdata/result/ddl/create_table.sql.txt
@@ -184,26 +184,6 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys: []*ast.IndexKey{
-    &ast.IndexKey{
-      DirPos: -1,
-      Name:   &ast.Ident{
-        NamePos: 439,
-        NameEnd: 442,
-        Name:    "foo",
-      },
-      Dir: "",
-    },
-    &ast.IndexKey{
-      DirPos: -1,
-      Name:   &ast.Ident{
-        NamePos: 444,
-        NameEnd: 447,
-        Name:    "bar",
-      },
-      Dir: "",
-    },
-  },
   TableConstraints: []*ast.TableConstraint{
     &ast.TableConstraint{
       ConstraintPos: 0,
@@ -320,6 +300,26 @@ create table foo (
           },
         },
       },
+    },
+  },
+  PrimaryKeys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 439,
+        NameEnd: 442,
+        Name:    "foo",
+      },
+      Dir: "",
+    },
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 444,
+        NameEnd: 447,
+        Name:    "bar",
+      },
+      Dir: "",
     },
   },
   Cluster:           (*ast.Cluster)(nil),

--- a/testdata/result/ddl/create_table_cluster.sql.txt
+++ b/testdata/result/ddl/create_table_cluster.sql.txt
@@ -48,8 +48,8 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys:      []*ast.IndexKey(nil),
   TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey(nil),
   Cluster:          &ast.Cluster{
     Comma:       60,
     OnDeleteEnd: -1,

--- a/testdata/result/ddl/create_table_cluster_and_row_deletion_policy.sql.txt
+++ b/testdata/result/ddl/create_table_cluster_and_row_deletion_policy.sql.txt
@@ -66,8 +66,8 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys:      []*ast.IndexKey(nil),
   TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey(nil),
   Cluster:          &ast.Cluster{
     Comma:       78,
     OnDeleteEnd: -1,
@@ -82,6 +82,7 @@ create table foo (
     Comma:             109,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
       Row:        113,
+      Rparen:     171,
       ColumnName: &ast.Ident{
         NamePos: 148,
         NameEnd: 151,
@@ -93,7 +94,6 @@ create table foo (
         Base:     10,
         Value:    "30",
       },
-      Rparen: 171,
     },
   },
 }

--- a/testdata/result/ddl/create_table_cluster_on_delete_no_action.sql.txt
+++ b/testdata/result/ddl/create_table_cluster_on_delete_no_action.sql.txt
@@ -31,7 +31,8 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys: []*ast.IndexKey{
+  TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
@@ -42,8 +43,7 @@ create table foo (
       Dir: "",
     },
   },
-  TableConstraints: []*ast.TableConstraint(nil),
-  Cluster:          &ast.Cluster{
+  Cluster: &ast.Cluster{
     Comma:       51,
     OnDeleteEnd: 115,
     TableName:   &ast.Ident{

--- a/testdata/result/ddl/create_table_cluster_set_on_delete.sql.txt
+++ b/testdata/result/ddl/create_table_cluster_set_on_delete.sql.txt
@@ -31,7 +31,8 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys: []*ast.IndexKey{
+  TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
@@ -42,8 +43,7 @@ create table foo (
       Dir: "",
     },
   },
-  TableConstraints: []*ast.TableConstraint(nil),
-  Cluster:          &ast.Cluster{
+  Cluster: &ast.Cluster{
     Comma:       50,
     OnDeleteEnd: 112,
     TableName:   &ast.Ident{

--- a/testdata/result/ddl/create_table_row_deletion_policy.sql.txt
+++ b/testdata/result/ddl/create_table_row_deletion_policy.sql.txt
@@ -65,13 +65,14 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys:       []*ast.IndexKey(nil),
   TableConstraints:  []*ast.TableConstraint(nil),
+  PrimaryKeys:       []*ast.IndexKey(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: &ast.CreateRowDeletionPolicy{
     Comma:             78,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
       Row:        82,
+      Rparen:     140,
       ColumnName: &ast.Ident{
         NamePos: 117,
         NameEnd: 120,
@@ -83,7 +84,6 @@ create table foo (
         Base:     10,
         Value:    "30",
       },
-      Rparen: 140,
     },
   },
 }

--- a/testdata/result/ddl/create_table_trailing_comma.sql.txt
+++ b/testdata/result/ddl/create_table_trailing_comma.sql.txt
@@ -50,7 +50,8 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys: []*ast.IndexKey{
+  TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: 66,
       Name:   &ast.Ident{
@@ -70,7 +71,6 @@ create table foo (
       Dir: "DESC",
     },
   },
-  TableConstraints:  []*ast.TableConstraint(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }

--- a/testdata/result/ddl/create_table_types.sql.txt
+++ b/testdata/result/ddl/create_table_types.sql.txt
@@ -233,7 +233,8 @@ create table types (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys: []*ast.IndexKey{
+  TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
@@ -244,7 +245,6 @@ create table types (
       Dir: "",
     },
   },
-  TableConstraints:  []*ast.TableConstraint(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }

--- a/testdata/result/ddl/grant_privileges.sql.txt
+++ b/testdata/result/ddl/grant_privileges.sql.txt
@@ -20,6 +20,7 @@ GRANT SELECT(name, level, location), UPDATE(location) ON TABLE employees, contra
   Privileges:     []*ast.Privilege{
     &ast.Privilege{
       NamePos: 0,
+      Rparen:  0,
       Name:    "SELECT",
       Columns: []*ast.Ident{
         &ast.Ident{
@@ -38,11 +39,10 @@ GRANT SELECT(name, level, location), UPDATE(location) ON TABLE employees, contra
           Name:    "location",
         },
       },
-      Lparen: 0,
-      Rparen: 0,
     },
     &ast.Privilege{
       NamePos: 0,
+      Rparen:  0,
       Name:    "UPDATE",
       Columns: []*ast.Ident{
         &ast.Ident{
@@ -51,8 +51,6 @@ GRANT SELECT(name, level, location), UPDATE(location) ON TABLE employees, contra
           Name:    "location",
         },
       },
-      Lparen: 0,
-      Rparen: 0,
     },
   },
   TableNames: []*ast.Ident{

--- a/testdata/result/ddl/revoke_privileges.sql.txt
+++ b/testdata/result/ddl/revoke_privileges.sql.txt
@@ -20,6 +20,7 @@ REVOKE SELECT(name, level, location), UPDATE(location) ON TABLE employees, contr
   Privileges:      []*ast.Privilege{
     &ast.Privilege{
       NamePos: 0,
+      Rparen:  0,
       Name:    "SELECT",
       Columns: []*ast.Ident{
         &ast.Ident{
@@ -38,11 +39,10 @@ REVOKE SELECT(name, level, location), UPDATE(location) ON TABLE employees, contr
           Name:    "location",
         },
       },
-      Lparen: 0,
-      Rparen: 0,
     },
     &ast.Privilege{
       NamePos: 0,
+      Rparen:  0,
       Name:    "UPDATE",
       Columns: []*ast.Ident{
         &ast.Ident{
@@ -51,8 +51,6 @@ REVOKE SELECT(name, level, location), UPDATE(location) ON TABLE employees, contr
           Name:    "location",
         },
       },
-      Lparen: 0,
-      Rparen: 0,
     },
   },
   TableNames: []*ast.Ident{

--- a/testdata/result/statement/alter_table_add_row_deletion_policy.sql.txt
+++ b/testdata/result/statement/alter_table_add_row_deletion_policy.sql.txt
@@ -13,6 +13,7 @@ alter table foo add row deletion policy ( older_than ( bar, interval 30 day ))
     Add:               16,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
       Row:        20,
+      Rparen:     77,
       ColumnName: &ast.Ident{
         NamePos: 55,
         NameEnd: 58,
@@ -24,7 +25,6 @@ alter table foo add row deletion policy ( older_than ( bar, interval 30 day ))
         Base:     10,
         Value:    "30",
       },
-      Rparen: 77,
     },
   },
 }

--- a/testdata/result/statement/alter_table_replace_row_deletion_policy.sql.txt
+++ b/testdata/result/statement/alter_table_replace_row_deletion_policy.sql.txt
@@ -13,6 +13,7 @@ alter table foo replace row deletion policy ( older_than ( bar, interval 30 day 
     Replace:           16,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
       Row:        24,
+      Rparen:     81,
       ColumnName: &ast.Ident{
         NamePos: 59,
         NameEnd: 62,
@@ -24,7 +25,6 @@ alter table foo replace row deletion policy ( older_than ( bar, interval 30 day 
         Base:     10,
         Value:    "30",
       },
-      Rparen: 81,
     },
   },
 }

--- a/testdata/result/statement/create_table.sql.txt
+++ b/testdata/result/statement/create_table.sql.txt
@@ -184,26 +184,6 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys: []*ast.IndexKey{
-    &ast.IndexKey{
-      DirPos: -1,
-      Name:   &ast.Ident{
-        NamePos: 439,
-        NameEnd: 442,
-        Name:    "foo",
-      },
-      Dir: "",
-    },
-    &ast.IndexKey{
-      DirPos: -1,
-      Name:   &ast.Ident{
-        NamePos: 444,
-        NameEnd: 447,
-        Name:    "bar",
-      },
-      Dir: "",
-    },
-  },
   TableConstraints: []*ast.TableConstraint{
     &ast.TableConstraint{
       ConstraintPos: 0,
@@ -320,6 +300,26 @@ create table foo (
           },
         },
       },
+    },
+  },
+  PrimaryKeys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 439,
+        NameEnd: 442,
+        Name:    "foo",
+      },
+      Dir: "",
+    },
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 444,
+        NameEnd: 447,
+        Name:    "bar",
+      },
+      Dir: "",
     },
   },
   Cluster:           (*ast.Cluster)(nil),

--- a/testdata/result/statement/create_table_cluster.sql.txt
+++ b/testdata/result/statement/create_table_cluster.sql.txt
@@ -48,8 +48,8 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys:      []*ast.IndexKey(nil),
   TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey(nil),
   Cluster:          &ast.Cluster{
     Comma:       60,
     OnDeleteEnd: -1,

--- a/testdata/result/statement/create_table_cluster_and_row_deletion_policy.sql.txt
+++ b/testdata/result/statement/create_table_cluster_and_row_deletion_policy.sql.txt
@@ -66,8 +66,8 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys:      []*ast.IndexKey(nil),
   TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey(nil),
   Cluster:          &ast.Cluster{
     Comma:       78,
     OnDeleteEnd: -1,
@@ -82,6 +82,7 @@ create table foo (
     Comma:             109,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
       Row:        113,
+      Rparen:     171,
       ColumnName: &ast.Ident{
         NamePos: 148,
         NameEnd: 151,
@@ -93,7 +94,6 @@ create table foo (
         Base:     10,
         Value:    "30",
       },
-      Rparen: 171,
     },
   },
 }

--- a/testdata/result/statement/create_table_cluster_on_delete_no_action.sql.txt
+++ b/testdata/result/statement/create_table_cluster_on_delete_no_action.sql.txt
@@ -31,7 +31,8 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys: []*ast.IndexKey{
+  TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
@@ -42,8 +43,7 @@ create table foo (
       Dir: "",
     },
   },
-  TableConstraints: []*ast.TableConstraint(nil),
-  Cluster:          &ast.Cluster{
+  Cluster: &ast.Cluster{
     Comma:       51,
     OnDeleteEnd: 115,
     TableName:   &ast.Ident{

--- a/testdata/result/statement/create_table_cluster_set_on_delete.sql.txt
+++ b/testdata/result/statement/create_table_cluster_set_on_delete.sql.txt
@@ -31,7 +31,8 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys: []*ast.IndexKey{
+  TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
@@ -42,8 +43,7 @@ create table foo (
       Dir: "",
     },
   },
-  TableConstraints: []*ast.TableConstraint(nil),
-  Cluster:          &ast.Cluster{
+  Cluster: &ast.Cluster{
     Comma:       50,
     OnDeleteEnd: 112,
     TableName:   &ast.Ident{

--- a/testdata/result/statement/create_table_row_deletion_policy.sql.txt
+++ b/testdata/result/statement/create_table_row_deletion_policy.sql.txt
@@ -65,13 +65,14 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys:       []*ast.IndexKey(nil),
   TableConstraints:  []*ast.TableConstraint(nil),
+  PrimaryKeys:       []*ast.IndexKey(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: &ast.CreateRowDeletionPolicy{
     Comma:             78,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
       Row:        82,
+      Rparen:     140,
       ColumnName: &ast.Ident{
         NamePos: 117,
         NameEnd: 120,
@@ -83,7 +84,6 @@ create table foo (
         Base:     10,
         Value:    "30",
       },
-      Rparen: 140,
     },
   },
 }

--- a/testdata/result/statement/create_table_trailing_comma.sql.txt
+++ b/testdata/result/statement/create_table_trailing_comma.sql.txt
@@ -50,7 +50,8 @@ create table foo (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys: []*ast.IndexKey{
+  TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: 66,
       Name:   &ast.Ident{
@@ -70,7 +71,6 @@ create table foo (
       Dir: "DESC",
     },
   },
-  TableConstraints:  []*ast.TableConstraint(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }

--- a/testdata/result/statement/create_table_types.sql.txt
+++ b/testdata/result/statement/create_table_types.sql.txt
@@ -233,7 +233,8 @@ create table types (
       Options:       (*ast.ColumnDefOptions)(nil),
     },
   },
-  PrimaryKeys: []*ast.IndexKey{
+  TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
@@ -244,7 +245,6 @@ create table types (
       Dir: "",
     },
   },
-  TableConstraints:  []*ast.TableConstraint(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }

--- a/testdata/result/statement/grant_privileges.sql.txt
+++ b/testdata/result/statement/grant_privileges.sql.txt
@@ -20,6 +20,7 @@ GRANT SELECT(name, level, location), UPDATE(location) ON TABLE employees, contra
   Privileges:     []*ast.Privilege{
     &ast.Privilege{
       NamePos: 0,
+      Rparen:  0,
       Name:    "SELECT",
       Columns: []*ast.Ident{
         &ast.Ident{
@@ -38,11 +39,10 @@ GRANT SELECT(name, level, location), UPDATE(location) ON TABLE employees, contra
           Name:    "location",
         },
       },
-      Lparen: 0,
-      Rparen: 0,
     },
     &ast.Privilege{
       NamePos: 0,
+      Rparen:  0,
       Name:    "UPDATE",
       Columns: []*ast.Ident{
         &ast.Ident{
@@ -51,8 +51,6 @@ GRANT SELECT(name, level, location), UPDATE(location) ON TABLE employees, contra
           Name:    "location",
         },
       },
-      Lparen: 0,
-      Rparen: 0,
     },
   },
   TableNames: []*ast.Ident{

--- a/testdata/result/statement/revoke_privileges.sql.txt
+++ b/testdata/result/statement/revoke_privileges.sql.txt
@@ -20,6 +20,7 @@ REVOKE SELECT(name, level, location), UPDATE(location) ON TABLE employees, contr
   Privileges:      []*ast.Privilege{
     &ast.Privilege{
       NamePos: 0,
+      Rparen:  0,
       Name:    "SELECT",
       Columns: []*ast.Ident{
         &ast.Ident{
@@ -38,11 +39,10 @@ REVOKE SELECT(name, level, location), UPDATE(location) ON TABLE employees, contr
           Name:    "location",
         },
       },
-      Lparen: 0,
-      Rparen: 0,
     },
     &ast.Privilege{
       NamePos: 0,
+      Rparen:  0,
       Name:    "UPDATE",
       Columns: []*ast.Ident{
         &ast.Ident{
@@ -51,8 +51,6 @@ REVOKE SELECT(name, level, location), UPDATE(location) ON TABLE employees, contr
           Name:    "location",
         },
       },
-      Lparen: 0,
-      Rparen: 0,
     },
   },
   TableNames: []*ast.Ident{


### PR DESCRIPTION
This PR adds the package docs for describing `text/template` fashion comments and pos/end comments of nodes.
Also, this fixes code styles and removes some unnecessary fields.