### PR TITLE
Update deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -15,13 +15,26 @@ jobs:
       - name: Set up Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.63.2'
+          hugo-version: '0.133.0'
           extended: true
       - name: Build docs
         run: make docs
-      - name: Deploy
-        uses: docker://peaceiris/gh-pages:v2
-        env:
-          ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          PUBLISH_BRANCH: gh-pages
-          PUBLISH_DIR: ./docs/public
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs/public
+
+  deploy:
+    needs: build
+    name: Deploy to GitHub Pages
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ bin
 
 # Go workspace file
 go.work
+
+docs/.hugo_*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
-[submodule "docs/themes/hugo-whisper-theme"]
+[submodule "hugo-whisper-theme"]
 	path = docs/themes/hugo-whisper-theme
-	url = https://github.com/jugglerx/hugo-whisper-theme.git
+	url = https://github.com/deining/hugo-whisper-theme.git
+	branch = deprecation-warning


### PR DESCRIPTION
Fix #86

This PR also updates Hugo version. Currently, hugo-wisper-theme causes a deprecation error, so we use forked version instead for now.