### PR TITLE
add support for missing IF (NOT) EXISTS clauses

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1791,14 +1791,15 @@ type InterleaveIn struct {
 
 // DropIndex is DROP INDEX statement node.
 //
-//	DROP INDEX {{.Name | sql}}
+//	DROP INDEX {{.IfExists}}IF EXISTS{{end}} {{.Name | sql}}
 type DropIndex struct {
 	// pos = Drop
 	// end = Name.end
 
 	Drop token.Pos // position of "DROP" keyword
 
-	Name *Ident
+	IfExists bool
+	Name     *Ident
 }
 
 // CreateRole is CREATE ROLE statement node.

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1741,7 +1741,7 @@ type DropTable struct {
 //	CREATE
 //	  {{if .Unique}}UNIQUE{{end}}
 //	  {{if .NullFiltered}}NULL_FILTERED{{end}}
-//	INDEX {{.Name | sql}} ON {{.TableName | sql}} (
+//	INDEX {{if .IfExists}}IF NOT EXISTS{{end}} {{.Name | sql}} ON {{.TableName | sql}} (
 //	  {{.Keys | sqlJoin ","}}
 //	)
 //	{{.Storing | sqlOpt}}
@@ -1755,6 +1755,7 @@ type CreateIndex struct {
 
 	Unique       bool
 	NullFiltered bool
+	IfNotExists  bool
 	Name         *Ident
 	TableName    *Ident
 	Keys         []*IndexKey

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1600,14 +1600,15 @@ type AlterTable struct {
 
 // AddColumn is ADD COLUMN clause in ALTER TABLE.
 //
-//	ADD COLUMN {{.Column | sql}}
+//	ADD COLUMN {{.IfNotExists}}IF NOT EXISTS{{end}} {{.Column | sql}}
 type AddColumn struct {
 	// pos = Add
 	// end = Column.end
 
 	Add token.Pos // position of "ADD" keyword
 
-	Column *ColumnDef
+	IfNotExists bool
+	Column      *ColumnDef
 }
 
 // AddTableConstraint is ADD table_constraint clause in ALTER TABLE.

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -873,7 +873,11 @@ func (a *AlterTable) SQL() string {
 }
 
 func (a *AddColumn) SQL() string {
-	return "ADD COLUMN " + a.Column.SQL()
+	sql := "ADD COLUMN "
+	if a.IfNotExists {
+		sql += "IF NOT EXISTS "
+	}
+	return sql + a.Column.SQL()
 }
 
 func (a *AddTableConstraint) SQL() string {

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -940,7 +940,11 @@ func (c *CreateIndex) SQL() string {
 	if c.NullFiltered {
 		sql += "NULL_FILTERED "
 	}
-	sql += "INDEX " + c.Name.SQL() + " ON " + c.TableName.SQL() + " ("
+	sql += "INDEX "
+	if c.IfNotExists {
+		sql += "IF NOT EXISTS "
+	}
+	sql += c.Name.SQL() + " ON " + c.TableName.SQL() + " ("
 	for i, k := range c.Keys {
 		if i != 0 {
 			sql += ", "

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -982,7 +982,11 @@ func (i *InterleaveIn) SQL() string {
 }
 
 func (d *DropIndex) SQL() string {
-	return "DROP INDEX " + d.Name.SQL()
+	sql := "DROP INDEX "
+	if d.IfExists {
+		sql += "IF EXISTS "
+	}
+	return sql + d.Name.SQL()
 }
 
 func (c *CreateRole) SQL() string {

--- a/parser.go
+++ b/parser.go
@@ -2730,10 +2730,17 @@ func (p *Parser) parseDropTable(pos token.Pos) *ast.DropTable {
 
 func (p *Parser) parseDropIndex(pos token.Pos) *ast.DropIndex {
 	p.expectKeywordLike("INDEX")
+	ifExists := false
+	if p.Token.IsKeywordLike("IF") {
+		p.nextToken()
+		p.expect("EXISTS")
+		ifExists = true
+	}
 	name := p.parseIdent()
 	return &ast.DropIndex{
-		Drop: pos,
-		Name: name,
+		Drop:     pos,
+		IfExists: ifExists,
+		Name:     name,
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -2571,10 +2571,18 @@ func (p *Parser) parseAlterTableAdd() ast.TableAlternation {
 	switch {
 	case p.Token.IsKeywordLike("COLUMN"):
 		p.expectKeywordLike("COLUMN")
+		ifNotExists := false
+		if p.Token.IsKeywordLike("IF") {
+			p.nextToken()
+			p.expect("NOT")
+			p.expect("EXISTS")
+			ifNotExists = true
+		}
 		column := p.parseColumnDef()
 		alternation = &ast.AddColumn{
-			Add:    pos,
-			Column: column,
+			Add:         pos,
+			IfNotExists: ifNotExists,
+			Column:      column,
 		}
 	case p.Token.IsKeywordLike("CONSTRAINT"):
 		alternation = &ast.AddTableConstraint{

--- a/parser.go
+++ b/parser.go
@@ -2030,13 +2030,7 @@ func (p *Parser) parseCreateDatabase(pos token.Pos) *ast.CreateDatabase {
 
 func (p *Parser) parseCreateTable(pos token.Pos) *ast.CreateTable {
 	p.expectKeywordLike("TABLE")
-	ifNotExists := false
-	if p.Token.IsKeywordLike("IF") {
-		p.nextToken()
-		p.expect("NOT")
-		p.expect("EXISTS")
-		ifNotExists = true
-	}
+	ifNotExists := p.parseIfNotExists()
 	name := p.parseIdent()
 
 	// This loop allows parsing trailing comma intentionally.
@@ -2102,13 +2096,7 @@ func (p *Parser) parseCreateTable(pos token.Pos) *ast.CreateTable {
 
 func (p *Parser) parseCreateSequence(pos token.Pos) *ast.CreateSequence {
 	p.expectKeywordLike("SEQUENCE")
-	ifNotExists := false
-	if p.Token.IsKeywordLike("IF") {
-		p.nextToken()
-		p.expect("NOT")
-		p.expect("EXISTS")
-		ifNotExists = true
-	}
+	ifNotExists := p.parseIfNotExists()
 	name := p.parseIdent()
 
 	p.expectKeywordLike("OPTIONS")
@@ -2452,13 +2440,7 @@ func (p *Parser) parseCreateIndex(pos token.Pos) *ast.CreateIndex {
 
 	p.expectKeywordLike("INDEX")
 
-	ifNotExists := false
-	if p.Token.IsKeywordLike("IF") {
-		p.nextToken()
-		p.expect("NOT")
-		p.expect("EXISTS")
-		ifNotExists = true
-	}
+	ifNotExists := p.parseIfNotExists()
 
 	name := p.parseIdent()
 
@@ -2571,13 +2553,7 @@ func (p *Parser) parseAlterTableAdd() ast.TableAlternation {
 	switch {
 	case p.Token.IsKeywordLike("COLUMN"):
 		p.expectKeywordLike("COLUMN")
-		ifNotExists := false
-		if p.Token.IsKeywordLike("IF") {
-			p.nextToken()
-			p.expect("NOT")
-			p.expect("EXISTS")
-			ifNotExists = true
-		}
+		ifNotExists := p.parseIfNotExists()
 		column := p.parseColumnDef()
 		alternation = &ast.AddColumn{
 			Add:         pos,
@@ -2714,12 +2690,7 @@ func (p *Parser) parseAlterColumn() ast.TableAlternation {
 
 func (p *Parser) parseDropTable(pos token.Pos) *ast.DropTable {
 	p.expectKeywordLike("TABLE")
-	ifExists := false
-	if p.Token.IsKeywordLike("IF") {
-		p.nextToken()
-		p.expect("EXISTS")
-		ifExists = true
-	}
+	ifExists := p.parseIfExists()
 	name := p.parseIdent()
 	return &ast.DropTable{
 		Drop:     pos,
@@ -2730,12 +2701,7 @@ func (p *Parser) parseDropTable(pos token.Pos) *ast.DropTable {
 
 func (p *Parser) parseDropIndex(pos token.Pos) *ast.DropIndex {
 	p.expectKeywordLike("INDEX")
-	ifExists := false
-	if p.Token.IsKeywordLike("IF") {
-		p.nextToken()
-		p.expect("EXISTS")
-		ifExists = true
-	}
+	ifExists := p.parseIfExists()
 	name := p.parseIdent()
 	return &ast.DropIndex{
 		Drop:     pos,
@@ -3014,6 +2980,25 @@ func (p *Parser) parseScalarSchemaType() ast.SchemaType {
 	}
 
 	panic(p.errorfAtToken(id, "expect ident: %s, %s, but: %s", strings.Join(scalarSchemaTypes, ","), strings.Join(sizedSchemaTypes, ","), id.AsString))
+}
+
+func (p *Parser) parseIfNotExists() bool {
+	if p.Token.IsKeywordLike("IF") {
+		p.nextToken()
+		p.expect("NOT")
+		p.expect("EXISTS")
+		return true
+	}
+	return false
+}
+
+func (p *Parser) parseIfExists() bool {
+	if p.Token.IsKeywordLike("IF") {
+		p.nextToken()
+		p.expect("EXISTS")
+		return true
+	}
+	return false
 }
 
 // ================================================================================

--- a/parser.go
+++ b/parser.go
@@ -2451,6 +2451,15 @@ func (p *Parser) parseCreateIndex(pos token.Pos) *ast.CreateIndex {
 	}
 
 	p.expectKeywordLike("INDEX")
+
+	ifNotExists := false
+	if p.Token.IsKeywordLike("IF") {
+		p.nextToken()
+		p.expect("NOT")
+		p.expect("EXISTS")
+		ifNotExists = true
+	}
+
 	name := p.parseIdent()
 
 	p.expect("ON")
@@ -2478,6 +2487,7 @@ func (p *Parser) parseCreateIndex(pos token.Pos) *ast.CreateIndex {
 		Rparen:       rparen,
 		Unique:       unique,
 		NullFiltered: nullFiltered,
+		IfNotExists:  ifNotExists,
 		Name:         name,
 		TableName:    tableName,
 		Keys:         keys,

--- a/testdata/input/ddl/alter_table_add_column_if_not_exists.sql
+++ b/testdata/input/ddl/alter_table_add_column_if_not_exists.sql
@@ -1,0 +1,1 @@
+alter table foo add column if not exists baz string(max) not null

--- a/testdata/input/ddl/create_index_if_not_exists.sql
+++ b/testdata/input/ddl/create_index_if_not_exists.sql
@@ -1,0 +1,1 @@
+create index if not exists foo_bar on foo (bar)

--- a/testdata/input/ddl/drop_index_if_exists.sql
+++ b/testdata/input/ddl/drop_index_if_exists.sql
@@ -1,0 +1,1 @@
+drop index if exists foo_bar

--- a/testdata/result/ddl/alter_table_add_column_if_not_exists.sql.txt
+++ b/testdata/result/ddl/alter_table_add_column_if_not_exists.sql.txt
@@ -1,5 +1,6 @@
---- alter_table_add_column.sql
-alter table foo add column baz string(max) not null
+--- alter_table_add_column_if_not_exists.sql
+alter table foo add column if not exists baz string(max) not null
+
 --- AST
 &ast.AlterTable{
   Alter: 0,
@@ -10,17 +11,17 @@ alter table foo add column baz string(max) not null
   },
   TableAlternation: &ast.AddColumn{
     Add:         16,
-    IfNotExists: false,
+    IfNotExists: true,
     Column:      &ast.ColumnDef{
-      Null: 47,
+      Null: 61,
       Name: &ast.Ident{
-        NamePos: 27,
-        NameEnd: 30,
+        NamePos: 41,
+        NameEnd: 44,
         Name:    "baz",
       },
       Type: &ast.SizedSchemaType{
-        NamePos: 31,
-        Rparen:  41,
+        NamePos: 45,
+        Rparen:  55,
         Name:    "STRING",
         Max:     true,
         Size:    nil,
@@ -34,4 +35,4 @@ alter table foo add column baz string(max) not null
 }
 
 --- SQL
-ALTER TABLE foo ADD COLUMN baz STRING(MAX) NOT NULL
+ALTER TABLE foo ADD COLUMN IF NOT EXISTS baz STRING(MAX) NOT NULL

--- a/testdata/result/ddl/alter_table_add_column_with_if_expression.sql.txt
+++ b/testdata/result/ddl/alter_table_add_column_with_if_expression.sql.txt
@@ -9,8 +9,9 @@ ALTER TABLE foo ADD COLUMN expired_at TIMESTAMP AS (IF (status != "OPEN" AND sta
     Name:    "foo",
   },
   TableAlternation: &ast.AddColumn{
-    Add:    16,
-    Column: &ast.ColumnDef{
+    Add:         16,
+    IfNotExists: false,
+    Column:      &ast.ColumnDef{
       Null: -1,
       Name: &ast.Ident{
         NamePos: 27,

--- a/testdata/result/ddl/create_index.sql.txt
+++ b/testdata/result/ddl/create_index.sql.txt
@@ -10,6 +10,7 @@ create index foo_bar on foo (
   Rparen:       53,
   Unique:       false,
   NullFiltered: false,
+  IfNotExists:  false,
   Name:         &ast.Ident{
     NamePos: 13,
     NameEnd: 20,

--- a/testdata/result/ddl/create_index_if_not_exists.sql.txt
+++ b/testdata/result/ddl/create_index_if_not_exists.sql.txt
@@ -1,0 +1,37 @@
+--- create_index_if_not_exists.sql
+create index if not exists foo_bar on foo (bar)
+
+--- AST
+&ast.CreateIndex{
+  Create:       0,
+  Rparen:       46,
+  Unique:       false,
+  NullFiltered: false,
+  IfNotExists:  true,
+  Name:         &ast.Ident{
+    NamePos: 27,
+    NameEnd: 34,
+    Name:    "foo_bar",
+  },
+  TableName: &ast.Ident{
+    NamePos: 38,
+    NameEnd: 41,
+    Name:    "foo",
+  },
+  Keys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 43,
+        NameEnd: 46,
+        Name:    "bar",
+      },
+      Dir: "",
+    },
+  },
+  Storing:      (*ast.Storing)(nil),
+  InterleaveIn: (*ast.InterleaveIn)(nil),
+}
+
+--- SQL
+CREATE INDEX IF NOT EXISTS foo_bar ON foo (bar)

--- a/testdata/result/ddl/create_index_interleave.sql.txt
+++ b/testdata/result/ddl/create_index_interleave.sql.txt
@@ -10,6 +10,7 @@ create index foo_bar on foo (
   Rparen:       41,
   Unique:       false,
   NullFiltered: false,
+  IfNotExists:  false,
   Name:         &ast.Ident{
     NamePos: 13,
     NameEnd: 20,

--- a/testdata/result/ddl/create_index_storing.sql.txt
+++ b/testdata/result/ddl/create_index_storing.sql.txt
@@ -9,6 +9,7 @@ create index foo_bar on foo (
   Rparen:       40,
   Unique:       false,
   NullFiltered: false,
+  IfNotExists:  false,
   Name:         &ast.Ident{
     NamePos: 13,
     NameEnd: 20,

--- a/testdata/result/ddl/create_uniq_null_filtered_index.sql.txt
+++ b/testdata/result/ddl/create_uniq_null_filtered_index.sql.txt
@@ -7,6 +7,7 @@ create unique null_filtered index foo_bar on foo (foo)
   Rparen:       53,
   Unique:       true,
   NullFiltered: true,
+  IfNotExists:  false,
   Name:         &ast.Ident{
     NamePos: 34,
     NameEnd: 41,

--- a/testdata/result/ddl/drop_index.sql.txt
+++ b/testdata/result/ddl/drop_index.sql.txt
@@ -3,8 +3,9 @@ drop index foo_bar
 
 --- AST
 &ast.DropIndex{
-  Drop: 0,
-  Name: &ast.Ident{
+  Drop:     0,
+  IfExists: false,
+  Name:     &ast.Ident{
     NamePos: 11,
     NameEnd: 18,
     Name:    "foo_bar",

--- a/testdata/result/ddl/drop_index_if_exists.sql.txt
+++ b/testdata/result/ddl/drop_index_if_exists.sql.txt
@@ -1,0 +1,16 @@
+--- drop_index_if_exists.sql
+drop index if exists foo_bar
+
+--- AST
+&ast.DropIndex{
+  Drop:     0,
+  IfExists: true,
+  Name:     &ast.Ident{
+    NamePos: 21,
+    NameEnd: 28,
+    Name:    "foo_bar",
+  },
+}
+
+--- SQL
+DROP INDEX IF EXISTS foo_bar

--- a/testdata/result/statement/alter_table_add_column.sql.txt
+++ b/testdata/result/statement/alter_table_add_column.sql.txt
@@ -9,8 +9,9 @@ alter table foo add column baz string(max) not null
     Name:    "foo",
   },
   TableAlternation: &ast.AddColumn{
-    Add:    16,
-    Column: &ast.ColumnDef{
+    Add:         16,
+    IfNotExists: false,
+    Column:      &ast.ColumnDef{
       Null: 47,
       Name: &ast.Ident{
         NamePos: 27,

--- a/testdata/result/statement/alter_table_add_column_if_not_exists.sql.txt
+++ b/testdata/result/statement/alter_table_add_column_if_not_exists.sql.txt
@@ -1,5 +1,6 @@
---- alter_table_add_column.sql
-alter table foo add column baz string(max) not null
+--- alter_table_add_column_if_not_exists.sql
+alter table foo add column if not exists baz string(max) not null
+
 --- AST
 &ast.AlterTable{
   Alter: 0,
@@ -10,17 +11,17 @@ alter table foo add column baz string(max) not null
   },
   TableAlternation: &ast.AddColumn{
     Add:         16,
-    IfNotExists: false,
+    IfNotExists: true,
     Column:      &ast.ColumnDef{
-      Null: 47,
+      Null: 61,
       Name: &ast.Ident{
-        NamePos: 27,
-        NameEnd: 30,
+        NamePos: 41,
+        NameEnd: 44,
         Name:    "baz",
       },
       Type: &ast.SizedSchemaType{
-        NamePos: 31,
-        Rparen:  41,
+        NamePos: 45,
+        Rparen:  55,
         Name:    "STRING",
         Max:     true,
         Size:    nil,
@@ -34,4 +35,4 @@ alter table foo add column baz string(max) not null
 }
 
 --- SQL
-ALTER TABLE foo ADD COLUMN baz STRING(MAX) NOT NULL
+ALTER TABLE foo ADD COLUMN IF NOT EXISTS baz STRING(MAX) NOT NULL

--- a/testdata/result/statement/alter_table_add_column_with_if_expression.sql.txt
+++ b/testdata/result/statement/alter_table_add_column_with_if_expression.sql.txt
@@ -9,8 +9,9 @@ ALTER TABLE foo ADD COLUMN expired_at TIMESTAMP AS (IF (status != "OPEN" AND sta
     Name:    "foo",
   },
   TableAlternation: &ast.AddColumn{
-    Add:    16,
-    Column: &ast.ColumnDef{
+    Add:         16,
+    IfNotExists: false,
+    Column:      &ast.ColumnDef{
       Null: -1,
       Name: &ast.Ident{
         NamePos: 27,

--- a/testdata/result/statement/create_index.sql.txt
+++ b/testdata/result/statement/create_index.sql.txt
@@ -10,6 +10,7 @@ create index foo_bar on foo (
   Rparen:       53,
   Unique:       false,
   NullFiltered: false,
+  IfNotExists:  false,
   Name:         &ast.Ident{
     NamePos: 13,
     NameEnd: 20,

--- a/testdata/result/statement/create_index_if_not_exists.sql.txt
+++ b/testdata/result/statement/create_index_if_not_exists.sql.txt
@@ -1,0 +1,37 @@
+--- create_index_if_not_exists.sql
+create index if not exists foo_bar on foo (bar)
+
+--- AST
+&ast.CreateIndex{
+  Create:       0,
+  Rparen:       46,
+  Unique:       false,
+  NullFiltered: false,
+  IfNotExists:  true,
+  Name:         &ast.Ident{
+    NamePos: 27,
+    NameEnd: 34,
+    Name:    "foo_bar",
+  },
+  TableName: &ast.Ident{
+    NamePos: 38,
+    NameEnd: 41,
+    Name:    "foo",
+  },
+  Keys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 43,
+        NameEnd: 46,
+        Name:    "bar",
+      },
+      Dir: "",
+    },
+  },
+  Storing:      (*ast.Storing)(nil),
+  InterleaveIn: (*ast.InterleaveIn)(nil),
+}
+
+--- SQL
+CREATE INDEX IF NOT EXISTS foo_bar ON foo (bar)

--- a/testdata/result/statement/create_index_interleave.sql.txt
+++ b/testdata/result/statement/create_index_interleave.sql.txt
@@ -10,6 +10,7 @@ create index foo_bar on foo (
   Rparen:       41,
   Unique:       false,
   NullFiltered: false,
+  IfNotExists:  false,
   Name:         &ast.Ident{
     NamePos: 13,
     NameEnd: 20,

--- a/testdata/result/statement/create_index_storing.sql.txt
+++ b/testdata/result/statement/create_index_storing.sql.txt
@@ -9,6 +9,7 @@ create index foo_bar on foo (
   Rparen:       40,
   Unique:       false,
   NullFiltered: false,
+  IfNotExists:  false,
   Name:         &ast.Ident{
     NamePos: 13,
     NameEnd: 20,

--- a/testdata/result/statement/create_uniq_null_filtered_index.sql.txt
+++ b/testdata/result/statement/create_uniq_null_filtered_index.sql.txt
@@ -7,6 +7,7 @@ create unique null_filtered index foo_bar on foo (foo)
   Rparen:       53,
   Unique:       true,
   NullFiltered: true,
+  IfNotExists:  false,
   Name:         &ast.Ident{
     NamePos: 34,
     NameEnd: 41,

--- a/testdata/result/statement/drop_index.sql.txt
+++ b/testdata/result/statement/drop_index.sql.txt
@@ -3,8 +3,9 @@ drop index foo_bar
 
 --- AST
 &ast.DropIndex{
-  Drop: 0,
-  Name: &ast.Ident{
+  Drop:     0,
+  IfExists: false,
+  Name:     &ast.Ident{
     NamePos: 11,
     NameEnd: 18,
     Name:    "foo_bar",

--- a/testdata/result/statement/drop_index_if_exists.sql.txt
+++ b/testdata/result/statement/drop_index_if_exists.sql.txt
@@ -1,0 +1,16 @@
+--- drop_index_if_exists.sql
+drop index if exists foo_bar
+
+--- AST
+&ast.DropIndex{
+  Drop:     0,
+  IfExists: true,
+  Name:     &ast.Ident{
+    NamePos: 21,
+    NameEnd: 28,
+    Name:    "foo_bar",
+  },
+}
+
+--- SQL
+DROP INDEX IF EXISTS foo_bar


### PR DESCRIPTION
This PR adds support for following DDL syntax.

- [CREATE INDEX IF NOT EXISTS](https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#create-index)
- [ALTER TABLE ADD COLUMN IF NOT EXISTS](https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#alter_table)
- [DROP INDEX IF EXISTS](https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#drop-index)