### PR TITLE
Add Pos, End to SplitRawStatements()

### DIFF
--- a/split.go
+++ b/split.go
@@ -2,14 +2,20 @@ package memefish
 
 import "github.com/cloudspannerecosystem/memefish/token"
 
+type RawStatement struct {
+	Pos, End  token.Pos
+	Statement string
+}
+
 // SplitRawStatements splits an input string to statement strings at terminating semicolons without parsing.
+// It preserves all comments.
 // Statements are terminated by `;`, `<eof>` or `;<eof>` and the minimum output will be []string{""}.
 // See [terminating semicolons].
 // This function won't panic but return error if lexer become error state.
-// filepath can be used in error message.
+// filepath can be empty, it is only used in error message.
 //
 // [terminating semicolons]: https://cloud.google.com/spanner/docs/reference/standard-sql/lexical#terminating_semicolons
-func SplitRawStatements(filepath, s string) ([]string, error) {
+func SplitRawStatements(filepath, s string) ([]*RawStatement, error) {
 	lex := &Lexer{
 		File: &token.File{
 			FilePath: filepath,
@@ -17,11 +23,14 @@ func SplitRawStatements(filepath, s string) ([]string, error) {
 		},
 	}
 
-	var result []string
+	var result []*RawStatement
 	var firstPos token.Pos
 	for {
 		if lex.Token.Kind == ";" {
-			result = append(result, s[firstPos:lex.Token.Pos])
+			result = append(result, &RawStatement{Pos: firstPos,
+				End:       lex.Token.Pos,
+				Statement: s[firstPos:lex.Token.Pos],
+			})
 			if err := lex.NextToken(); err != nil {
 				return nil, err
 			}
@@ -36,13 +45,18 @@ func SplitRawStatements(filepath, s string) ([]string, error) {
 
 		if lex.Token.Kind == token.TokenEOF {
 			if lex.Token.Pos != firstPos {
-				result = append(result, s[firstPos:lex.Token.Pos])
+				result = append(result, &RawStatement{Pos: firstPos,
+					End:       lex.Token.Pos,
+					Statement: s[firstPos:lex.Token.Pos],
+				})
 			}
 			break
 		}
 	}
 	if len(result) == 0 {
-		return []string{""}, nil
+		return []*RawStatement{
+			{Pos: token.Pos(0), End: token.Pos(0), Statement: ""},
+		}, nil
 	}
 	return result, nil
 }

--- a/split.go
+++ b/split.go
@@ -27,7 +27,8 @@ func SplitRawStatements(filepath, s string) ([]*RawStatement, error) {
 	var firstPos token.Pos
 	for {
 		if lex.Token.Kind == ";" {
-			result = append(result, &RawStatement{Pos: firstPos,
+			result = append(result, &RawStatement{
+				Pos:       firstPos,
 				End:       lex.Token.Pos,
 				Statement: s[firstPos:lex.Token.Pos],
 			})
@@ -45,7 +46,8 @@ func SplitRawStatements(filepath, s string) ([]*RawStatement, error) {
 
 		if lex.Token.Kind == token.TokenEOF {
 			if lex.Token.Pos != firstPos {
-				result = append(result, &RawStatement{Pos: firstPos,
+				result = append(result, &RawStatement{
+					Pos:       firstPos,
 					End:       lex.Token.Pos,
 					Statement: s[firstPos:lex.Token.Pos],
 				})
@@ -55,7 +57,7 @@ func SplitRawStatements(filepath, s string) ([]*RawStatement, error) {
 	}
 	if len(result) == 0 {
 		return []*RawStatement{
-			{Pos: token.Pos(0), End: token.Pos(0), Statement: ""},
+			{Statement: ""},
 		}, nil
 	}
 	return result, nil

--- a/split_test.go
+++ b/split_test.go
@@ -2,6 +2,7 @@ package memefish_test
 
 import (
 	"github.com/cloudspannerecosystem/memefish"
+	"github.com/cloudspannerecosystem/memefish/token"
 	"github.com/google/go-cmp/cmp"
 	"regexp"
 	"testing"
@@ -12,23 +13,62 @@ func TestSplitRawStatements(t *testing.T) {
 		desc  string
 		input string
 		errRe *regexp.Regexp
-		want  []string
+		want  []*memefish.RawStatement
 	}{
 		// SplitRawStatements treats only lexical structures, so the test cases can be invalid statements.
-		{desc: "empty input", input: "", want: []string{""}},
-		{desc: "single statement ends with semicolon", input: `SELECT "123";`, want: []string{`SELECT "123"`}},
-		{desc: "single statement ends with EOF", input: `SELECT "123"`, want: []string{`SELECT "123"`}},
-		{desc: "two statement ends with semicolon", input: `SELECT "123"; SELECT "456";`, want: []string{`SELECT "123"`, `SELECT "456"`}},
-		{desc: "two statement ends with EOF", input: `SELECT "123"; SELECT "456"`, want: []string{`SELECT "123"`, `SELECT "456"`}},
-		{desc: "second statement is empty", input: `SELECT 1; ;`, want: []string{`SELECT 1`, ``}},
-		{desc: "two statement with new lines", input: "SELECT 1;\n SELECT 2;\n", want: []string{"SELECT 1", "SELECT 2"}},
+		{desc: "empty input", input: "", want: []*memefish.RawStatement{{Statement: ""}}},
+		{desc: "single statement ends with semicolon", input: `SELECT "123";`,
+			want: []*memefish.RawStatement{
+				{Statement: `SELECT "123"`, End: token.Pos(12)},
+			}},
+		{desc: "single statement ends with EOF", input: `SELECT "123"`,
+			want: []*memefish.RawStatement{
+				{Statement: `SELECT "123"`, End: token.Pos(12)},
+			}},
+		{desc: "two statement ends with semicolon", input: `SELECT "123"; SELECT "456";`,
+			want: []*memefish.RawStatement{
+				{Statement: `SELECT "123"`, End: token.Pos(12)},
+				{Statement: `SELECT "456"`, Pos: token.Pos(14), End: token.Pos(26)},
+			}},
+		{desc: "two statement ends with EOF", input: `SELECT "123"; SELECT "456"`,
+			want: []*memefish.RawStatement{
+				{Statement: `SELECT "123"`, End: token.Pos(12)},
+				{Statement: `SELECT "456"`, Pos: token.Pos(14), End: token.Pos(26)},
+			}},
+		{desc: "second statement is empty", input: `SELECT 1; ;`,
+			want: []*memefish.RawStatement{
+				{Statement: `SELECT 1`, End: token.Pos(8)},
+				{Statement: ``, Pos: token.Pos(10), End: token.Pos(10)},
+			}},
+		{desc: "two statement with new lines", input: "SELECT 1;\n SELECT 2;\n",
+			want: []*memefish.RawStatement{
+				{Statement: "SELECT 1", End: token.Pos(8)},
+				{Statement: "SELECT 2", Pos: token.Pos(11), End: token.Pos(19)},
+			}},
 		{desc: "single statement with line comment", input: `SELECT 1//
-`, want: []string{"SELECT 1//\n"}},
-		{desc: "semicolon in line comment", input: "SELECT 1 //;\n + 2", want: []string{"SELECT 1 //;\n + 2"}},
-		{desc: "semicolon in multi-line comment", input: "SELECT 1 /*;\n*/ + 2", want: []string{"SELECT 1 /*;\n*/ + 2"}},
-		{desc: "semicolon in double-quoted string", input: `SELECT "1;2;3";`, want: []string{`SELECT "1;2;3"`}},
-		{desc: "semicolon in single-quoted string", input: `SELECT '1;2;3';`, want: []string{`SELECT '1;2;3'`}},
-		{desc: "semicolon in back-quote", input: "SELECT `1;2;3`;", want: []string{"SELECT `1;2;3`"}},
+`, want: []*memefish.RawStatement{
+			{Statement: "SELECT 1//\n", End: token.Pos(11)},
+		}},
+		{desc: "semicolon in line comment", input: "SELECT 1 //;\n + 2",
+			want: []*memefish.RawStatement{
+				{Statement: "SELECT 1 //;\n + 2", End: token.Pos(17)},
+			}},
+		{desc: "semicolon in multi-line comment", input: "SELECT 1 /*;\n*/ + 2",
+			want: []*memefish.RawStatement{
+				{Statement: "SELECT 1 /*;\n*/ + 2", End: token.Pos(19)},
+			}},
+		{desc: "semicolon in double-quoted string", input: `SELECT "1;2;3";`,
+			want: []*memefish.RawStatement{
+				{Statement: `SELECT "1;2;3"`, End: token.Pos(14)},
+			}},
+		{desc: "semicolon in single-quoted string", input: `SELECT '1;2;3';`,
+			want: []*memefish.RawStatement{
+				{Statement: `SELECT '1;2;3'`, End: token.Pos(14)},
+			}},
+		{desc: "semicolon in back-quote", input: "SELECT `1;2;3`;",
+			want: []*memefish.RawStatement{
+				{Statement: "SELECT `1;2;3`", End: token.Pos(14)},
+			}},
 		// $` may become a valid token in the future, but it's reasonable to check its current behavior.
 		{desc: "unknown token", input: "SELECT $;", errRe: regexp.MustCompile(`illegal input character: '\$'`)},
 	} {


### PR DESCRIPTION
It changes `SplitRawStatements()` result to struct and add `Pos`, `End`.
This decision is talked in GCPUG Slack `#memefish` channel.
https://gcpug.slack.com/archives/C0518HUTECE/p1726919315091699 (This private link will be expired because Slack community plan)

It is a breaking change of exported function, but it is permitted beause memefish has no release `v0.0.0` software.