### PR TITLE
Support proto/enum as typename

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1396,7 +1396,7 @@ type StructField struct {
 
 // NamedType is named type node.
 // It is currently PROTO or ENUM.
-// Name is full qualified name, but it can be not to contain ".".
+// Name is full qualified name, but it can be len(Name) == 1 if it doesn't contain ".".
 //
 //	{{.Path | sqlJoin "."}}
 type NamedType struct {

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1392,6 +1392,32 @@ type StructField struct {
 	Type  Type
 }
 
+// NamedType is named type node.
+// It is currently PROTO or ENUM.
+// Name is full qualified name, but it can be not to contain ".".
+//
+//	{{.TypeName | sql}}
+type NamedType struct {
+	// pos = Name.pos
+	// end = Name.end
+
+	Name *Path
+}
+
+func (n *NamedType) Pos() token.Pos {
+	return n.Name.Pos()
+}
+
+func (n *NamedType) End() token.Pos {
+	return n.Name.End()
+}
+
+func (n *NamedType) SQL() string {
+	return n.Name.SQL()
+}
+
+func (n NamedType) isType() {}
+
 // ================================================================================
 //
 // Cast for Special Cases

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1404,6 +1404,8 @@ type NamedType struct {
 	Name *Path
 }
 
+func (NamedType) isSchemaType() {}
+
 func (n *NamedType) Pos() token.Pos {
 	return n.Name.Pos()
 }
@@ -1416,7 +1418,7 @@ func (n *NamedType) SQL() string {
 	return n.Name.SQL()
 }
 
-func (n NamedType) isType() {}
+func (NamedType) isType() {}
 
 // ================================================================================
 //

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1398,12 +1398,12 @@ type StructField struct {
 // It is currently PROTO or ENUM.
 // Name is full qualified name, but it can be not to contain ".".
 //
-//	{{.TypeName | sql}}
+//	{{.Path | sqlJoin "."}}
 type NamedType struct {
 	// pos = Name.pos
 	// end = Name.end
 
-	Name *Path
+	Path []*Ident // len(Path) > 0
 }
 
 // ================================================================================

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -185,6 +185,7 @@ type Type interface {
 func (SimpleType) isType() {}
 func (ArrayType) isType()  {}
 func (StructType) isType() {}
+func (NamedType) isType()  {}
 
 // IntValue represents integer values in SQL.
 type IntValue interface {
@@ -302,6 +303,7 @@ type SchemaType interface {
 func (ScalarSchemaType) isSchemaType() {}
 func (SizedSchemaType) isSchemaType()  {}
 func (ArraySchemaType) isSchemaType()  {}
+func (NamedType) isSchemaType()        {}
 
 // IndexAlteration represents ALTER INDEX action.
 type IndexAlteration interface {
@@ -1403,22 +1405,6 @@ type NamedType struct {
 
 	Name *Path
 }
-
-func (NamedType) isSchemaType() {}
-
-func (n *NamedType) Pos() token.Pos {
-	return n.Name.Pos()
-}
-
-func (n *NamedType) End() token.Pos {
-	return n.Name.End()
-}
-
-func (n *NamedType) SQL() string {
-	return n.Name.SQL()
-}
-
-func (NamedType) isType() {}
 
 // ================================================================================
 //

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -466,6 +466,9 @@ func (f *StructField) End() token.Pos {
 	return f.Type.End()
 }
 
+func (n *NamedType) Pos() token.Pos { return n.Name.Pos() }
+func (n *NamedType) End() token.Pos { return n.Name.End() }
+
 // ================================================================================
 //
 // Cast for Special Cases

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -466,8 +466,8 @@ func (f *StructField) End() token.Pos {
 	return f.Type.End()
 }
 
-func (n *NamedType) Pos() token.Pos { return n.Name.Pos() }
-func (n *NamedType) End() token.Pos { return n.Name.End() }
+func (n *NamedType) Pos() token.Pos { return n.Path[0].Pos() }
+func (n *NamedType) End() token.Pos { return n.Path[len(n.Path)-1].End() }
 
 // ================================================================================
 //

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -720,6 +720,10 @@ func (f *StructField) SQL() string {
 	return sql
 }
 
+func (n *NamedType) SQL() string {
+	return n.Name.SQL()
+}
+
 // ================================================================================
 //
 // Cast for Special Cases

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -721,7 +721,14 @@ func (f *StructField) SQL() string {
 }
 
 func (n *NamedType) SQL() string {
-	return n.Name.SQL()
+	var sql string
+	for i, elem := range n.Path {
+		if i > 0 {
+			sql += "."
+		}
+		sql += elem.SQL()
+	}
+	return sql
 }
 
 // ================================================================================

--- a/parser.go
+++ b/parser.go
@@ -1884,9 +1884,13 @@ func (p *Parser) lookaheadSubQuery() bool {
 
 // ================================================================================
 //
-// Type
+// # Type
 //
 // ================================================================================
+func (p *Parser) parseNamedType() *ast.NamedType {
+	path := p.parseIdentOrPath()
+	return &ast.NamedType{Name: &ast.Path{Idents: path}}
+}
 
 func (p *Parser) parseType() ast.Type {
 	switch p.Token.Kind {
@@ -1894,8 +1898,7 @@ func (p *Parser) parseType() ast.Type {
 		if p.lookaheadSimpleType() {
 			return p.parseSimpleType()
 		}
-		path := p.parseIdentOrPath()
-		return &ast.NamedType{Name: &ast.Path{Idents: path}}
+		return p.parseNamedType()
 	case "ARRAY":
 		return p.parseArrayType()
 	case "STRUCT":
@@ -1915,6 +1918,7 @@ var simpleTypes = []string{
 	"NUMERIC",
 	"STRING",
 	"BYTES",
+	"JSON",
 }
 
 func (p *Parser) parseSimpleType() *ast.SimpleType {
@@ -3298,6 +3302,9 @@ func (p *Parser) tryParseTablePrivilegeColumns() ([]*ast.Ident, token.Pos) {
 func (p *Parser) parseSchemaType() ast.SchemaType {
 	switch p.Token.Kind {
 	case token.TokenIdent:
+		if !p.lookaheadSimpleType() {
+			return p.parseNamedType()
+		}
 		return p.parseScalarSchemaType()
 	case "ARRAY":
 		pos := p.expect("ARRAY").Pos

--- a/parser.go
+++ b/parser.go
@@ -1889,7 +1889,7 @@ func (p *Parser) lookaheadSubQuery() bool {
 // ================================================================================
 func (p *Parser) parseNamedType() *ast.NamedType {
 	path := p.parseIdentOrPath()
-	return &ast.NamedType{Name: &ast.Path{Idents: path}}
+	return &ast.NamedType{Path: path}
 }
 
 func (p *Parser) parseType() ast.Type {

--- a/parser.go
+++ b/parser.go
@@ -1896,10 +1896,10 @@ func (p *Parser) parseNamedType() *ast.NamedType {
 func (p *Parser) parseType() ast.Type {
 	switch p.Token.Kind {
 	case token.TokenIdent:
-		if p.lookaheadSimpleType() {
-			return p.parseSimpleType()
+		if !p.lookaheadSimpleType() {
+			return p.parseNamedType()
 		}
-		return p.parseNamedType()
+		return p.parseSimpleType()
 	case "ARRAY":
 		return p.parseArrayType()
 	case "STRUCT":

--- a/parser.go
+++ b/parser.go
@@ -1891,7 +1891,11 @@ func (p *Parser) lookaheadSubQuery() bool {
 func (p *Parser) parseType() ast.Type {
 	switch p.Token.Kind {
 	case token.TokenIdent:
-		return p.parseSimpleType()
+		if p.lookaheadSimpleType() {
+			return p.parseSimpleType()
+		}
+		path := p.parseIdentOrPath()
+		return &ast.NamedType{Name: &ast.Path{Idents: path}}
 	case "ARRAY":
 		return p.parseArrayType()
 	case "STRUCT":
@@ -2016,6 +2020,21 @@ func (p *Parser) parseFieldType() *ast.StructField {
 
 func (p *Parser) lookaheadType() bool {
 	return p.Token.Kind == token.TokenIdent || p.Token.Kind == "ARRAY" || p.Token.Kind == "STRUCT"
+}
+
+func (p *Parser) lookaheadSimpleType() bool {
+	if p.Token.Kind != token.TokenIdent {
+		return false
+	}
+
+	id := p.Token
+
+	for _, name := range simpleTypes {
+		if id.IsIdent(name) {
+			return true
+		}
+	}
+	return false
 }
 
 // ================================================================================

--- a/parser.go
+++ b/parser.go
@@ -1884,9 +1884,10 @@ func (p *Parser) lookaheadSubQuery() bool {
 
 // ================================================================================
 //
-// # Type
+// Type
 //
 // ================================================================================
+
 func (p *Parser) parseNamedType() *ast.NamedType {
 	path := p.parseIdentOrPath()
 	return &ast.NamedType{Path: path}

--- a/testdata/input/ddl/create_table_types.sql
+++ b/testdata/input/ddl/create_table_types.sql
@@ -10,5 +10,6 @@ create table types (
   bs bytes(256),
   bsmax bytes(max),
   ab array<bool>,
-  abs array<bytes(max)>
+  abs array<bytes(max)>,
+  p examples.ProtoType,
 ) primary key (i)

--- a/testdata/input/expr/cast_as_typename.sql
+++ b/testdata/input/expr/cast_as_typename.sql
@@ -1,0 +1,1 @@
+CAST('order_number: "123"' AS examples.shipping.`Order`)

--- a/testdata/result/ddl/create_table_types.sql.txt
+++ b/testdata/result/ddl/create_table_types.sql.txt
@@ -11,13 +11,14 @@ create table types (
   bs bytes(256),
   bsmax bytes(max),
   ab array<bool>,
-  abs array<bytes(max)>
+  abs array<bytes(max)>,
+  p examples.ProtoType,
 ) primary key (i)
 
 --- AST
 &ast.CreateTable{
   Create:      0,
-  Rparen:      227,
+  Rparen:      252,
   IfNotExists: false,
   Name:        &ast.Ident{
     NamePos: 13,
@@ -250,14 +251,42 @@ create table types (
       GeneratedExpr: (*ast.GeneratedColumnExpr)(nil),
       Options:       (*ast.ColumnDefOptions)(nil),
     },
+    &ast.ColumnDef{
+      Null: -1,
+      Name: &ast.Ident{
+        NamePos: 214,
+        NameEnd: 215,
+        Name:    "p",
+      },
+      Type: &ast.NamedType{
+        Name: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 216,
+              NameEnd: 224,
+              Name:    "examples",
+            },
+            &ast.Ident{
+              NamePos: 225,
+              NameEnd: 234,
+              Name:    "ProtoType",
+            },
+          },
+        },
+      },
+      NotNull:       false,
+      DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
+      GeneratedExpr: (*ast.GeneratedColumnExpr)(nil),
+      Options:       (*ast.ColumnDefOptions)(nil),
+    },
   },
   TableConstraints: []*ast.TableConstraint(nil),
   PrimaryKeys:      []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
-        NamePos: 226,
-        NameEnd: 227,
+        NamePos: 251,
+        NameEnd: 252,
         Name:    "i",
       },
       Dir: "",
@@ -268,4 +297,4 @@ create table types (
 }
 
 --- SQL
-CREATE TABLE types (b BOOL, i INT64, f32 FLOAT32, f FLOAT64, d DATE, t TIMESTAMP, s STRING(256), smax STRING(MAX), bs BYTES(256), bsmax BYTES(MAX), ab ARRAY<BOOL>, abs ARRAY<BYTES(MAX)>) PRIMARY KEY (i)
+CREATE TABLE types (b BOOL, i INT64, f32 FLOAT32, f FLOAT64, d DATE, t TIMESTAMP, s STRING(256), smax STRING(MAX), bs BYTES(256), bsmax BYTES(MAX), ab ARRAY<BOOL>, abs ARRAY<BYTES(MAX)>, p examples.ProtoType) PRIMARY KEY (i)

--- a/testdata/result/ddl/create_table_types.sql.txt
+++ b/testdata/result/ddl/create_table_types.sql.txt
@@ -259,18 +259,16 @@ create table types (
         Name:    "p",
       },
       Type: &ast.NamedType{
-        Name: &ast.Path{
-          Idents: []*ast.Ident{
-            &ast.Ident{
-              NamePos: 216,
-              NameEnd: 224,
-              Name:    "examples",
-            },
-            &ast.Ident{
-              NamePos: 225,
-              NameEnd: 234,
-              Name:    "ProtoType",
-            },
+        Path: []*ast.Ident{
+          &ast.Ident{
+            NamePos: 216,
+            NameEnd: 224,
+            Name:    "examples",
+          },
+          &ast.Ident{
+            NamePos: 225,
+            NameEnd: 234,
+            Name:    "ProtoType",
           },
         },
       },

--- a/testdata/result/expr/cast_as_typename.sql.txt
+++ b/testdata/result/expr/cast_as_typename.sql.txt
@@ -10,23 +10,21 @@ CAST('order_number: "123"' AS examples.shipping.`Order`)
     Value:    "order_number: \"123\"",
   },
   Type: &ast.NamedType{
-    Name: &ast.Path{
-      Idents: []*ast.Ident{
-        &ast.Ident{
-          NamePos: 30,
-          NameEnd: 38,
-          Name:    "examples",
-        },
-        &ast.Ident{
-          NamePos: 39,
-          NameEnd: 47,
-          Name:    "shipping",
-        },
-        &ast.Ident{
-          NamePos: 48,
-          NameEnd: 55,
-          Name:    "Order",
-        },
+    Path: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 30,
+        NameEnd: 38,
+        Name:    "examples",
+      },
+      &ast.Ident{
+        NamePos: 39,
+        NameEnd: 47,
+        Name:    "shipping",
+      },
+      &ast.Ident{
+        NamePos: 48,
+        NameEnd: 55,
+        Name:    "Order",
       },
     },
   },

--- a/testdata/result/expr/cast_as_typename.sql.txt
+++ b/testdata/result/expr/cast_as_typename.sql.txt
@@ -1,0 +1,36 @@
+--- cast_as_typename.sql
+CAST('order_number: "123"' AS examples.shipping.`Order`)
+--- AST
+&ast.CastExpr{
+  Cast:   0,
+  Rparen: 55,
+  Expr:   &ast.StringLiteral{
+    ValuePos: 5,
+    ValueEnd: 26,
+    Value:    "order_number: \"123\"",
+  },
+  Type: &ast.NamedType{
+    Name: &ast.Path{
+      Idents: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 30,
+          NameEnd: 38,
+          Name:    "examples",
+        },
+        &ast.Ident{
+          NamePos: 39,
+          NameEnd: 47,
+          Name:    "shipping",
+        },
+        &ast.Ident{
+          NamePos: 48,
+          NameEnd: 55,
+          Name:    "Order",
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+CAST("order_number: \"123\"" AS examples.shipping.`Order`)

--- a/testdata/result/statement/create_table_types.sql.txt
+++ b/testdata/result/statement/create_table_types.sql.txt
@@ -11,13 +11,14 @@ create table types (
   bs bytes(256),
   bsmax bytes(max),
   ab array<bool>,
-  abs array<bytes(max)>
+  abs array<bytes(max)>,
+  p examples.ProtoType,
 ) primary key (i)
 
 --- AST
 &ast.CreateTable{
   Create:      0,
-  Rparen:      227,
+  Rparen:      252,
   IfNotExists: false,
   Name:        &ast.Ident{
     NamePos: 13,
@@ -250,14 +251,42 @@ create table types (
       GeneratedExpr: (*ast.GeneratedColumnExpr)(nil),
       Options:       (*ast.ColumnDefOptions)(nil),
     },
+    &ast.ColumnDef{
+      Null: -1,
+      Name: &ast.Ident{
+        NamePos: 214,
+        NameEnd: 215,
+        Name:    "p",
+      },
+      Type: &ast.NamedType{
+        Name: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 216,
+              NameEnd: 224,
+              Name:    "examples",
+            },
+            &ast.Ident{
+              NamePos: 225,
+              NameEnd: 234,
+              Name:    "ProtoType",
+            },
+          },
+        },
+      },
+      NotNull:       false,
+      DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
+      GeneratedExpr: (*ast.GeneratedColumnExpr)(nil),
+      Options:       (*ast.ColumnDefOptions)(nil),
+    },
   },
   TableConstraints: []*ast.TableConstraint(nil),
   PrimaryKeys:      []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
-        NamePos: 226,
-        NameEnd: 227,
+        NamePos: 251,
+        NameEnd: 252,
         Name:    "i",
       },
       Dir: "",
@@ -268,4 +297,4 @@ create table types (
 }
 
 --- SQL
-CREATE TABLE types (b BOOL, i INT64, f32 FLOAT32, f FLOAT64, d DATE, t TIMESTAMP, s STRING(256), smax STRING(MAX), bs BYTES(256), bsmax BYTES(MAX), ab ARRAY<BOOL>, abs ARRAY<BYTES(MAX)>) PRIMARY KEY (i)
+CREATE TABLE types (b BOOL, i INT64, f32 FLOAT32, f FLOAT64, d DATE, t TIMESTAMP, s STRING(256), smax STRING(MAX), bs BYTES(256), bsmax BYTES(MAX), ab ARRAY<BOOL>, abs ARRAY<BYTES(MAX)>, p examples.ProtoType) PRIMARY KEY (i)

--- a/testdata/result/statement/create_table_types.sql.txt
+++ b/testdata/result/statement/create_table_types.sql.txt
@@ -259,18 +259,16 @@ create table types (
         Name:    "p",
       },
       Type: &ast.NamedType{
-        Name: &ast.Path{
-          Idents: []*ast.Ident{
-            &ast.Ident{
-              NamePos: 216,
-              NameEnd: 224,
-              Name:    "examples",
-            },
-            &ast.Ident{
-              NamePos: 225,
-              NameEnd: 234,
-              Name:    "ProtoType",
-            },
+        Path: []*ast.Ident{
+          &ast.Ident{
+            NamePos: 216,
+            NameEnd: 224,
+            Name:    "examples",
+          },
+          &ast.Ident{
+            NamePos: 225,
+            NameEnd: 234,
+            Name:    "ProtoType",
           },
         },
       },


### PR DESCRIPTION
This PR adds `NamedType`.

it is required for `PROTO`/`ENUM` support:

* [CAST AS ENUM](https://cloud.google.com/spanner/docs/reference/standard-sql/conversion_functions#cast_as_enum)
* [CAST AS PROTO](https://cloud.google.com/spanner/docs/reference/standard-sql/conversion_functions#cast_as_proto)
* [Use a protocol buffer message in a column definition](https://cloud.google.com/spanner/docs/reference/standard-sql/protocol-buffers#use_a_protocol_buffer_message_in_a_column_definition)