### PR TITLE
Rename `alternation` to `alteration` for clarity

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -245,22 +245,22 @@ type Constraint interface {
 func (ForeignKey) isConstraint() {}
 func (Check) isConstraint()      {}
 
-// TableAlternation represents ALTER TABLE action.
-type TableAlternation interface {
+// TableAlteration represents ALTER TABLE action.
+type TableAlteration interface {
 	Node
-	isTableAlternation()
+	isTableAlteration()
 }
 
-func (AddColumn) isTableAlternation()                {}
-func (AddTableConstraint) isTableAlternation()       {}
-func (AddRowDeletionPolicy) isTableAlternation()     {}
-func (DropColumn) isTableAlternation()               {}
-func (DropConstraint) isTableAlternation()           {}
-func (DropRowDeletionPolicy) isTableAlternation()    {}
-func (ReplaceRowDeletionPolicy) isTableAlternation() {}
-func (SetOnDelete) isTableAlternation()              {}
-func (AlterColumn) isTableAlternation()              {}
-func (AlterColumnSet) isTableAlternation()           {}
+func (AddColumn) isTableAlteration()                {}
+func (AddTableConstraint) isTableAlteration()       {}
+func (AddRowDeletionPolicy) isTableAlteration()     {}
+func (DropColumn) isTableAlteration()               {}
+func (DropConstraint) isTableAlteration()           {}
+func (DropRowDeletionPolicy) isTableAlteration()    {}
+func (ReplaceRowDeletionPolicy) isTableAlteration() {}
+func (SetOnDelete) isTableAlteration()              {}
+func (AlterColumn) isTableAlteration()              {}
+func (AlterColumnSet) isTableAlteration()           {}
 
 // Privilege represents privileges specified by GRANT and REVOKE.
 type Privilege interface {
@@ -294,14 +294,14 @@ func (ScalarSchemaType) isSchemaType() {}
 func (SizedSchemaType) isSchemaType()  {}
 func (ArraySchemaType) isSchemaType()  {}
 
-// IndexAlternation represents ALTER INDEX action.
-type IndexAlternation interface {
+// IndexAlteration represents ALTER INDEX action.
+type IndexAlteration interface {
 	Node
-	isIndexAlternation()
+	isIndexAlteration()
 }
 
-func (AddStoredColumn) isIndexAlternation()  {}
-func (DropStoredColumn) isIndexAlternation() {}
+func (AddStoredColumn) isIndexAlteration()  {}
+func (DropStoredColumn) isIndexAlteration() {}
 
 // DML represents data manipulation language in SQL.
 //
@@ -333,15 +333,15 @@ type ChangeStreamFor interface {
 func (ChangeStreamForAll) isChangeStreamFor()    {}
 func (ChangeStreamForTables) isChangeStreamFor() {}
 
-// ChangeStreamAlternation represents ALTER CHANGE STREAM action.
-type ChangeStreamAlternation interface {
+// ChangeStreamAlteration represents ALTER CHANGE STREAM action.
+type ChangeStreamAlteration interface {
 	Node
-	isChangeStreamAlternation()
+	isChangeStreamAlteration()
 }
 
-func (ChangeStreamSetFor) isChangeStreamAlternation()     {}
-func (ChangeStreamDropForAll) isChangeStreamAlternation() {}
-func (ChangeStreamSetOptions) isChangeStreamAlternation() {}
+func (ChangeStreamSetFor) isChangeStreamAlteration()     {}
+func (ChangeStreamDropForAll) isChangeStreamAlteration() {}
+func (ChangeStreamSetOptions) isChangeStreamAlteration() {}
 
 // ================================================================================
 //
@@ -1626,41 +1626,41 @@ type CreateView struct {
 
 // AlterTable is ALTER TABLE statement node.
 //
-//	ALTER TABLE {{.Name | sql}} {{.TableAlternation | sql}}
+//	ALTER TABLE {{.Name | sql}} {{.TableAlteration | sql}}
 type AlterTable struct {
 	// pos = Alter
-	// end = TableAlternation.end
+	// end = TableAlteration.end
 
 	Alter token.Pos // position of "ALTER" keyword
 
 	Name             *Ident
-	TableAlternation TableAlternation
+	TableAlteration TableAlteration
 }
 
 // AlterIndex is ALTER INDEX statement node.
 //
-//	ALTER INDEX {{.Name | sql}} {{.IndexAlternation | sql}}
+//	ALTER INDEX {{.Name | sql}} {{.IndexAlteration | sql}}
 type AlterIndex struct {
 	// pos = Alter
-	// end = IndexAlternation.end
+	// end = IndexAlteration.end
 
 	Alter token.Pos // position of "ALTER" keyword
 
 	Name             *Ident
-	IndexAlternation IndexAlternation
+	IndexAlteration IndexAlteration
 }
 
 // AlterChangeStream is ALTER CHANGE STREAM statement node.
 //
-//	ALTER CHANGE STREAM {{.Name | sql}} {{.ChangeStreamAlternation | sql}}
+//	ALTER CHANGE STREAM {{.Name | sql}} {{.ChangeStreamAlteration | sql}}
 type AlterChangeStream struct {
 	// pos = Alter
-	// end = ChangeStreamAlternation.end
+	// end = ChangeStreamAlteration.end
 
 	Alter token.Pos // position of "ALTER" keyword
 
 	Name                    *Ident
-	ChangeStreamAlternation ChangeStreamAlternation
+	ChangeStreamAlteration ChangeStreamAlteration
 }
 
 // AddColumn is ADD COLUMN clause in ALTER TABLE.

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -142,14 +142,14 @@ func TestConstraint(t *testing.T) {
 	Constraint(&Check{}).isConstraint()
 }
 
-func TestTableAlternation(t *testing.T) {
-	TableAlternation(&AddColumn{}).isTableAlternation()
-	TableAlternation(&AddTableConstraint{}).isTableAlternation()
-	TableAlternation(&DropColumn{}).isTableAlternation()
-	TableAlternation(&DropConstraint{}).isTableAlternation()
-	TableAlternation(&SetOnDelete{}).isTableAlternation()
-	TableAlternation(&AlterColumn{}).isTableAlternation()
-	TableAlternation(&AlterColumnSet{}).isTableAlternation()
+func TestTableAlteration(t *testing.T) {
+	TableAlteration(&AddColumn{}).isTableAlteration()
+	TableAlteration(&AddTableConstraint{}).isTableAlteration()
+	TableAlteration(&DropColumn{}).isTableAlteration()
+	TableAlteration(&DropConstraint{}).isTableAlteration()
+	TableAlteration(&SetOnDelete{}).isTableAlteration()
+	TableAlteration(&AlterColumn{}).isTableAlteration()
+	TableAlteration(&AlterColumnSet{}).isTableAlteration()
 }
 
 func TestPrivilege(t *testing.T) {
@@ -172,9 +172,9 @@ func TestSchemaType(t *testing.T) {
 	SchemaType(&ArraySchemaType{}).isSchemaType()
 }
 
-func TestIndexAlternation(t *testing.T) {
-	IndexAlternation(&AddStoredColumn{}).isIndexAlternation()
-	IndexAlternation(&DropStoredColumn{}).isIndexAlternation()
+func TestIndexAlteration(t *testing.T) {
+	IndexAlteration(&AddStoredColumn{}).isIndexAlteration()
+	IndexAlteration(&DropStoredColumn{}).isIndexAlteration()
 }
 
 func TestDML(t *testing.T) {

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -601,7 +601,7 @@ func (r *RowDeletionPolicy) End() token.Pos {
 }
 
 func (a *AlterTable) Pos() token.Pos { return a.Alter }
-func (a *AlterTable) End() token.Pos { return a.TableAlternation.End() }
+func (a *AlterTable) End() token.Pos { return a.TableAlteration.End() }
 
 func (a *AddColumn) Pos() token.Pos { return a.Add }
 func (a *AddColumn) End() token.Pos { return a.Column.End() }
@@ -693,7 +693,7 @@ func (i *InterleaveIn) Pos() token.Pos { return i.Comma }
 func (i *InterleaveIn) End() token.Pos { return i.TableName.End() }
 
 func (a *AlterIndex) Pos() token.Pos { return a.Alter }
-func (a *AlterIndex) End() token.Pos { return a.IndexAlternation.End() }
+func (a *AlterIndex) End() token.Pos { return a.IndexAlteration.End() }
 
 func (a *AddStoredColumn) Pos() token.Pos { return a.Add }
 func (a *AddStoredColumn) End() token.Pos { return a.Name.End() }
@@ -714,7 +714,7 @@ func (d *DropChangeStream) Pos() token.Pos { return d.Drop }
 func (d *DropChangeStream) End() token.Pos { return d.Name.End() }
 
 func (a *AlterChangeStream) Pos() token.Pos      { return a.Alter }
-func (a *AlterChangeStream) End() token.Pos      { return a.ChangeStreamAlternation.End() }
+func (a *AlterChangeStream) End() token.Pos      { return a.ChangeStreamAlteration.End() }
 
 func (a *ChangeStreamSetFor) Pos() token.Pos     { return a.Set }
 func (a *ChangeStreamSetFor) End() token.Pos     { return a.For.End() }

--- a/ast/pos_test.go
+++ b/ast/pos_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudspannerecosystem/memefish/token"
 )
 
-func TestTableAlternation_Position(t *testing.T) {
+func TestTableAlteration_Position(t *testing.T) {
 	alterColumnDefaultExpr := AlterColumn{
 		DefaultExpr: &ColumnDefaultExpr{Rparen: 100},
 	}

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -872,7 +872,7 @@ func (r *RowDeletionPolicy) SQL() string {
 }
 
 func (a *AlterTable) SQL() string {
-	return "ALTER TABLE " + a.Name.SQL() + " " + a.TableAlternation.SQL()
+	return "ALTER TABLE " + a.Name.SQL() + " " + a.TableAlteration.SQL()
 }
 
 func (a *AddColumn) SQL() string {
@@ -1007,7 +1007,7 @@ func (c *ChangeStreamOptions) SQL() string {
 }
 
 func (a *AlterChangeStream) SQL() string {
-	return "ALTER CHANGE STREAM " + a.Name.SQL() + " " + a.ChangeStreamAlternation.SQL()
+	return "ALTER CHANGE STREAM " + a.Name.SQL() + " " + a.ChangeStreamAlteration.SQL()
 }
 
 func (a ChangeStreamSetFor) SQL() string {
@@ -1058,7 +1058,7 @@ func (i *InterleaveIn) SQL() string {
 }
 
 func (a *AlterIndex) SQL() string {
-	return "ALTER INDEX " + a.Name.SQL() + " " + a.IndexAlternation.SQL()
+	return "ALTER INDEX " + a.Name.SQL() + " " + a.IndexAlteration.SQL()
 }
 
 func (a *AddStoredColumn) SQL() string {

--- a/testdata/result/ddl/alter_change_stream_options.sql.txt
+++ b/testdata/result/ddl/alter_change_stream_options.sql.txt
@@ -9,7 +9,7 @@ ALTER CHANGE STREAM change_stream_name SET OPTIONS (retention_period = '1d', val
     NameEnd: 38,
     Name:    "change_stream_name",
   },
-  ChangeStreamAlternation: &ast.ChangeStreamSetOptions{
+  ChangeStreamAlteration: &ast.ChangeStreamSetOptions{
     Set:     39,
     Options: &ast.ChangeStreamOptions{
       Options: 43,

--- a/testdata/result/ddl/alter_change_stream_set_drop_for_all.sql.txt
+++ b/testdata/result/ddl/alter_change_stream_set_drop_for_all.sql.txt
@@ -9,7 +9,7 @@ ALTER CHANGE STREAM change_stream_name DROP FOR ALL
     NameEnd: 38,
     Name:    "change_stream_name",
   },
-  ChangeStreamAlternation: &ast.ChangeStreamDropForAll{
+  ChangeStreamAlteration: &ast.ChangeStreamDropForAll{
     Drop: 39,
     All:  48,
   },

--- a/testdata/result/ddl/alter_change_stream_set_for_all.sql.txt
+++ b/testdata/result/ddl/alter_change_stream_set_for_all.sql.txt
@@ -9,7 +9,7 @@ ALTER CHANGE STREAM change_stream_name SET FOR ALL
     NameEnd: 38,
     Name:    "change_stream_name",
   },
-  ChangeStreamAlternation: &ast.ChangeStreamSetFor{
+  ChangeStreamAlteration: &ast.ChangeStreamSetFor{
     Set: 39,
     For: &ast.ChangeStreamForAll{
       For: 43,

--- a/testdata/result/ddl/alter_change_stream_set_for_table_columns.sql.txt
+++ b/testdata/result/ddl/alter_change_stream_set_for_table_columns.sql.txt
@@ -9,7 +9,7 @@ ALTER CHANGE STREAM change_stream_name SET FOR table_name1(column1, column2), ta
     NameEnd: 38,
     Name:    "change_stream_name",
   },
-  ChangeStreamAlternation: &ast.ChangeStreamSetFor{
+  ChangeStreamAlteration: &ast.ChangeStreamSetFor{
     Set: 39,
     For: &ast.ChangeStreamForTables{
       For:    43,

--- a/testdata/result/ddl/alter_index_add_stored_column.sql.txt
+++ b/testdata/result/ddl/alter_index_add_stored_column.sql.txt
@@ -9,7 +9,7 @@ alter index foo add stored column bar
     NameEnd: 15,
     Name:    "foo",
   },
-  IndexAlternation: &ast.AddStoredColumn{
+  IndexAlteration: &ast.AddStoredColumn{
     Add:  16,
     Name: &ast.Ident{
       NamePos: 34,

--- a/testdata/result/ddl/alter_index_drop_stored_column.sql.txt
+++ b/testdata/result/ddl/alter_index_drop_stored_column.sql.txt
@@ -9,7 +9,7 @@ alter index foo drop stored column bar
     NameEnd: 15,
     Name:    "foo",
   },
-  IndexAlternation: &ast.DropStoredColumn{
+  IndexAlteration: &ast.DropStoredColumn{
     Drop: 16,
     Name: &ast.Ident{
       NamePos: 35,

--- a/testdata/result/ddl/alter_table_add_check.sql.txt
+++ b/testdata/result/ddl/alter_table_add_check.sql.txt
@@ -9,7 +9,7 @@ alter table foo add check (c1 > 0)
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddTableConstraint{
+  TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
       ConstraintPos: 0,

--- a/testdata/result/ddl/alter_table_add_column.sql.txt
+++ b/testdata/result/ddl/alter_table_add_column.sql.txt
@@ -8,7 +8,7 @@ alter table foo add column baz string(max) not null
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddColumn{
+  TableAlteration: &ast.AddColumn{
     Add:         16,
     IfNotExists: false,
     Column:      &ast.ColumnDef{

--- a/testdata/result/ddl/alter_table_add_column_if_not_exists.sql.txt
+++ b/testdata/result/ddl/alter_table_add_column_if_not_exists.sql.txt
@@ -9,7 +9,7 @@ alter table foo add column if not exists baz string(max) not null
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddColumn{
+  TableAlteration: &ast.AddColumn{
     Add:         16,
     IfNotExists: true,
     Column:      &ast.ColumnDef{

--- a/testdata/result/ddl/alter_table_add_column_with_if_expression.sql.txt
+++ b/testdata/result/ddl/alter_table_add_column_with_if_expression.sql.txt
@@ -8,7 +8,7 @@ ALTER TABLE foo ADD COLUMN expired_at TIMESTAMP AS (IF (status != "OPEN" AND sta
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddColumn{
+  TableAlteration: &ast.AddColumn{
     Add:         16,
     IfNotExists: false,
     Column:      &ast.ColumnDef{

--- a/testdata/result/ddl/alter_table_add_constraint_check.sql.txt
+++ b/testdata/result/ddl/alter_table_add_constraint_check.sql.txt
@@ -9,7 +9,7 @@ alter table foo add constraint cname check (c1 > 0)
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddTableConstraint{
+  TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
       ConstraintPos: 20,

--- a/testdata/result/ddl/alter_table_add_constraint_foreign_key.sql.txt
+++ b/testdata/result/ddl/alter_table_add_constraint_foreign_key.sql.txt
@@ -9,7 +9,7 @@ alter table foo add constraint fkname foreign key (foo, bar) references t2 (t2ke
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddTableConstraint{
+  TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
       ConstraintPos: 20,

--- a/testdata/result/ddl/alter_table_add_constraint_foreign_key_on_delete_cascade.sql.txt
+++ b/testdata/result/ddl/alter_table_add_constraint_foreign_key_on_delete_cascade.sql.txt
@@ -9,7 +9,7 @@ alter table foo add constraint fkname foreign key (foo, bar) references t2 (t2ke
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddTableConstraint{
+  TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
       ConstraintPos: 20,

--- a/testdata/result/ddl/alter_table_add_constraint_foreign_key_on_delete_no_action.sql.txt
+++ b/testdata/result/ddl/alter_table_add_constraint_foreign_key_on_delete_no_action.sql.txt
@@ -9,7 +9,7 @@ alter table foo add constraint fkname foreign key (foo, bar) references t2 (t2ke
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddTableConstraint{
+  TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
       ConstraintPos: 20,

--- a/testdata/result/ddl/alter_table_add_foreign_key.sql.txt
+++ b/testdata/result/ddl/alter_table_add_foreign_key.sql.txt
@@ -9,7 +9,7 @@ alter table foo add foreign key (bar) references t2 (t2key1)
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddTableConstraint{
+  TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
       ConstraintPos: 0,

--- a/testdata/result/ddl/alter_table_add_row_deletion_policy.sql.txt
+++ b/testdata/result/ddl/alter_table_add_row_deletion_policy.sql.txt
@@ -9,7 +9,7 @@ alter table foo add row deletion policy ( older_than ( bar, interval 30 day ))
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddRowDeletionPolicy{
+  TableAlteration: &ast.AddRowDeletionPolicy{
     Add:               16,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
       Row:        20,

--- a/testdata/result/ddl/alter_table_alter_column.sql.txt
+++ b/testdata/result/ddl/alter_table_alter_column.sql.txt
@@ -8,7 +8,7 @@ alter table foo alter column foo string(256) not null
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AlterColumn{
+  TableAlteration: &ast.AlterColumn{
     Alter: 16,
     Null:  49,
     Name:  &ast.Ident{

--- a/testdata/result/ddl/alter_table_alter_column_set.sql.txt
+++ b/testdata/result/ddl/alter_table_alter_column_set.sql.txt
@@ -8,7 +8,7 @@ alter table foo alter column foo set options(allow_commit_timestamp = true)
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AlterColumnSet{
+  TableAlteration: &ast.AlterColumnSet{
     Alter: 16,
     Name:  &ast.Ident{
       NamePos: 29,

--- a/testdata/result/ddl/alter_table_alter_column_set_default.sql.txt
+++ b/testdata/result/ddl/alter_table_alter_column_set_default.sql.txt
@@ -8,7 +8,7 @@ ALTER TABLE actions ALTER COLUMN output SET DEFAULT("")
     NameEnd: 19,
     Name:    "actions",
   },
-  TableAlternation: &ast.AlterColumnSet{
+  TableAlteration: &ast.AlterColumnSet{
     Alter: 20,
     Name:  &ast.Ident{
       NamePos: 33,

--- a/testdata/result/ddl/alter_table_alter_column_with_default.sql.txt
+++ b/testdata/result/ddl/alter_table_alter_column_with_default.sql.txt
@@ -8,7 +8,7 @@ ALTER TABLE actions ALTER COLUMN output STRING(MAX) NOT NULL DEFAULT("")
     NameEnd: 19,
     Name:    "actions",
   },
-  TableAlternation: &ast.AlterColumn{
+  TableAlteration: &ast.AlterColumn{
     Alter: 20,
     Null:  56,
     Name:  &ast.Ident{

--- a/testdata/result/ddl/alter_table_drop_column.sql.txt
+++ b/testdata/result/ddl/alter_table_drop_column.sql.txt
@@ -9,7 +9,7 @@ alter table foo drop column bar
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.DropColumn{
+  TableAlteration: &ast.DropColumn{
     Drop: 16,
     Name: &ast.Ident{
       NamePos: 28,

--- a/testdata/result/ddl/alter_table_drop_constraint.sql.txt
+++ b/testdata/result/ddl/alter_table_drop_constraint.sql.txt
@@ -9,7 +9,7 @@ alter table foo drop constraint bar
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.DropConstraint{
+  TableAlteration: &ast.DropConstraint{
     Drop: 16,
     Name: &ast.Ident{
       NamePos: 32,

--- a/testdata/result/ddl/alter_table_drop_row_deletion_policy.sql.txt
+++ b/testdata/result/ddl/alter_table_drop_row_deletion_policy.sql.txt
@@ -9,7 +9,7 @@ alter table foo drop row deletion policy
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.DropRowDeletionPolicy{
+  TableAlteration: &ast.DropRowDeletionPolicy{
     Drop:   16,
     Policy: 34,
   },

--- a/testdata/result/ddl/alter_table_replace_row_deletion_policy.sql.txt
+++ b/testdata/result/ddl/alter_table_replace_row_deletion_policy.sql.txt
@@ -9,7 +9,7 @@ alter table foo replace row deletion policy ( older_than ( bar, interval 30 day 
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.ReplaceRowDeletionPolicy{
+  TableAlteration: &ast.ReplaceRowDeletionPolicy{
     Replace:           16,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
       Row:        24,

--- a/testdata/result/ddl/alter_table_set_on_delete.sql.txt
+++ b/testdata/result/ddl/alter_table_set_on_delete.sql.txt
@@ -8,7 +8,7 @@ alter table foo set on delete cascade
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.SetOnDelete{
+  TableAlteration: &ast.SetOnDelete{
     Set:         16,
     OnDeleteEnd: 37,
     OnDelete:    "ON DELETE CASCADE",

--- a/testdata/result/ddl/alter_table_set_on_delete_no_action.sql.txt
+++ b/testdata/result/ddl/alter_table_set_on_delete_no_action.sql.txt
@@ -8,7 +8,7 @@ alter table foo set on delete no action
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.SetOnDelete{
+  TableAlteration: &ast.SetOnDelete{
     Set:         16,
     OnDeleteEnd: 39,
     OnDelete:    "ON DELETE NO ACTION",

--- a/testdata/result/statement/alter_change_stream_options.sql.txt
+++ b/testdata/result/statement/alter_change_stream_options.sql.txt
@@ -9,7 +9,7 @@ ALTER CHANGE STREAM change_stream_name SET OPTIONS (retention_period = '1d', val
     NameEnd: 38,
     Name:    "change_stream_name",
   },
-  ChangeStreamAlternation: &ast.ChangeStreamSetOptions{
+  ChangeStreamAlteration: &ast.ChangeStreamSetOptions{
     Set:     39,
     Options: &ast.ChangeStreamOptions{
       Options: 43,

--- a/testdata/result/statement/alter_change_stream_set_drop_for_all.sql.txt
+++ b/testdata/result/statement/alter_change_stream_set_drop_for_all.sql.txt
@@ -9,7 +9,7 @@ ALTER CHANGE STREAM change_stream_name DROP FOR ALL
     NameEnd: 38,
     Name:    "change_stream_name",
   },
-  ChangeStreamAlternation: &ast.ChangeStreamDropForAll{
+  ChangeStreamAlteration: &ast.ChangeStreamDropForAll{
     Drop: 39,
     All:  48,
   },

--- a/testdata/result/statement/alter_change_stream_set_for_all.sql.txt
+++ b/testdata/result/statement/alter_change_stream_set_for_all.sql.txt
@@ -9,7 +9,7 @@ ALTER CHANGE STREAM change_stream_name SET FOR ALL
     NameEnd: 38,
     Name:    "change_stream_name",
   },
-  ChangeStreamAlternation: &ast.ChangeStreamSetFor{
+  ChangeStreamAlteration: &ast.ChangeStreamSetFor{
     Set: 39,
     For: &ast.ChangeStreamForAll{
       For: 43,

--- a/testdata/result/statement/alter_change_stream_set_for_table_columns.sql.txt
+++ b/testdata/result/statement/alter_change_stream_set_for_table_columns.sql.txt
@@ -9,7 +9,7 @@ ALTER CHANGE STREAM change_stream_name SET FOR table_name1(column1, column2), ta
     NameEnd: 38,
     Name:    "change_stream_name",
   },
-  ChangeStreamAlternation: &ast.ChangeStreamSetFor{
+  ChangeStreamAlteration: &ast.ChangeStreamSetFor{
     Set: 39,
     For: &ast.ChangeStreamForTables{
       For:    43,

--- a/testdata/result/statement/alter_index_add_stored_column.sql.txt
+++ b/testdata/result/statement/alter_index_add_stored_column.sql.txt
@@ -9,7 +9,7 @@ alter index foo add stored column bar
     NameEnd: 15,
     Name:    "foo",
   },
-  IndexAlternation: &ast.AddStoredColumn{
+  IndexAlteration: &ast.AddStoredColumn{
     Add:  16,
     Name: &ast.Ident{
       NamePos: 34,

--- a/testdata/result/statement/alter_index_drop_stored_column.sql.txt
+++ b/testdata/result/statement/alter_index_drop_stored_column.sql.txt
@@ -9,7 +9,7 @@ alter index foo drop stored column bar
     NameEnd: 15,
     Name:    "foo",
   },
-  IndexAlternation: &ast.DropStoredColumn{
+  IndexAlteration: &ast.DropStoredColumn{
     Drop: 16,
     Name: &ast.Ident{
       NamePos: 35,

--- a/testdata/result/statement/alter_table_add_check.sql.txt
+++ b/testdata/result/statement/alter_table_add_check.sql.txt
@@ -9,7 +9,7 @@ alter table foo add check (c1 > 0)
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddTableConstraint{
+  TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
       ConstraintPos: 0,

--- a/testdata/result/statement/alter_table_add_column.sql.txt
+++ b/testdata/result/statement/alter_table_add_column.sql.txt
@@ -8,7 +8,7 @@ alter table foo add column baz string(max) not null
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddColumn{
+  TableAlteration: &ast.AddColumn{
     Add:         16,
     IfNotExists: false,
     Column:      &ast.ColumnDef{

--- a/testdata/result/statement/alter_table_add_column_if_not_exists.sql.txt
+++ b/testdata/result/statement/alter_table_add_column_if_not_exists.sql.txt
@@ -9,7 +9,7 @@ alter table foo add column if not exists baz string(max) not null
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddColumn{
+  TableAlteration: &ast.AddColumn{
     Add:         16,
     IfNotExists: true,
     Column:      &ast.ColumnDef{

--- a/testdata/result/statement/alter_table_add_column_with_if_expression.sql.txt
+++ b/testdata/result/statement/alter_table_add_column_with_if_expression.sql.txt
@@ -8,7 +8,7 @@ ALTER TABLE foo ADD COLUMN expired_at TIMESTAMP AS (IF (status != "OPEN" AND sta
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddColumn{
+  TableAlteration: &ast.AddColumn{
     Add:         16,
     IfNotExists: false,
     Column:      &ast.ColumnDef{

--- a/testdata/result/statement/alter_table_add_constraint_check.sql.txt
+++ b/testdata/result/statement/alter_table_add_constraint_check.sql.txt
@@ -9,7 +9,7 @@ alter table foo add constraint cname check (c1 > 0)
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddTableConstraint{
+  TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
       ConstraintPos: 20,

--- a/testdata/result/statement/alter_table_add_constraint_foreign_key.sql.txt
+++ b/testdata/result/statement/alter_table_add_constraint_foreign_key.sql.txt
@@ -9,7 +9,7 @@ alter table foo add constraint fkname foreign key (foo, bar) references t2 (t2ke
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddTableConstraint{
+  TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
       ConstraintPos: 20,

--- a/testdata/result/statement/alter_table_add_constraint_foreign_key_on_delete_cascade.sql.txt
+++ b/testdata/result/statement/alter_table_add_constraint_foreign_key_on_delete_cascade.sql.txt
@@ -9,7 +9,7 @@ alter table foo add constraint fkname foreign key (foo, bar) references t2 (t2ke
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddTableConstraint{
+  TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
       ConstraintPos: 20,

--- a/testdata/result/statement/alter_table_add_constraint_foreign_key_on_delete_no_action.sql.txt
+++ b/testdata/result/statement/alter_table_add_constraint_foreign_key_on_delete_no_action.sql.txt
@@ -9,7 +9,7 @@ alter table foo add constraint fkname foreign key (foo, bar) references t2 (t2ke
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddTableConstraint{
+  TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
       ConstraintPos: 20,

--- a/testdata/result/statement/alter_table_add_foreign_key.sql.txt
+++ b/testdata/result/statement/alter_table_add_foreign_key.sql.txt
@@ -9,7 +9,7 @@ alter table foo add foreign key (bar) references t2 (t2key1)
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddTableConstraint{
+  TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
       ConstraintPos: 0,

--- a/testdata/result/statement/alter_table_add_row_deletion_policy.sql.txt
+++ b/testdata/result/statement/alter_table_add_row_deletion_policy.sql.txt
@@ -9,7 +9,7 @@ alter table foo add row deletion policy ( older_than ( bar, interval 30 day ))
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AddRowDeletionPolicy{
+  TableAlteration: &ast.AddRowDeletionPolicy{
     Add:               16,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
       Row:        20,

--- a/testdata/result/statement/alter_table_alter_column.sql.txt
+++ b/testdata/result/statement/alter_table_alter_column.sql.txt
@@ -8,7 +8,7 @@ alter table foo alter column foo string(256) not null
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AlterColumn{
+  TableAlteration: &ast.AlterColumn{
     Alter: 16,
     Null:  49,
     Name:  &ast.Ident{

--- a/testdata/result/statement/alter_table_alter_column_set.sql.txt
+++ b/testdata/result/statement/alter_table_alter_column_set.sql.txt
@@ -8,7 +8,7 @@ alter table foo alter column foo set options(allow_commit_timestamp = true)
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.AlterColumnSet{
+  TableAlteration: &ast.AlterColumnSet{
     Alter: 16,
     Name:  &ast.Ident{
       NamePos: 29,

--- a/testdata/result/statement/alter_table_alter_column_set_default.sql.txt
+++ b/testdata/result/statement/alter_table_alter_column_set_default.sql.txt
@@ -8,7 +8,7 @@ ALTER TABLE actions ALTER COLUMN output SET DEFAULT("")
     NameEnd: 19,
     Name:    "actions",
   },
-  TableAlternation: &ast.AlterColumnSet{
+  TableAlteration: &ast.AlterColumnSet{
     Alter: 20,
     Name:  &ast.Ident{
       NamePos: 33,

--- a/testdata/result/statement/alter_table_alter_column_with_default.sql.txt
+++ b/testdata/result/statement/alter_table_alter_column_with_default.sql.txt
@@ -8,7 +8,7 @@ ALTER TABLE actions ALTER COLUMN output STRING(MAX) NOT NULL DEFAULT("")
     NameEnd: 19,
     Name:    "actions",
   },
-  TableAlternation: &ast.AlterColumn{
+  TableAlteration: &ast.AlterColumn{
     Alter: 20,
     Null:  56,
     Name:  &ast.Ident{

--- a/testdata/result/statement/alter_table_drop_column.sql.txt
+++ b/testdata/result/statement/alter_table_drop_column.sql.txt
@@ -9,7 +9,7 @@ alter table foo drop column bar
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.DropColumn{
+  TableAlteration: &ast.DropColumn{
     Drop: 16,
     Name: &ast.Ident{
       NamePos: 28,

--- a/testdata/result/statement/alter_table_drop_constraint.sql.txt
+++ b/testdata/result/statement/alter_table_drop_constraint.sql.txt
@@ -9,7 +9,7 @@ alter table foo drop constraint bar
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.DropConstraint{
+  TableAlteration: &ast.DropConstraint{
     Drop: 16,
     Name: &ast.Ident{
       NamePos: 32,

--- a/testdata/result/statement/alter_table_drop_row_deletion_policy.sql.txt
+++ b/testdata/result/statement/alter_table_drop_row_deletion_policy.sql.txt
@@ -9,7 +9,7 @@ alter table foo drop row deletion policy
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.DropRowDeletionPolicy{
+  TableAlteration: &ast.DropRowDeletionPolicy{
     Drop:   16,
     Policy: 34,
   },

--- a/testdata/result/statement/alter_table_replace_row_deletion_policy.sql.txt
+++ b/testdata/result/statement/alter_table_replace_row_deletion_policy.sql.txt
@@ -9,7 +9,7 @@ alter table foo replace row deletion policy ( older_than ( bar, interval 30 day 
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.ReplaceRowDeletionPolicy{
+  TableAlteration: &ast.ReplaceRowDeletionPolicy{
     Replace:           16,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
       Row:        24,

--- a/testdata/result/statement/alter_table_set_on_delete.sql.txt
+++ b/testdata/result/statement/alter_table_set_on_delete.sql.txt
@@ -8,7 +8,7 @@ alter table foo set on delete cascade
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.SetOnDelete{
+  TableAlteration: &ast.SetOnDelete{
     Set:         16,
     OnDeleteEnd: 37,
     OnDelete:    "ON DELETE CASCADE",

--- a/testdata/result/statement/alter_table_set_on_delete_no_action.sql.txt
+++ b/testdata/result/statement/alter_table_set_on_delete_no_action.sql.txt
@@ -8,7 +8,7 @@ alter table foo set on delete no action
     NameEnd: 15,
     Name:    "foo",
   },
-  TableAlternation: &ast.SetOnDelete{
+  TableAlteration: &ast.SetOnDelete{
     Set:         16,
     OnDeleteEnd: 39,
     OnDelete:    "ON DELETE NO ACTION",


### PR DESCRIPTION
This PR renames `alternation` to `alteration` to enhance clarity, as discussed in https://github.com/cloudspannerecosystem/memefish/pull/76#discussion_r1367706369.

To address this issue, I executed the following commands:

```console
$ perl -pi -e 's/lternation/lteration/g' **/*.go
$ make update-results
```
