### PR TITLE
Add support for CREATE VIEW with SQL SECURITY DEFINER

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1599,7 +1599,7 @@ type RowDeletionPolicy struct {
 // CreateView is CREATE VIEW statement node.
 //
 //	CREATE {{if .OrReplace}}OR REPLACE{{end}} VIEW {{.Name | sql}}
-//	SQL SECURITY INVOKER AS
+//	SQL SECURITY {{.SecurityType}} AS
 //	{{.Query | sql}}
 type CreateView struct {
 	// pos = Create
@@ -1607,9 +1607,10 @@ type CreateView struct {
 
 	Create token.Pos
 
-	Name      *Ident
-	OrReplace bool
-	Query     QueryExpr
+	Name         *Ident
+	OrReplace    bool
+	SecurityType SecurityType
+	Query        QueryExpr
 }
 
 // AlterTable is ALTER TABLE statement node.

--- a/ast/const.go
+++ b/ast/const.go
@@ -115,3 +115,10 @@ const (
 	OnDeleteCascade  OnDeleteAction = "ON DELETE CASCADE"
 	OnDeleteNoAction OnDeleteAction = "ON DELETE NO ACTION"
 )
+
+type SecurityType string
+
+const (
+	SecurityTypeInvoker SecurityType = "INVOKER"
+	SecurityTypeDefiner SecurityType = "DEFINER"
+)

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -771,7 +771,7 @@ func (c *CreateView) SQL() string {
 	if c.OrReplace {
 		sql += " OR REPLACE"
 	}
-	sql += " VIEW " + c.Name.SQL() + " SQL SECURITY INVOKER AS " + c.Query.SQL()
+	sql += " VIEW " + c.Name.SQL() + " SQL SECURITY " + string(c.SecurityType) + " AS " + c.Query.SQL()
 	return sql
 }
 

--- a/parser.go
+++ b/parser.go
@@ -2164,16 +2164,28 @@ func (p *Parser) parseCreateView(pos token.Pos) *ast.CreateView {
 
 	p.expectKeywordLike("SQL")
 	p.expectKeywordLike("SECURITY")
-	p.expectKeywordLike("INVOKER")
+
+	id := p.expect(token.TokenIdent)
+	var securityType ast.SecurityType
+	switch {
+	case id.IsIdent("INVOKER"):
+		securityType = ast.SecurityTypeInvoker
+	case id.IsIdent("DEFINER"):
+		securityType = ast.SecurityTypeDefiner
+	default:
+		p.panicfAtToken(id, "expected identifier: INVOKER, DEFINER, but: %s", id.Raw)
+	}
+
 	p.expect("AS")
 
 	query := p.parseQueryExpr()
 
 	return &ast.CreateView{
-		Create:    pos,
-		Name:      name,
-		OrReplace: orReplace,
-		Query:     query,
+		Create:       pos,
+		Name:         name,
+		OrReplace:    orReplace,
+		SecurityType: securityType,
+		Query:        query,
 	}
 }
 

--- a/testdata/input/ddl/create_view_sql_security_definer.sql
+++ b/testdata/input/ddl/create_view_sql_security_definer.sql
@@ -1,0 +1,6 @@
+create view singernames
+sql security definer
+as select
+    singers.singerid as singerid,
+    singers.firstname || ' ' || singers.lastname as name
+from singers

--- a/testdata/result/ddl/create_view.sql.txt
+++ b/testdata/result/ddl/create_view.sql.txt
@@ -14,8 +14,9 @@ from singers
     NameEnd: 23,
     Name:    "singernames",
   },
-  OrReplace: false,
-  Query:     &ast.Select{
+  OrReplace:    false,
+  SecurityType: "INVOKER",
+  Query:        &ast.Select{
     Select:   48,
     Distinct: false,
     AsStruct: false,

--- a/testdata/result/ddl/create_view_sql_security_definer.sql.txt
+++ b/testdata/result/ddl/create_view_sql_security_definer.sql.txt
@@ -1,6 +1,6 @@
---- create_or_replace_view.sql
-create or replace view singernames
-sql security invoker
+--- create_view_sql_security_definer.sql
+create view singernames
+sql security definer
 as select
     singers.singerid as singerid,
     singers.firstname || ' ' || singers.lastname as name
@@ -10,14 +10,14 @@ from singers
 &ast.CreateView{
   Create: 0,
   Name:   &ast.Ident{
-    NamePos: 23,
-    NameEnd: 34,
+    NamePos: 12,
+    NameEnd: 23,
     Name:    "singernames",
   },
-  OrReplace:    true,
-  SecurityType: "INVOKER",
+  OrReplace:    false,
+  SecurityType: "DEFINER",
   Query:        &ast.Select{
-    Select:   59,
+    Select:   48,
     Distinct: false,
     AsStruct: false,
     Results:  []ast.SelectItem{
@@ -25,13 +25,13 @@ from singers
         Expr: &ast.Path{
           Idents: []*ast.Ident{
             &ast.Ident{
-              NamePos: 70,
-              NameEnd: 77,
+              NamePos: 59,
+              NameEnd: 66,
               Name:    "singers",
             },
             &ast.Ident{
-              NamePos: 78,
-              NameEnd: 86,
+              NamePos: 67,
+              NameEnd: 75,
               Name:    "singerid",
             },
           },
@@ -39,8 +39,8 @@ from singers
         As: &ast.AsAlias{
           As:    -1,
           Alias: &ast.Ident{
-            NamePos: 90,
-            NameEnd: 98,
+            NamePos: 79,
+            NameEnd: 87,
             Name:    "singerid",
           },
         },
@@ -53,33 +53,33 @@ from singers
             Left: &ast.Path{
               Idents: []*ast.Ident{
                 &ast.Ident{
-                  NamePos: 104,
-                  NameEnd: 111,
+                  NamePos: 93,
+                  NameEnd: 100,
                   Name:    "singers",
                 },
                 &ast.Ident{
-                  NamePos: 112,
-                  NameEnd: 121,
+                  NamePos: 101,
+                  NameEnd: 110,
                   Name:    "firstname",
                 },
               },
             },
             Right: &ast.StringLiteral{
-              ValuePos: 125,
-              ValueEnd: 128,
+              ValuePos: 114,
+              ValueEnd: 117,
               Value:    " ",
             },
           },
           Right: &ast.Path{
             Idents: []*ast.Ident{
               &ast.Ident{
-                NamePos: 132,
-                NameEnd: 139,
+                NamePos: 121,
+                NameEnd: 128,
                 Name:    "singers",
               },
               &ast.Ident{
-                NamePos: 140,
-                NameEnd: 148,
+                NamePos: 129,
+                NameEnd: 137,
                 Name:    "lastname",
               },
             },
@@ -88,19 +88,19 @@ from singers
         As: &ast.AsAlias{
           As:    -1,
           Alias: &ast.Ident{
-            NamePos: 152,
-            NameEnd: 156,
+            NamePos: 141,
+            NameEnd: 145,
             Name:    "name",
           },
         },
       },
     },
     From: &ast.From{
-      From:   157,
+      From:   146,
       Source: &ast.TableName{
         Table: &ast.Ident{
-          NamePos: 162,
-          NameEnd: 169,
+          NamePos: 151,
+          NameEnd: 158,
           Name:    "singers",
         },
         Hint:   (*ast.Hint)(nil),
@@ -117,4 +117,4 @@ from singers
 }
 
 --- SQL
-CREATE OR REPLACE VIEW singernames SQL SECURITY INVOKER AS SELECT singers.singerid AS singerid, singers.firstname || " " || singers.lastname AS name FROM singers
+CREATE VIEW singernames SQL SECURITY DEFINER AS SELECT singers.singerid AS singerid, singers.firstname || " " || singers.lastname AS name FROM singers

--- a/testdata/result/statement/create_or_replace_view.sql.txt
+++ b/testdata/result/statement/create_or_replace_view.sql.txt
@@ -14,8 +14,9 @@ from singers
     NameEnd: 34,
     Name:    "singernames",
   },
-  OrReplace: true,
-  Query:     &ast.Select{
+  OrReplace:    true,
+  SecurityType: "INVOKER",
+  Query:        &ast.Select{
     Select:   59,
     Distinct: false,
     AsStruct: false,

--- a/testdata/result/statement/create_view.sql.txt
+++ b/testdata/result/statement/create_view.sql.txt
@@ -14,8 +14,9 @@ from singers
     NameEnd: 23,
     Name:    "singernames",
   },
-  OrReplace: false,
-  Query:     &ast.Select{
+  OrReplace:    false,
+  SecurityType: "INVOKER",
+  Query:        &ast.Select{
     Select:   48,
     Distinct: false,
     AsStruct: false,

--- a/testdata/result/statement/create_view_sql_security_definer.sql.txt
+++ b/testdata/result/statement/create_view_sql_security_definer.sql.txt
@@ -1,6 +1,6 @@
---- create_or_replace_view.sql
-create or replace view singernames
-sql security invoker
+--- create_view_sql_security_definer.sql
+create view singernames
+sql security definer
 as select
     singers.singerid as singerid,
     singers.firstname || ' ' || singers.lastname as name
@@ -10,14 +10,14 @@ from singers
 &ast.CreateView{
   Create: 0,
   Name:   &ast.Ident{
-    NamePos: 23,
-    NameEnd: 34,
+    NamePos: 12,
+    NameEnd: 23,
     Name:    "singernames",
   },
-  OrReplace:    true,
-  SecurityType: "INVOKER",
+  OrReplace:    false,
+  SecurityType: "DEFINER",
   Query:        &ast.Select{
-    Select:   59,
+    Select:   48,
     Distinct: false,
     AsStruct: false,
     Results:  []ast.SelectItem{
@@ -25,13 +25,13 @@ from singers
         Expr: &ast.Path{
           Idents: []*ast.Ident{
             &ast.Ident{
-              NamePos: 70,
-              NameEnd: 77,
+              NamePos: 59,
+              NameEnd: 66,
               Name:    "singers",
             },
             &ast.Ident{
-              NamePos: 78,
-              NameEnd: 86,
+              NamePos: 67,
+              NameEnd: 75,
               Name:    "singerid",
             },
           },
@@ -39,8 +39,8 @@ from singers
         As: &ast.AsAlias{
           As:    -1,
           Alias: &ast.Ident{
-            NamePos: 90,
-            NameEnd: 98,
+            NamePos: 79,
+            NameEnd: 87,
             Name:    "singerid",
           },
         },
@@ -53,33 +53,33 @@ from singers
             Left: &ast.Path{
               Idents: []*ast.Ident{
                 &ast.Ident{
-                  NamePos: 104,
-                  NameEnd: 111,
+                  NamePos: 93,
+                  NameEnd: 100,
                   Name:    "singers",
                 },
                 &ast.Ident{
-                  NamePos: 112,
-                  NameEnd: 121,
+                  NamePos: 101,
+                  NameEnd: 110,
                   Name:    "firstname",
                 },
               },
             },
             Right: &ast.StringLiteral{
-              ValuePos: 125,
-              ValueEnd: 128,
+              ValuePos: 114,
+              ValueEnd: 117,
               Value:    " ",
             },
           },
           Right: &ast.Path{
             Idents: []*ast.Ident{
               &ast.Ident{
-                NamePos: 132,
-                NameEnd: 139,
+                NamePos: 121,
+                NameEnd: 128,
                 Name:    "singers",
               },
               &ast.Ident{
-                NamePos: 140,
-                NameEnd: 148,
+                NamePos: 129,
+                NameEnd: 137,
                 Name:    "lastname",
               },
             },
@@ -88,19 +88,19 @@ from singers
         As: &ast.AsAlias{
           As:    -1,
           Alias: &ast.Ident{
-            NamePos: 152,
-            NameEnd: 156,
+            NamePos: 141,
+            NameEnd: 145,
             Name:    "name",
           },
         },
       },
     },
     From: &ast.From{
-      From:   157,
+      From:   146,
       Source: &ast.TableName{
         Table: &ast.Ident{
-          NamePos: 162,
-          NameEnd: 169,
+          NamePos: 151,
+          NameEnd: 158,
           Name:    "singers",
         },
         Hint:   (*ast.Hint)(nil),
@@ -117,4 +117,4 @@ from singers
 }
 
 --- SQL
-CREATE OR REPLACE VIEW singernames SQL SECURITY INVOKER AS SELECT singers.singerid AS singerid, singers.firstname || " " || singers.lastname AS name FROM singers
+CREATE VIEW singernames SQL SECURITY DEFINER AS SELECT singers.singerid AS singerid, singers.firstname || " " || singers.lastname AS name FROM singers


### PR DESCRIPTION
This PR add support `DEFINER` security type for [CREATE VIEW DDL](https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#create-view).

I have referenced an existing [implementation of TableSampleMethod](https://github.com/cloudspannerecosystem/memefish/blob/d6176ec284231388e9f38dd3331c0479aa401940/parser.go#L921-L930) while working on this feature.
