### PR TITLE
Support SELECT AS VALUE and SELECT AS typename

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -96,6 +96,16 @@ func (DotStar) isSelectItem()        {}
 func (Alias) isSelectItem()          {}
 func (ExprSelectItem) isSelectItem() {}
 
+// SelectAs represents AS VALUE/STRUCT/typename clause in SELECT clause.
+type SelectAs interface {
+	Node
+	isSelectAs()
+}
+
+func (AsStruct) isSelectAs()   {}
+func (AsValue) isSelectAs()    {}
+func (AsTypeName) isSelectAs() {}
+
 // TableExpr represents JOIN operands.
 type TableExpr interface {
 	Node
@@ -443,8 +453,8 @@ type Select struct {
 	Select token.Pos // position of "select" keyword
 
 	Distinct bool
-	AsStruct bool // deprecated, use As
-	As       SelectAs
+	AsStruct bool         // deprecated, use As
+	As       SelectAs     // optional
 	Results  []SelectItem // len(Results) > 0
 	From     *From        // optional
 	Where    *Where       // optional
@@ -454,16 +464,7 @@ type Select struct {
 	Limit    *Limit       // optional
 }
 
-type SelectAs interface {
-	Node
-	isSelectAs()
-}
-
-func (AsStruct) isSelectAs()   {}
-func (AsValue) isSelectAs()    {}
-func (AsTypeName) isSelectAs() {}
-
-// AsStruct
+// AsStruct represents AS STRUCT node in SELECT clause.
 //
 //	AS STRUCT
 type AsStruct struct {
@@ -473,19 +474,7 @@ type AsStruct struct {
 	Struct token.Pos
 }
 
-func (a *AsStruct) Pos() token.Pos {
-	return a.As
-}
-
-func (a *AsStruct) End() token.Pos {
-	return a.Struct + 6
-}
-
-func (a *AsStruct) SQL() string {
-	return "AS STRUCT"
-}
-
-// AsValue
+// AsValue represents AS VALUE node in SELECT clause.
 //
 //	AS VALUE
 type AsValue struct {
@@ -496,19 +485,7 @@ type AsValue struct {
 	Value token.Pos
 }
 
-func (a *AsValue) Pos() token.Pos {
-	return a.As
-}
-
-func (a *AsValue) End() token.Pos {
-	return a.Value + 5
-}
-
-func (a *AsValue) SQL() string {
-	return "AS VALUE"
-}
-
-// AsTypeName
+// AsTypeName represents AS typename node in SELECT clause.
 //
 //	AS {{.TypeName | sql}}
 type AsTypeName struct {
@@ -516,18 +493,6 @@ type AsTypeName struct {
 	// end = TypeName.end
 	As       token.Pos
 	TypeName *NamedType
-}
-
-func (a *AsTypeName) Pos() token.Pos {
-	return a.As
-}
-
-func (a *AsTypeName) End() token.Pos {
-	return a.TypeName.End()
-}
-
-func (a *AsTypeName) SQL() string {
-	return "AS " + a.TypeName.SQL()
 }
 
 // CompoundQuery is query statement node compounded by set operators.

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -491,6 +491,7 @@ type AsValue struct {
 type AsTypeName struct {
 	// pos = As
 	// end = TypeName.end
+
 	As       token.Pos
 	TypeName *NamedType
 }

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -453,7 +453,6 @@ type Select struct {
 	Select token.Pos // position of "select" keyword
 
 	Distinct bool
-	AsStruct bool         // deprecated, use As
 	As       SelectAs     // optional
 	Results  []SelectItem // len(Results) > 0
 	From     *From        // optional

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -38,6 +38,12 @@ func TestSelectItem(t *testing.T) {
 	SelectItem(&ExprSelectItem{}).isSelectItem()
 }
 
+func TestSelectAs(t *testing.T) {
+	SelectAs(&AsStruct{}).isSelectAs()
+	SelectAs(&AsValue{}).isSelectAs()
+	SelectAs(&AsTypeName{}).isSelectAs()
+}
+
 func TestTableExpr(t *testing.T) {
 	TableExpr(&Unnest{}).isTableExpr()
 	TableExpr(&TableName{}).isTableExpr()

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -60,6 +60,15 @@ func (s *Select) End() token.Pos {
 	return s.Results[len(s.Results)-1].End()
 }
 
+func (a *AsStruct) Pos() token.Pos { return a.As }
+func (a *AsStruct) End() token.Pos { return a.Struct + 6 }
+
+func (a *AsValue) Pos() token.Pos { return a.As }
+func (a *AsValue) End() token.Pos { return a.Value + 5 }
+
+func (a *AsTypeName) Pos() token.Pos { return a.As }
+func (a *AsTypeName) End() token.Pos { return a.TypeName.End() }
+
 func (c *CompoundQuery) Pos() token.Pos {
 	return c.Queries[0].Pos()
 }

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -148,6 +148,12 @@ func (s *Select) SQL() string {
 	return sql
 }
 
+func (a *AsStruct) SQL() string { return "AS STRUCT" }
+
+func (a *AsValue) SQL() string { return "AS VALUE" }
+
+func (a *AsTypeName) SQL() string { return "AS " + a.TypeName.SQL() }
+
 func (c *CompoundQuery) SQL() string {
 	op := string(c.Op)
 	if c.Distinct {

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -120,8 +120,8 @@ func (s *Select) SQL() string {
 	if s.Distinct {
 		sql += "DISTINCT "
 	}
-	if s.AsStruct {
-		sql += "AS STRUCT "
+	if s.As != nil {
+		sql += s.As.SQL() + " "
 	}
 	sql += s.Results[0].SQL()
 	for _, r := range s.Results[1:] {

--- a/parser.go
+++ b/parser.go
@@ -384,6 +384,32 @@ func (p *Parser) parseSimpleQueryExpr() ast.QueryExpr {
 	return p.parseSelect()
 }
 
+func (p *Parser) tryParseSelectAs() ast.SelectAs {
+	if p.Token.Kind != "AS" {
+		return nil
+	}
+	asPos := p.expect("AS").Pos
+	switch {
+	case p.Token.Kind == "STRUCT":
+		structPos := p.expect("STRUCT").Pos
+		return &ast.AsStruct{
+			As:     asPos,
+			Struct: structPos,
+		}
+	case p.Token.IsKeywordLike("VALUE"):
+		valuePos := p.expectKeywordLike("VALUE").Pos
+		return &ast.AsValue{
+			As:    asPos,
+			Value: valuePos,
+		}
+	default:
+		namedType := p.parseNamedType()
+		return &ast.AsTypeName{
+			As:       asPos,
+			TypeName: namedType,
+		}
+	}
+}
 func (p *Parser) parseSelect() *ast.Select {
 	sel := p.expect("SELECT").Pos
 	var distinct bool
@@ -391,12 +417,8 @@ func (p *Parser) parseSelect() *ast.Select {
 		p.nextToken()
 		distinct = true
 	}
-	var asStruct bool
-	if p.Token.Kind == "AS" {
-		p.nextToken()
-		p.expect("STRUCT")
-		asStruct = true
-	}
+	selectAs := p.tryParseSelectAs()
+	_, asStruct := selectAs.(*ast.AsStruct)
 
 	results := p.parseSelectResults()
 	from := p.tryParseFrom()
@@ -408,6 +430,7 @@ func (p *Parser) parseSelect() *ast.Select {
 		Select:   sel,
 		Distinct: distinct,
 		AsStruct: asStruct,
+		As:       selectAs,
 		Results:  results,
 		From:     from,
 		Where:    where,

--- a/parser.go
+++ b/parser.go
@@ -410,6 +410,7 @@ func (p *Parser) tryParseSelectAs() ast.SelectAs {
 		}
 	}
 }
+
 func (p *Parser) parseSelect() *ast.Select {
 	sel := p.expect("SELECT").Pos
 	var distinct bool

--- a/parser.go
+++ b/parser.go
@@ -419,8 +419,6 @@ func (p *Parser) parseSelect() *ast.Select {
 		distinct = true
 	}
 	selectAs := p.tryParseSelectAs()
-	_, asStruct := selectAs.(*ast.AsStruct)
-
 	results := p.parseSelectResults()
 	from := p.tryParseFrom()
 	where := p.tryParseWhere()
@@ -430,7 +428,6 @@ func (p *Parser) parseSelect() *ast.Select {
 	return &ast.Select{
 		Select:   sel,
 		Distinct: distinct,
-		AsStruct: asStruct,
 		As:       selectAs,
 		Results:  results,
 		From:     from,

--- a/testdata/input/expr/value_subquery_select_as_fqn_typename.sql
+++ b/testdata/input/expr/value_subquery_select_as_fqn_typename.sql
@@ -1,0 +1,1 @@
+(SELECT AS example.TypeName 1 AS i)

--- a/testdata/input/expr/value_subquery_select_as_leaf_typename.sql
+++ b/testdata/input/expr/value_subquery_select_as_leaf_typename.sql
@@ -1,0 +1,1 @@
+(SELECT AS TypeName 1 AS i)

--- a/testdata/input/expr/value_subquery_select_as_struct.sql
+++ b/testdata/input/expr/value_subquery_select_as_struct.sql
@@ -1,0 +1,1 @@
+(SELECT AS STRUCT 1 AS i)

--- a/testdata/input/expr/value_subquery_select_as_value.sql
+++ b/testdata/input/expr/value_subquery_select_as_value.sql
@@ -1,0 +1,1 @@
+(SELECT AS VALUE 1)

--- a/testdata/result/ddl/create_or_replace_view.sql.txt
+++ b/testdata/result/ddl/create_or_replace_view.sql.txt
@@ -19,7 +19,6 @@ from singers
   Query:        &ast.Select{
     Select:   59,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{

--- a/testdata/result/ddl/create_or_replace_view.sql.txt
+++ b/testdata/result/ddl/create_or_replace_view.sql.txt
@@ -20,6 +20,7 @@ from singers
     Select:   59,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.Path{

--- a/testdata/result/ddl/create_view.sql.txt
+++ b/testdata/result/ddl/create_view.sql.txt
@@ -19,7 +19,6 @@ from singers
   Query:        &ast.Select{
     Select:   48,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{

--- a/testdata/result/ddl/create_view.sql.txt
+++ b/testdata/result/ddl/create_view.sql.txt
@@ -20,6 +20,7 @@ from singers
     Select:   48,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.Path{

--- a/testdata/result/ddl/create_view_sql_security_definer.sql.txt
+++ b/testdata/result/ddl/create_view_sql_security_definer.sql.txt
@@ -19,7 +19,6 @@ from singers
   Query:        &ast.Select{
     Select:   48,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{

--- a/testdata/result/ddl/create_view_sql_security_definer.sql.txt
+++ b/testdata/result/ddl/create_view_sql_security_definer.sql.txt
@@ -20,6 +20,7 @@ from singers
     Select:   48,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.Path{

--- a/testdata/result/dml/insert_select.sql.txt
+++ b/testdata/result/dml/insert_select.sql.txt
@@ -26,7 +26,6 @@ select * from unnest([(1, 2), (3, 4)])
     Query: &ast.Select{
       Select:   22,
       Distinct: false,
-      AsStruct: false,
       As:       nil,
       Results:  []ast.SelectItem{
         &ast.Star{

--- a/testdata/result/dml/insert_select.sql.txt
+++ b/testdata/result/dml/insert_select.sql.txt
@@ -27,6 +27,7 @@ select * from unnest([(1, 2), (3, 4)])
       Select:   22,
       Distinct: false,
       AsStruct: false,
+      As:       nil,
       Results:  []ast.SelectItem{
         &ast.Star{
           Star: 29,

--- a/testdata/result/expr/value_subquery_select_as_fqn_typename.sql.txt
+++ b/testdata/result/expr/value_subquery_select_as_fqn_typename.sql.txt
@@ -11,18 +11,16 @@
     As:       &ast.AsTypeName{
       As:       8,
       TypeName: &ast.NamedType{
-        Name: &ast.Path{
-          Idents: []*ast.Ident{
-            &ast.Ident{
-              NamePos: 11,
-              NameEnd: 18,
-              Name:    "example",
-            },
-            &ast.Ident{
-              NamePos: 19,
-              NameEnd: 27,
-              Name:    "TypeName",
-            },
+        Path: []*ast.Ident{
+          &ast.Ident{
+            NamePos: 11,
+            NameEnd: 18,
+            Name:    "example",
+          },
+          &ast.Ident{
+            NamePos: 19,
+            NameEnd: 27,
+            Name:    "TypeName",
           },
         },
       },

--- a/testdata/result/expr/value_subquery_select_as_fqn_typename.sql.txt
+++ b/testdata/result/expr/value_subquery_select_as_fqn_typename.sql.txt
@@ -55,4 +55,4 @@
 }
 
 --- SQL
-(SELECT 1 AS i)
+(SELECT AS example.TypeName 1 AS i)

--- a/testdata/result/expr/value_subquery_select_as_fqn_typename.sql.txt
+++ b/testdata/result/expr/value_subquery_select_as_fqn_typename.sql.txt
@@ -1,0 +1,58 @@
+--- value_subquery_select_as_fqn_typename.sql
+(SELECT AS example.TypeName 1 AS i)
+--- AST
+&ast.ScalarSubQuery{
+  Lparen: 0,
+  Rparen: 34,
+  Query:  &ast.Select{
+    Select:   1,
+    Distinct: false,
+    AsStruct: false,
+    As:       &ast.AsTypeName{
+      As:       8,
+      TypeName: &ast.NamedType{
+        Name: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 11,
+              NameEnd: 18,
+              Name:    "example",
+            },
+            &ast.Ident{
+              NamePos: 19,
+              NameEnd: 27,
+              Name:    "TypeName",
+            },
+          },
+        },
+      },
+    },
+    Results: []ast.SelectItem{
+      &ast.Alias{
+        Expr: &ast.IntLiteral{
+          ValuePos: 28,
+          ValueEnd: 29,
+          Base:     10,
+          Value:    "1",
+        },
+        As: &ast.AsAlias{
+          As:    -1,
+          Alias: &ast.Ident{
+            NamePos: 33,
+            NameEnd: 34,
+            Name:    "i",
+          },
+        },
+      },
+    },
+    From:    (*ast.From)(nil),
+    Where:   (*ast.Where)(nil),
+    GroupBy: (*ast.GroupBy)(nil),
+    Having:  (*ast.Having)(nil),
+    OrderBy: (*ast.OrderBy)(nil),
+    Limit:   (*ast.Limit)(nil),
+  },
+}
+
+--- SQL
+(SELECT 1 AS i)

--- a/testdata/result/expr/value_subquery_select_as_fqn_typename.sql.txt
+++ b/testdata/result/expr/value_subquery_select_as_fqn_typename.sql.txt
@@ -7,7 +7,6 @@
   Query:  &ast.Select{
     Select:   1,
     Distinct: false,
-    AsStruct: false,
     As:       &ast.AsTypeName{
       As:       8,
       TypeName: &ast.NamedType{

--- a/testdata/result/expr/value_subquery_select_as_leaf_typename.sql.txt
+++ b/testdata/result/expr/value_subquery_select_as_leaf_typename.sql.txt
@@ -1,0 +1,53 @@
+--- value_subquery_select_as_leaf_typename.sql
+(SELECT AS TypeName 1 AS i)
+--- AST
+&ast.ScalarSubQuery{
+  Lparen: 0,
+  Rparen: 26,
+  Query:  &ast.Select{
+    Select:   1,
+    Distinct: false,
+    AsStruct: false,
+    As:       &ast.AsTypeName{
+      As:       8,
+      TypeName: &ast.NamedType{
+        Name: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 11,
+              NameEnd: 19,
+              Name:    "TypeName",
+            },
+          },
+        },
+      },
+    },
+    Results: []ast.SelectItem{
+      &ast.Alias{
+        Expr: &ast.IntLiteral{
+          ValuePos: 20,
+          ValueEnd: 21,
+          Base:     10,
+          Value:    "1",
+        },
+        As: &ast.AsAlias{
+          As:    -1,
+          Alias: &ast.Ident{
+            NamePos: 25,
+            NameEnd: 26,
+            Name:    "i",
+          },
+        },
+      },
+    },
+    From:    (*ast.From)(nil),
+    Where:   (*ast.Where)(nil),
+    GroupBy: (*ast.GroupBy)(nil),
+    Having:  (*ast.Having)(nil),
+    OrderBy: (*ast.OrderBy)(nil),
+    Limit:   (*ast.Limit)(nil),
+  },
+}
+
+--- SQL
+(SELECT 1 AS i)

--- a/testdata/result/expr/value_subquery_select_as_leaf_typename.sql.txt
+++ b/testdata/result/expr/value_subquery_select_as_leaf_typename.sql.txt
@@ -11,13 +11,11 @@
     As:       &ast.AsTypeName{
       As:       8,
       TypeName: &ast.NamedType{
-        Name: &ast.Path{
-          Idents: []*ast.Ident{
-            &ast.Ident{
-              NamePos: 11,
-              NameEnd: 19,
-              Name:    "TypeName",
-            },
+        Path: []*ast.Ident{
+          &ast.Ident{
+            NamePos: 11,
+            NameEnd: 19,
+            Name:    "TypeName",
           },
         },
       },

--- a/testdata/result/expr/value_subquery_select_as_leaf_typename.sql.txt
+++ b/testdata/result/expr/value_subquery_select_as_leaf_typename.sql.txt
@@ -7,7 +7,6 @@
   Query:  &ast.Select{
     Select:   1,
     Distinct: false,
-    AsStruct: false,
     As:       &ast.AsTypeName{
       As:       8,
       TypeName: &ast.NamedType{

--- a/testdata/result/expr/value_subquery_select_as_leaf_typename.sql.txt
+++ b/testdata/result/expr/value_subquery_select_as_leaf_typename.sql.txt
@@ -50,4 +50,4 @@
 }
 
 --- SQL
-(SELECT 1 AS i)
+(SELECT AS TypeName 1 AS i)

--- a/testdata/result/expr/value_subquery_select_as_struct.sql.txt
+++ b/testdata/result/expr/value_subquery_select_as_struct.sql.txt
@@ -1,0 +1,44 @@
+--- value_subquery_select_as_struct.sql
+(SELECT AS STRUCT 1 AS i)
+
+--- AST
+&ast.ScalarSubQuery{
+  Lparen: 0,
+  Rparen: 24,
+  Query:  &ast.Select{
+    Select:   1,
+    Distinct: false,
+    AsStruct: true,
+    As:       &ast.AsStruct{
+      As:     8,
+      Struct: 11,
+    },
+    Results: []ast.SelectItem{
+      &ast.Alias{
+        Expr: &ast.IntLiteral{
+          ValuePos: 18,
+          ValueEnd: 19,
+          Base:     10,
+          Value:    "1",
+        },
+        As: &ast.AsAlias{
+          As:    -1,
+          Alias: &ast.Ident{
+            NamePos: 23,
+            NameEnd: 24,
+            Name:    "i",
+          },
+        },
+      },
+    },
+    From:    (*ast.From)(nil),
+    Where:   (*ast.Where)(nil),
+    GroupBy: (*ast.GroupBy)(nil),
+    Having:  (*ast.Having)(nil),
+    OrderBy: (*ast.OrderBy)(nil),
+    Limit:   (*ast.Limit)(nil),
+  },
+}
+
+--- SQL
+(SELECT AS STRUCT 1 AS i)

--- a/testdata/result/expr/value_subquery_select_as_struct.sql.txt
+++ b/testdata/result/expr/value_subquery_select_as_struct.sql.txt
@@ -8,7 +8,6 @@
   Query:  &ast.Select{
     Select:   1,
     Distinct: false,
-    AsStruct: true,
     As:       &ast.AsStruct{
       As:     8,
       Struct: 11,

--- a/testdata/result/expr/value_subquery_select_as_value.sql.txt
+++ b/testdata/result/expr/value_subquery_select_as_value.sql.txt
@@ -32,4 +32,4 @@
 }
 
 --- SQL
-(SELECT 1)
+(SELECT AS VALUE 1)

--- a/testdata/result/expr/value_subquery_select_as_value.sql.txt
+++ b/testdata/result/expr/value_subquery_select_as_value.sql.txt
@@ -1,0 +1,35 @@
+--- value_subquery_select_as_value.sql
+(SELECT AS VALUE 1)
+--- AST
+&ast.ScalarSubQuery{
+  Lparen: 0,
+  Rparen: 18,
+  Query:  &ast.Select{
+    Select:   1,
+    Distinct: false,
+    AsStruct: false,
+    As:       &ast.AsValue{
+      As:    8,
+      Value: 11,
+    },
+    Results: []ast.SelectItem{
+      &ast.ExprSelectItem{
+        Expr: &ast.IntLiteral{
+          ValuePos: 17,
+          ValueEnd: 18,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+    From:    (*ast.From)(nil),
+    Where:   (*ast.Where)(nil),
+    GroupBy: (*ast.GroupBy)(nil),
+    Having:  (*ast.Having)(nil),
+    OrderBy: (*ast.OrderBy)(nil),
+    Limit:   (*ast.Limit)(nil),
+  },
+}
+
+--- SQL
+(SELECT 1)

--- a/testdata/result/expr/value_subquery_select_as_value.sql.txt
+++ b/testdata/result/expr/value_subquery_select_as_value.sql.txt
@@ -7,7 +7,6 @@
   Query:  &ast.Select{
     Select:   1,
     Distinct: false,
-    AsStruct: false,
     As:       &ast.AsValue{
       As:    8,
       Value: 11,

--- a/testdata/result/query/select_album_with_index_directive.sql.txt
+++ b/testdata/result/query/select_album_with_index_directive.sql.txt
@@ -11,6 +11,7 @@ WHERE AlbumTitle >= @startTitle AND AlbumTitle < @endTitle
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Ident{

--- a/testdata/result/query/select_album_with_index_directive.sql.txt
+++ b/testdata/result/query/select_album_with_index_directive.sql.txt
@@ -10,7 +10,6 @@ WHERE AlbumTitle >= @startTitle AND AlbumTitle < @endTitle
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_alias_without_as.sql.txt
+++ b/testdata/result/query/select_alias_without_as.sql.txt
@@ -9,6 +9,7 @@ select 1 A
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.IntLiteral{

--- a/testdata/result/query/select_alias_without_as.sql.txt
+++ b/testdata/result/query/select_alias_without_as.sql.txt
@@ -8,7 +8,6 @@ select 1 A
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{

--- a/testdata/result/query/select_array_with_struct.sql.txt
+++ b/testdata/result/query/select_array_with_struct.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_array_with_struct.sql.txt
+++ b/testdata/result/query/select_array_with_struct.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_call_with_named_expr.sql.txt
+++ b/testdata/result/query/select_call_with_named_expr.sql.txt
@@ -10,6 +10,7 @@ WHERE a.SingerId = 1 AND SEARCH(a.DescriptionTokens, 'classic albums', enhance_q
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Path{

--- a/testdata/result/query/select_call_with_named_expr.sql.txt
+++ b/testdata/result/query/select_call_with_named_expr.sql.txt
@@ -9,7 +9,6 @@ WHERE a.SingerId = 1 AND SEARCH(a.DescriptionTokens, 'classic albums', enhance_q
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_cast.sql.txt
+++ b/testdata/result/query/select_cast.sql.txt
@@ -12,7 +12,6 @@ limit cast(1 as INT64) offset cast(@foo as INT64)
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_cast.sql.txt
+++ b/testdata/result/query/select_cast.sql.txt
@@ -13,6 +13,7 @@ limit cast(1 as INT64) offset cast(@foo as INT64)
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.CastExpr{

--- a/testdata/result/query/select_complex_with_array_path.sql.txt
+++ b/testdata/result/query/select_complex_with_array_path.sql.txt
@@ -12,7 +12,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_complex_with_array_path.sql.txt
+++ b/testdata/result/query/select_complex_with_array_path.sql.txt
@@ -13,6 +13,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_complex_with_unnest_array_path.sql.txt
+++ b/testdata/result/query/select_complex_with_unnest_array_path.sql.txt
@@ -12,7 +12,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_complex_with_unnest_array_path.sql.txt
+++ b/testdata/result/query/select_complex_with_unnest_array_path.sql.txt
@@ -13,6 +13,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_count_asterisk.sql.txt
+++ b/testdata/result/query/select_count_asterisk.sql.txt
@@ -9,6 +9,7 @@ select count(*) from singers
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.CountStarExpr{

--- a/testdata/result/query/select_count_asterisk.sql.txt
+++ b/testdata/result/query/select_count_asterisk.sql.txt
@@ -8,7 +8,6 @@ select count(*) from singers
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_count_distinct.sql.txt
+++ b/testdata/result/query/select_count_distinct.sql.txt
@@ -7,7 +7,6 @@ select count(distinct x) from foo
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_count_distinct.sql.txt
+++ b/testdata/result/query/select_count_distinct.sql.txt
@@ -8,6 +8,7 @@ select count(distinct x) from foo
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.CallExpr{

--- a/testdata/result/query/select_expr.sql.txt
+++ b/testdata/result/query/select_expr.sql.txt
@@ -37,6 +37,7 @@ select 1 + 2, 1 - 2,
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.BinaryExpr{
@@ -331,6 +332,7 @@ select 1 + 2, 1 - 2,
               Select:   195,
               Distinct: false,
               AsStruct: false,
+              As:       nil,
               Results:  []ast.SelectItem{
                 &ast.Alias{
                   Expr: &ast.IntLiteral{
@@ -754,6 +756,7 @@ select 1 + 2, 1 - 2,
                   Select:   698,
                   Distinct: false,
                   AsStruct: false,
+                  As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{
                       Expr: &ast.IntLiteral{
@@ -775,6 +778,7 @@ select 1 + 2, 1 - 2,
                   Select:   717,
                   Distinct: false,
                   AsStruct: false,
+                  As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{
                       Expr: &ast.IntLiteral{
@@ -796,6 +800,7 @@ select 1 + 2, 1 - 2,
                   Select:   736,
                   Distinct: false,
                   AsStruct: false,
+                  As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{
                       Expr: &ast.IntLiteral{

--- a/testdata/result/query/select_expr.sql.txt
+++ b/testdata/result/query/select_expr.sql.txt
@@ -36,7 +36,6 @@ select 1 + 2, 1 - 2,
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -331,7 +330,6 @@ select 1 + 2, 1 - 2,
             Query:  &ast.Select{
               Select:   195,
               Distinct: false,
-              AsStruct: false,
               As:       nil,
               Results:  []ast.SelectItem{
                 &ast.Alias{
@@ -755,7 +753,6 @@ select 1 + 2, 1 - 2,
                 &ast.Select{
                   Select:   698,
                   Distinct: false,
-                  AsStruct: false,
                   As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{
@@ -777,7 +774,6 @@ select 1 + 2, 1 - 2,
                 &ast.Select{
                   Select:   717,
                   Distinct: false,
-                  AsStruct: false,
                   As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{
@@ -799,7 +795,6 @@ select 1 + 2, 1 - 2,
                 &ast.Select{
                   Select:   736,
                   Distinct: false,
-                  AsStruct: false,
                   As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{

--- a/testdata/result/query/select_expr_extract.sql.txt
+++ b/testdata/result/query/select_expr_extract.sql.txt
@@ -27,6 +27,7 @@ select
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ExtractExpr{

--- a/testdata/result/query/select_expr_extract.sql.txt
+++ b/testdata/result/query/select_expr_extract.sql.txt
@@ -26,7 +26,6 @@ select
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_hint.sql.txt
+++ b/testdata/result/query/select_hint.sql.txt
@@ -39,6 +39,7 @@
     Select:   24,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Ident{

--- a/testdata/result/query/select_hint.sql.txt
+++ b/testdata/result/query/select_hint.sql.txt
@@ -38,7 +38,6 @@
   Query: &ast.Select{
     Select:   24,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_literals_all.sql.txt
+++ b/testdata/result/query/select_literals_all.sql.txt
@@ -55,6 +55,7 @@ lines''',
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.StringLiteral{
@@ -390,6 +391,7 @@ lines''',
             Select:   460,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -437,6 +439,7 @@ lines''',
             Select:   493,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{

--- a/testdata/result/query/select_literals_all.sql.txt
+++ b/testdata/result/query/select_literals_all.sql.txt
@@ -54,7 +54,6 @@ lines''',
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -390,7 +389,6 @@ lines''',
           Query:  &ast.Select{
             Select:   460,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -438,7 +436,6 @@ lines''',
           Query:  &ast.Select{
             Select:   493,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{

--- a/testdata/result/query/select_literals_array.sql.txt
+++ b/testdata/result/query/select_literals_array.sql.txt
@@ -13,7 +13,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_literals_array.sql.txt
+++ b/testdata/result/query/select_literals_array.sql.txt
@@ -14,6 +14,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ArrayLiteral{

--- a/testdata/result/query/select_literals_array_invalid.sql.txt
+++ b/testdata/result/query/select_literals_array_invalid.sql.txt
@@ -10,6 +10,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ArrayLiteral{

--- a/testdata/result/query/select_literals_array_invalid.sql.txt
+++ b/testdata/result/query/select_literals_array_invalid.sql.txt
@@ -9,7 +9,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_literals_bytes.sql.txt
+++ b/testdata/result/query/select_literals_bytes.sql.txt
@@ -19,6 +19,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.BytesLiteral{

--- a/testdata/result/query/select_literals_bytes.sql.txt
+++ b/testdata/result/query/select_literals_bytes.sql.txt
@@ -18,7 +18,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_literals_date.sql.txt
+++ b/testdata/result/query/select_literals_date.sql.txt
@@ -18,7 +18,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_literals_date.sql.txt
+++ b/testdata/result/query/select_literals_date.sql.txt
@@ -19,6 +19,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.DateLiteral{

--- a/testdata/result/query/select_literals_float.sql.txt
+++ b/testdata/result/query/select_literals_float.sql.txt
@@ -12,7 +12,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_literals_float.sql.txt
+++ b/testdata/result/query/select_literals_float.sql.txt
@@ -13,6 +13,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.FloatLiteral{

--- a/testdata/result/query/select_literals_int.sql.txt
+++ b/testdata/result/query/select_literals_int.sql.txt
@@ -12,7 +12,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_literals_int.sql.txt
+++ b/testdata/result/query/select_literals_int.sql.txt
@@ -13,6 +13,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.IntLiteral{

--- a/testdata/result/query/select_literals_paren.sql.txt
+++ b/testdata/result/query/select_literals_paren.sql.txt
@@ -8,7 +8,6 @@ SELECT (1)
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_literals_paren.sql.txt
+++ b/testdata/result/query/select_literals_paren.sql.txt
@@ -9,6 +9,7 @@ SELECT (1)
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ParenExpr{

--- a/testdata/result/query/select_literals_paren_with_operator.sql.txt
+++ b/testdata/result/query/select_literals_paren_with_operator.sql.txt
@@ -9,6 +9,7 @@ SELECT (1+1)
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ParenExpr{

--- a/testdata/result/query/select_literals_paren_with_operator.sql.txt
+++ b/testdata/result/query/select_literals_paren_with_operator.sql.txt
@@ -8,7 +8,6 @@ SELECT (1+1)
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_literals_string.sql.txt
+++ b/testdata/result/query/select_literals_string.sql.txt
@@ -31,6 +31,7 @@ lines''',
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.StringLiteral{

--- a/testdata/result/query/select_literals_string.sql.txt
+++ b/testdata/result/query/select_literals_string.sql.txt
@@ -30,7 +30,6 @@ lines''',
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_literals_struct.sql.txt
+++ b/testdata/result/query/select_literals_struct.sql.txt
@@ -17,6 +17,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ArraySubQuery{
@@ -26,6 +27,7 @@ SELECT
             Select:   15,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -73,6 +75,7 @@ SELECT
             Select:   48,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -118,6 +121,7 @@ SELECT
             Select:   84,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -199,6 +203,7 @@ SELECT
             Select:   144,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -268,6 +273,7 @@ SELECT
             Select:   198,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -341,6 +347,7 @@ SELECT
             Select:   254,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -388,6 +395,7 @@ SELECT
             Select:   281,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -417,6 +425,7 @@ SELECT
             Select:   310,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{

--- a/testdata/result/query/select_literals_struct.sql.txt
+++ b/testdata/result/query/select_literals_struct.sql.txt
@@ -16,7 +16,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -26,7 +25,6 @@ SELECT
           Query:  &ast.Select{
             Select:   15,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -74,7 +72,6 @@ SELECT
           Query:  &ast.Select{
             Select:   48,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -120,7 +117,6 @@ SELECT
           Query:  &ast.Select{
             Select:   84,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -202,7 +198,6 @@ SELECT
           Query:  &ast.Select{
             Select:   144,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -272,7 +267,6 @@ SELECT
           Query:  &ast.Select{
             Select:   198,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -346,7 +340,6 @@ SELECT
           Query:  &ast.Select{
             Select:   254,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -394,7 +387,6 @@ SELECT
           Query:  &ast.Select{
             Select:   281,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -424,7 +416,6 @@ SELECT
           Query:  &ast.Select{
             Select:   310,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{

--- a/testdata/result/query/select_nest_complex.sql.txt
+++ b/testdata/result/query/select_nest_complex.sql.txt
@@ -13,7 +13,6 @@ from (
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
@@ -49,7 +48,6 @@ from (
                         &ast.Select{
                           Select:   23,
                           Distinct: false,
-                          AsStruct: false,
                           As:       nil,
                           Results:  []ast.SelectItem{
                             &ast.Alias{
@@ -82,7 +80,6 @@ from (
                           Query:  &ast.Select{
                             Select:   45,
                             Distinct: false,
-                            AsStruct: false,
                             As:       nil,
                             Results:  []ast.SelectItem{
                               &ast.ExprSelectItem{
@@ -117,7 +114,6 @@ from (
                     Query:  &ast.Select{
                       Select:   72,
                       Distinct: false,
-                      AsStruct: false,
                       As:       nil,
                       Results:  []ast.SelectItem{
                         &ast.ExprSelectItem{
@@ -164,7 +160,6 @@ from (
             Query:  &ast.Select{
               Select:   104,
               Distinct: false,
-              AsStruct: false,
               As:       nil,
               Results:  []ast.SelectItem{
                 &ast.Alias{

--- a/testdata/result/query/select_nest_complex.sql.txt
+++ b/testdata/result/query/select_nest_complex.sql.txt
@@ -14,6 +14,7 @@ from (
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 7,
@@ -49,6 +50,7 @@ from (
                           Select:   23,
                           Distinct: false,
                           AsStruct: false,
+                          As:       nil,
                           Results:  []ast.SelectItem{
                             &ast.Alias{
                               Expr: &ast.IntLiteral{
@@ -81,6 +83,7 @@ from (
                             Select:   45,
                             Distinct: false,
                             AsStruct: false,
+                            As:       nil,
                             Results:  []ast.SelectItem{
                               &ast.ExprSelectItem{
                                 Expr: &ast.IntLiteral{
@@ -115,6 +118,7 @@ from (
                       Select:   72,
                       Distinct: false,
                       AsStruct: false,
+                      As:       nil,
                       Results:  []ast.SelectItem{
                         &ast.ExprSelectItem{
                           Expr: &ast.IntLiteral{
@@ -161,6 +165,7 @@ from (
               Select:   104,
               Distinct: false,
               AsStruct: false,
+              As:       nil,
               Results:  []ast.SelectItem{
                 &ast.Alias{
                   Expr: &ast.IntLiteral{

--- a/testdata/result/query/select_select_limit_expr.sql.txt
+++ b/testdata/result/query/select_select_limit_expr.sql.txt
@@ -9,6 +9,7 @@ select ((select 1) limit 1 offset 0) + 3
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.BinaryExpr{
@@ -23,6 +24,7 @@ select ((select 1) limit 1 offset 0) + 3
                 Select:   9,
                 Distinct: false,
                 AsStruct: false,
+                As:       nil,
                 Results:  []ast.SelectItem{
                   &ast.ExprSelectItem{
                     Expr: &ast.IntLiteral{

--- a/testdata/result/query/select_select_limit_expr.sql.txt
+++ b/testdata/result/query/select_select_limit_expr.sql.txt
@@ -8,7 +8,6 @@ select ((select 1) limit 1 offset 0) + 3
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -23,7 +22,6 @@ select ((select 1) limit 1 offset 0) + 3
               Query:  &ast.Select{
                 Select:   9,
                 Distinct: false,
-                AsStruct: false,
                 As:       nil,
                 Results:  []ast.SelectItem{
                   &ast.ExprSelectItem{

--- a/testdata/result/query/select_select_set_operator_expr.sql.txt
+++ b/testdata/result/query/select_select_set_operator_expr.sql.txt
@@ -10,7 +10,6 @@ select ((select 1) union all (select 2)) + 3,
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -29,7 +28,6 @@ select ((select 1) union all (select 2)) + 3,
                   Query:  &ast.Select{
                     Select:   9,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
@@ -57,7 +55,6 @@ select ((select 1) union all (select 2)) + 3,
                   Query:  &ast.Select{
                     Select:   30,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
@@ -108,7 +105,6 @@ select ((select 1) union all (select 2)) + 3,
                   Query:  &ast.Select{
                     Select:   55,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
@@ -136,7 +132,6 @@ select ((select 1) union all (select 2)) + 3,
                   Query:  &ast.Select{
                     Select:   80,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
@@ -187,7 +182,6 @@ select ((select 1) union all (select 2)) + 3,
                   Query:  &ast.Select{
                     Select:   105,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
@@ -215,7 +209,6 @@ select ((select 1) union all (select 2)) + 3,
                   Query:  &ast.Select{
                     Select:   127,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{

--- a/testdata/result/query/select_select_set_operator_expr.sql.txt
+++ b/testdata/result/query/select_select_set_operator_expr.sql.txt
@@ -11,6 +11,7 @@ select ((select 1) union all (select 2)) + 3,
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.BinaryExpr{
@@ -29,6 +30,7 @@ select ((select 1) union all (select 2)) + 3,
                     Select:   9,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
                         Expr: &ast.IntLiteral{
@@ -56,6 +58,7 @@ select ((select 1) union all (select 2)) + 3,
                     Select:   30,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
                         Expr: &ast.IntLiteral{
@@ -106,6 +109,7 @@ select ((select 1) union all (select 2)) + 3,
                     Select:   55,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
                         Expr: &ast.IntLiteral{
@@ -133,6 +137,7 @@ select ((select 1) union all (select 2)) + 3,
                     Select:   80,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
                         Expr: &ast.IntLiteral{
@@ -183,6 +188,7 @@ select ((select 1) union all (select 2)) + 3,
                     Select:   105,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
                         Expr: &ast.IntLiteral{
@@ -210,6 +216,7 @@ select ((select 1) union all (select 2)) + 3,
                     Select:   127,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
                         Expr: &ast.IntLiteral{

--- a/testdata/result/query/select_singer_with_as_struct_subquery.sql.txt
+++ b/testdata/result/query/select_singer_with_as_struct_subquery.sql.txt
@@ -15,7 +15,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -28,7 +27,6 @@ SELECT
             Query:  &ast.Select{
               Select:   28,
               Distinct: false,
-              AsStruct: true,
               As:       &ast.AsStruct{
                 As:     35,
                 Struct: 38,

--- a/testdata/result/query/select_singer_with_as_struct_subquery.sql.txt
+++ b/testdata/result/query/select_singer_with_as_struct_subquery.sql.txt
@@ -16,6 +16,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ArraySubQuery{
@@ -28,7 +29,11 @@ SELECT
               Select:   28,
               Distinct: false,
               AsStruct: true,
-              Results:  []ast.SelectItem{
+              As:       &ast.AsStruct{
+                As:     35,
+                Struct: 38,
+              },
+              Results: []ast.SelectItem{
                 &ast.Star{
                   Star: 53,
                 },

--- a/testdata/result/query/select_singer_with_asterisk.sql.txt
+++ b/testdata/result/query/select_singer_with_asterisk.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_asterisk.sql.txt
+++ b/testdata/result/query/select_singer_with_asterisk.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_column_and_asterisk.sql.txt
+++ b/testdata/result/query/select_singer_with_column_and_asterisk.sql.txt
@@ -13,6 +13,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Ident{

--- a/testdata/result/query/select_singer_with_column_and_asterisk.sql.txt
+++ b/testdata/result/query/select_singer_with_column_and_asterisk.sql.txt
@@ -12,7 +12,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_singer_with_column_names.sql.txt
+++ b/testdata/result/query/select_singer_with_column_names.sql.txt
@@ -15,6 +15,7 @@ FROM Singers
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.Ident{

--- a/testdata/result/query/select_singer_with_column_names.sql.txt
+++ b/testdata/result/query/select_singer_with_column_names.sql.txt
@@ -14,7 +14,6 @@ FROM Singers
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{

--- a/testdata/result/query/select_singer_with_cross_join.sql.txt
+++ b/testdata/result/query/select_singer_with_cross_join.sql.txt
@@ -14,6 +14,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_cross_join.sql.txt
+++ b/testdata/result/query/select_singer_with_cross_join.sql.txt
@@ -13,7 +13,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_distinct.sql.txt
+++ b/testdata/result/query/select_singer_with_distinct.sql.txt
@@ -13,6 +13,7 @@ FROM
     Select:   0,
     Distinct: true,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 20,

--- a/testdata/result/query/select_singer_with_distinct.sql.txt
+++ b/testdata/result/query/select_singer_with_distinct.sql.txt
@@ -12,7 +12,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: true,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_full_join.sql.txt
+++ b/testdata/result/query/select_singer_with_full_join.sql.txt
@@ -12,7 +12,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_full_join.sql.txt
+++ b/testdata/result/query/select_singer_with_full_join.sql.txt
@@ -13,6 +13,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_groupby.sql.txt
+++ b/testdata/result/query/select_singer_with_groupby.sql.txt
@@ -14,6 +14,7 @@ GROUP BY
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Ident{

--- a/testdata/result/query/select_singer_with_groupby.sql.txt
+++ b/testdata/result/query/select_singer_with_groupby.sql.txt
@@ -13,7 +13,6 @@ GROUP BY
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_singer_with_hash_join.sql.txt
+++ b/testdata/result/query/select_singer_with_hash_join.sql.txt
@@ -20,7 +20,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_hash_join.sql.txt
+++ b/testdata/result/query/select_singer_with_hash_join.sql.txt
@@ -21,6 +21,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_having.sql.txt
+++ b/testdata/result/query/select_singer_with_having.sql.txt
@@ -16,6 +16,7 @@ HAVING
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Ident{

--- a/testdata/result/query/select_singer_with_having.sql.txt
+++ b/testdata/result/query/select_singer_with_having.sql.txt
@@ -15,7 +15,6 @@ HAVING
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_singer_with_in_and_unnest.sql.txt
+++ b/testdata/result/query/select_singer_with_in_and_unnest.sql.txt
@@ -14,6 +14,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_in_and_unnest.sql.txt
+++ b/testdata/result/query/select_singer_with_in_and_unnest.sql.txt
@@ -13,7 +13,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_in_and_unnest_with_query_parameter.sql.txt
+++ b/testdata/result/query/select_singer_with_in_and_unnest_with_query_parameter.sql.txt
@@ -14,6 +14,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_in_and_unnest_with_query_parameter.sql.txt
+++ b/testdata/result/query/select_singer_with_in_and_unnest_with_query_parameter.sql.txt
@@ -13,7 +13,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_join.sql.txt
+++ b/testdata/result/query/select_singer_with_join.sql.txt
@@ -14,7 +14,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_join.sql.txt
+++ b/testdata/result/query/select_singer_with_join.sql.txt
@@ -15,6 +15,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_join_hint.sql.txt
+++ b/testdata/result/query/select_singer_with_join_hint.sql.txt
@@ -23,7 +23,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_join_hint.sql.txt
+++ b/testdata/result/query/select_singer_with_join_hint.sql.txt
@@ -24,6 +24,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_join_twice.sql.txt
+++ b/testdata/result/query/select_singer_with_join_twice.sql.txt
@@ -18,6 +18,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_join_twice.sql.txt
+++ b/testdata/result/query/select_singer_with_join_twice.sql.txt
@@ -17,7 +17,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_join_using.sql.txt
+++ b/testdata/result/query/select_singer_with_join_using.sql.txt
@@ -14,7 +14,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_join_using.sql.txt
+++ b/testdata/result/query/select_singer_with_join_using.sql.txt
@@ -15,6 +15,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_join_various.sql.txt
+++ b/testdata/result/query/select_singer_with_join_various.sql.txt
@@ -37,7 +37,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_join_various.sql.txt
+++ b/testdata/result/query/select_singer_with_join_various.sql.txt
@@ -38,6 +38,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_limit.sql.txt
+++ b/testdata/result/query/select_singer_with_limit.sql.txt
@@ -13,6 +13,7 @@ LIMIT 100
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_limit.sql.txt
+++ b/testdata/result/query/select_singer_with_limit.sql.txt
@@ -12,7 +12,6 @@ LIMIT 100
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_limit_and_skiprows.sql.txt
+++ b/testdata/result/query/select_singer_with_limit_and_skiprows.sql.txt
@@ -13,7 +13,6 @@ OFFSET 10
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_limit_and_skiprows.sql.txt
+++ b/testdata/result/query/select_singer_with_limit_and_skiprows.sql.txt
@@ -14,6 +14,7 @@ OFFSET 10
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_orderby.sql.txt
+++ b/testdata/result/query/select_singer_with_orderby.sql.txt
@@ -14,7 +14,6 @@ ORDER BY
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_orderby.sql.txt
+++ b/testdata/result/query/select_singer_with_orderby.sql.txt
@@ -15,6 +15,7 @@ ORDER BY
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_query_parameter.sql.txt
+++ b/testdata/result/query/select_singer_with_query_parameter.sql.txt
@@ -14,7 +14,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_query_parameter.sql.txt
+++ b/testdata/result/query/select_singer_with_query_parameter.sql.txt
@@ -15,6 +15,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_root_parent.sql.txt
+++ b/testdata/result/query/select_singer_with_root_parent.sql.txt
@@ -12,6 +12,7 @@
       Select:   2,
       Distinct: false,
       AsStruct: false,
+      As:       nil,
       Results:  []ast.SelectItem{
         &ast.Star{
           Star: 9,

--- a/testdata/result/query/select_singer_with_root_parent.sql.txt
+++ b/testdata/result/query/select_singer_with_root_parent.sql.txt
@@ -11,7 +11,6 @@
     Query:  &ast.Select{
       Select:   2,
       Distinct: false,
-      AsStruct: false,
       As:       nil,
       Results:  []ast.SelectItem{
         &ast.Star{

--- a/testdata/result/query/select_singer_with_select_in_from.sql.txt
+++ b/testdata/result/query/select_singer_with_select_in_from.sql.txt
@@ -18,6 +18,7 @@ FROM (
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,
@@ -32,6 +33,7 @@ FROM (
           Select:   20,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.Star{
               Star: 31,

--- a/testdata/result/query/select_singer_with_select_in_from.sql.txt
+++ b/testdata/result/query/select_singer_with_select_in_from.sql.txt
@@ -17,7 +17,6 @@ FROM (
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
@@ -32,7 +31,6 @@ FROM (
         Query:  &ast.Select{
           Select:   20,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.Star{

--- a/testdata/result/query/select_singer_with_select_in_from_and_as.sql.txt
+++ b/testdata/result/query/select_singer_with_select_in_from_and_as.sql.txt
@@ -18,6 +18,7 @@ FROM (
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,
@@ -32,6 +33,7 @@ FROM (
           Select:   20,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.Star{
               Star: 31,

--- a/testdata/result/query/select_singer_with_select_in_from_and_as.sql.txt
+++ b/testdata/result/query/select_singer_with_select_in_from_and_as.sql.txt
@@ -17,7 +17,6 @@ FROM (
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
@@ -32,7 +31,6 @@ FROM (
         Query:  &ast.Select{
           Select:   20,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.Star{

--- a/testdata/result/query/select_singer_with_single_column_subquery.sql.txt
+++ b/testdata/result/query/select_singer_with_single_column_subquery.sql.txt
@@ -12,6 +12,7 @@ SELECT (
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ScalarSubQuery{
@@ -21,6 +22,7 @@ SELECT (
             Select:   11,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.Ident{

--- a/testdata/result/query/select_singer_with_single_column_subquery.sql.txt
+++ b/testdata/result/query/select_singer_with_single_column_subquery.sql.txt
@@ -11,7 +11,6 @@ SELECT (
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -21,7 +20,6 @@ SELECT (
           Query:  &ast.Select{
             Select:   11,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{

--- a/testdata/result/query/select_singer_with_single_column_subquery_with_at.sql.txt
+++ b/testdata/result/query/select_singer_with_single_column_subquery_with_at.sql.txt
@@ -11,7 +11,6 @@ SELECT (
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
@@ -21,7 +20,6 @@ SELECT (
           Query:  &ast.Select{
             Select:   11,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{

--- a/testdata/result/query/select_singer_with_single_column_subquery_with_at.sql.txt
+++ b/testdata/result/query/select_singer_with_single_column_subquery_with_at.sql.txt
@@ -12,6 +12,7 @@ SELECT (
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.ScalarSubQuery{
@@ -21,6 +22,7 @@ SELECT (
             Select:   11,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.Ident{

--- a/testdata/result/query/select_singer_with_table_alias.sql.txt
+++ b/testdata/result/query/select_singer_with_table_alias.sql.txt
@@ -13,6 +13,7 @@ FROM Singers S
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.DotStar{
         Star: 11,

--- a/testdata/result/query/select_singer_with_table_alias.sql.txt
+++ b/testdata/result/query/select_singer_with_table_alias.sql.txt
@@ -12,7 +12,6 @@ FROM Singers S
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.DotStar{

--- a/testdata/result/query/select_singer_with_table_alias_with_hint.sql.txt
+++ b/testdata/result/query/select_singer_with_table_alias_with_hint.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_table_alias_with_hint.sql.txt
+++ b/testdata/result/query/select_singer_with_table_alias_with_hint.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_table_hint.sql.txt
+++ b/testdata/result/query/select_singer_with_table_hint.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_table_hint.sql.txt
+++ b/testdata/result/query/select_singer_with_table_hint.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_tablesample.sql.txt
+++ b/testdata/result/query/select_singer_with_tablesample.sql.txt
@@ -14,6 +14,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_tablesample.sql.txt
+++ b/testdata/result/query/select_singer_with_tablesample.sql.txt
@@ -13,7 +13,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_tableset.sql.txt
+++ b/testdata/result/query/select_singer_with_tableset.sql.txt
@@ -15,6 +15,7 @@ SELECT * FROM Singers
         Select:   0,
         Distinct: false,
         AsStruct: false,
+        As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
             Star: 7,
@@ -43,6 +44,7 @@ SELECT * FROM Singers
         Select:   32,
         Distinct: false,
         AsStruct: false,
+        As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
             Star: 39,

--- a/testdata/result/query/select_singer_with_tableset.sql.txt
+++ b/testdata/result/query/select_singer_with_tableset.sql.txt
@@ -14,7 +14,6 @@ SELECT * FROM Singers
       &ast.Select{
         Select:   0,
         Distinct: false,
-        AsStruct: false,
         As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
@@ -43,7 +42,6 @@ SELECT * FROM Singers
       &ast.Select{
         Select:   32,
         Distinct: false,
-        AsStruct: false,
         As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{

--- a/testdata/result/query/select_singer_with_tableset_complex.sql.txt
+++ b/testdata/result/query/select_singer_with_tableset_complex.sql.txt
@@ -34,7 +34,6 @@ UNION ALL
       &ast.Select{
         Select:   0,
         Distinct: false,
-        AsStruct: false,
         As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
@@ -70,7 +69,6 @@ UNION ALL
             &ast.Select{
               Select:   36,
               Distinct: false,
-              AsStruct: false,
               As:       nil,
               Results:  []ast.SelectItem{
                 &ast.Star{
@@ -106,7 +104,6 @@ UNION ALL
                   &ast.Select{
                     Select:   83,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.Star{
@@ -142,7 +139,6 @@ UNION ALL
                         &ast.Select{
                           Select:   135,
                           Distinct: false,
-                          AsStruct: false,
                           As:       nil,
                           Results:  []ast.SelectItem{
                             &ast.Star{
@@ -178,7 +174,6 @@ UNION ALL
                               &ast.Select{
                                 Select:   198,
                                 Distinct: false,
-                                AsStruct: false,
                                 As:       nil,
                                 Results:  []ast.SelectItem{
                                   &ast.Star{
@@ -214,7 +209,6 @@ UNION ALL
                                     &ast.Select{
                                       Select:   259,
                                       Distinct: false,
-                                      AsStruct: false,
                                       As:       nil,
                                       Results:  []ast.SelectItem{
                                         &ast.Star{
@@ -243,7 +237,6 @@ UNION ALL
                                     &ast.Select{
                                       Select:   317,
                                       Distinct: false,
-                                      AsStruct: false,
                                       As:       nil,
                                       Results:  []ast.SelectItem{
                                         &ast.Star{

--- a/testdata/result/query/select_singer_with_tableset_complex.sql.txt
+++ b/testdata/result/query/select_singer_with_tableset_complex.sql.txt
@@ -35,6 +35,7 @@ UNION ALL
         Select:   0,
         Distinct: false,
         AsStruct: false,
+        As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
             Star: 7,
@@ -70,6 +71,7 @@ UNION ALL
               Select:   36,
               Distinct: false,
               AsStruct: false,
+              As:       nil,
               Results:  []ast.SelectItem{
                 &ast.Star{
                   Star: 43,
@@ -105,6 +107,7 @@ UNION ALL
                     Select:   83,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.Star{
                         Star: 90,
@@ -140,6 +143,7 @@ UNION ALL
                           Select:   135,
                           Distinct: false,
                           AsStruct: false,
+                          As:       nil,
                           Results:  []ast.SelectItem{
                             &ast.Star{
                               Star: 142,
@@ -175,6 +179,7 @@ UNION ALL
                                 Select:   198,
                                 Distinct: false,
                                 AsStruct: false,
+                                As:       nil,
                                 Results:  []ast.SelectItem{
                                   &ast.Star{
                                     Star: 205,
@@ -210,6 +215,7 @@ UNION ALL
                                       Select:   259,
                                       Distinct: false,
                                       AsStruct: false,
+                                      As:       nil,
                                       Results:  []ast.SelectItem{
                                         &ast.Star{
                                           Star: 266,
@@ -238,6 +244,7 @@ UNION ALL
                                       Select:   317,
                                       Distinct: false,
                                       AsStruct: false,
+                                      As:       nil,
                                       Results:  []ast.SelectItem{
                                         &ast.Star{
                                           Star: 324,

--- a/testdata/result/query/select_singer_with_tableset_with_where.sql.txt
+++ b/testdata/result/query/select_singer_with_tableset_with_where.sql.txt
@@ -19,6 +19,7 @@ ORDER BY
         Select:   0,
         Distinct: false,
         AsStruct: false,
+        As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
             Star: 7,
@@ -47,6 +48,7 @@ ORDER BY
         Select:   32,
         Distinct: false,
         AsStruct: false,
+        As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
             Star: 39,

--- a/testdata/result/query/select_singer_with_tableset_with_where.sql.txt
+++ b/testdata/result/query/select_singer_with_tableset_with_where.sql.txt
@@ -18,7 +18,6 @@ ORDER BY
       &ast.Select{
         Select:   0,
         Distinct: false,
-        AsStruct: false,
         As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
@@ -47,7 +46,6 @@ ORDER BY
       &ast.Select{
         Select:   32,
         Distinct: false,
-        AsStruct: false,
         As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{

--- a/testdata/result/query/select_singer_with_toplevel_join_hint.sql.txt
+++ b/testdata/result/query/select_singer_with_toplevel_join_hint.sql.txt
@@ -31,7 +31,6 @@ FROM
   Query: &ast.Select{
     Select:   25,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_toplevel_join_hint.sql.txt
+++ b/testdata/result/query/select_singer_with_toplevel_join_hint.sql.txt
@@ -32,6 +32,7 @@ FROM
     Select:   25,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 34,

--- a/testdata/result/query/select_singer_with_value_hex.sql.txt
+++ b/testdata/result/query/select_singer_with_value_hex.sql.txt
@@ -14,6 +14,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_value_hex.sql.txt
+++ b/testdata/result/query/select_singer_with_value_hex.sql.txt
@@ -13,7 +13,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_where.sql.txt
+++ b/testdata/result/query/select_singer_with_where.sql.txt
@@ -14,6 +14,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_where.sql.txt
+++ b/testdata/result/query/select_singer_with_where.sql.txt
@@ -13,7 +13,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_where_and_comparison.sql.txt
+++ b/testdata/result/query/select_singer_with_where_and_comparison.sql.txt
@@ -30,7 +30,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_singer_with_where_and_comparison.sql.txt
+++ b/testdata/result/query/select_singer_with_where_and_comparison.sql.txt
@@ -31,6 +31,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_where_and_op.sql.txt
+++ b/testdata/result/query/select_singer_with_where_and_op.sql.txt
@@ -14,6 +14,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_singer_with_where_and_op.sql.txt
+++ b/testdata/result/query/select_singer_with_where_and_op.sql.txt
@@ -13,7 +13,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_struct_compare_eq.sql.txt
+++ b/testdata/result/query/select_struct_compare_eq.sql.txt
@@ -14,7 +14,6 @@ SELECT ARRAY(
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -24,7 +23,6 @@ SELECT ARRAY(
           Query:  &ast.Select{
             Select:   16,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.Star{
@@ -39,7 +37,6 @@ SELECT ARRAY(
                 Query:  &ast.Select{
                   Select:   41,
                   Distinct: false,
-                  AsStruct: false,
                   As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{

--- a/testdata/result/query/select_struct_compare_eq.sql.txt
+++ b/testdata/result/query/select_struct_compare_eq.sql.txt
@@ -15,6 +15,7 @@ SELECT ARRAY(
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ArraySubQuery{
@@ -24,6 +25,7 @@ SELECT ARRAY(
             Select:   16,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.Star{
                 Star: 27,
@@ -38,6 +40,7 @@ SELECT ARRAY(
                   Select:   41,
                   Distinct: false,
                   AsStruct: false,
+                  As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{
                       Expr: &ast.StructLiteral{

--- a/testdata/result/query/select_tablesample_with_cross_join.sql.txt
+++ b/testdata/result/query/select_tablesample_with_cross_join.sql.txt
@@ -14,7 +14,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_tablesample_with_cross_join.sql.txt
+++ b/testdata/result/query/select_tablesample_with_cross_join.sql.txt
@@ -15,6 +15,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_tablesample_with_subquery.sql.txt
+++ b/testdata/result/query/select_tablesample_with_subquery.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
@@ -26,7 +25,6 @@ FROM
         Query:  &ast.Select{
           Select:   19,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.Star{

--- a/testdata/result/query/select_tablesample_with_subquery.sql.txt
+++ b/testdata/result/query/select_tablesample_with_subquery.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,
@@ -26,6 +27,7 @@ FROM
           Select:   19,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.Star{
               Star: 26,

--- a/testdata/result/query/select_tablesample_with_table.sql.txt
+++ b/testdata/result/query/select_tablesample_with_table.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_tablesample_with_table.sql.txt
+++ b/testdata/result/query/select_tablesample_with_table.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_tablesample_with_table_alias.sql.txt
+++ b/testdata/result/query/select_tablesample_with_table_alias.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_tablesample_with_table_alias.sql.txt
+++ b/testdata/result/query/select_tablesample_with_table_alias.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_tablesample_with_unnest_invalid.sql.txt
+++ b/testdata/result/query/select_tablesample_with_unnest_invalid.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_tablesample_with_unnest_invalid.sql.txt
+++ b/testdata/result/query/select_tablesample_with_unnest_invalid.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_union_chain.sql.txt
+++ b/testdata/result/query/select_union_chain.sql.txt
@@ -15,7 +15,6 @@
         Query:  &ast.Select{
           Select:   1,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
@@ -43,7 +42,6 @@
         Query:  &ast.Select{
           Select:   22,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
@@ -71,7 +69,6 @@
         Query:  &ast.Select{
           Select:   43,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{

--- a/testdata/result/query/select_union_chain.sql.txt
+++ b/testdata/result/query/select_union_chain.sql.txt
@@ -16,6 +16,7 @@
           Select:   1,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
               Expr: &ast.IntLiteral{
@@ -43,6 +44,7 @@
           Select:   22,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
               Expr: &ast.IntLiteral{
@@ -70,6 +72,7 @@
           Select:   43,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
               Expr: &ast.IntLiteral{

--- a/testdata/result/query/select_unnest_with_offset.sql.txt
+++ b/testdata/result/query/select_unnest_with_offset.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_unnest_with_offset.sql.txt
+++ b/testdata/result/query/select_unnest_with_offset.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_unnest_with_offset_and_alias.sql.txt
+++ b/testdata/result/query/select_unnest_with_offset_and_alias.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_unnest_with_offset_and_alias.sql.txt
+++ b/testdata/result/query/select_unnest_with_offset_and_alias.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_unnest_with_offset_and_alias_min.sql.txt
+++ b/testdata/result/query/select_unnest_with_offset_and_alias_min.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_unnest_with_offset_and_alias_min.sql.txt
+++ b/testdata/result/query/select_unnest_with_offset_and_alias_min.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_with_after_hint.sql.txt
+++ b/testdata/result/query/select_with_after_hint.sql.txt
@@ -36,6 +36,7 @@
           Select:   28,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
               Expr: &ast.Ident{
@@ -71,6 +72,7 @@
     Select:   48,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 55,

--- a/testdata/result/query/select_with_after_hint.sql.txt
+++ b/testdata/result/query/select_with_after_hint.sql.txt
@@ -35,7 +35,6 @@
         QueryExpr: &ast.Select{
           Select:   28,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
@@ -71,7 +70,6 @@
   Query: &ast.Select{
     Select:   48,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_with_comment.sql.txt
+++ b/testdata/result/query/select_with_comment.sql.txt
@@ -9,7 +9,6 @@ select 1
   Query: &ast.Select{
     Select:   10,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/query/select_with_comment.sql.txt
+++ b/testdata/result/query/select_with_comment.sql.txt
@@ -10,6 +10,7 @@ select 1
     Select:   10,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.IntLiteral{

--- a/testdata/result/query/select_with_field_path.sql.txt
+++ b/testdata/result/query/select_with_field_path.sql.txt
@@ -24,7 +24,6 @@ WHERE A.z.a = 2
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -114,7 +113,6 @@ WHERE A.z.a = 2
           Query:  &ast.Select{
             Select:   70,
             Distinct: false,
-            AsStruct: true,
             As:       &ast.AsStruct{
               As:     77,
               Struct: 80,

--- a/testdata/result/query/select_with_field_path.sql.txt
+++ b/testdata/result/query/select_with_field_path.sql.txt
@@ -25,6 +25,7 @@ WHERE A.z.a = 2
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Path{
@@ -114,7 +115,11 @@ WHERE A.z.a = 2
             Select:   70,
             Distinct: false,
             AsStruct: true,
-            Results:  []ast.SelectItem{
+            As:       &ast.AsStruct{
+              As:     77,
+              Struct: 80,
+            },
+            Results: []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.Ident{
                   NamePos: 95,

--- a/testdata/result/query/select_with_multiple_ctes.sql.txt
+++ b/testdata/result/query/select_with_multiple_ctes.sql.txt
@@ -18,6 +18,7 @@ with subq1 as (select c1 from foo), subq2 as (select c2 from foo) select * from 
           Select:   15,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
               Expr: &ast.Ident{
@@ -58,6 +59,7 @@ with subq1 as (select c1 from foo), subq2 as (select c2 from foo) select * from 
           Select:   46,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
               Expr: &ast.Ident{
@@ -93,6 +95,7 @@ with subq1 as (select c1 from foo), subq2 as (select c2 from foo) select * from 
     Select:   66,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 73,

--- a/testdata/result/query/select_with_multiple_ctes.sql.txt
+++ b/testdata/result/query/select_with_multiple_ctes.sql.txt
@@ -17,7 +17,6 @@ with subq1 as (select c1 from foo), subq2 as (select c2 from foo) select * from 
         QueryExpr: &ast.Select{
           Select:   15,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
@@ -58,7 +57,6 @@ with subq1 as (select c1 from foo), subq2 as (select c2 from foo) select * from 
         QueryExpr: &ast.Select{
           Select:   46,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
@@ -94,7 +92,6 @@ with subq1 as (select c1 from foo), subq2 as (select c2 from foo) select * from 
   Query: &ast.Select{
     Select:   66,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_with_reservedword.sql.txt
+++ b/testdata/result/query/select_with_reservedword.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/query/select_with_reservedword.sql.txt
+++ b/testdata/result/query/select_with_reservedword.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/query/select_with_sequence_function.sql.txt
+++ b/testdata/result/query/select_with_sequence_function.sql.txt
@@ -9,6 +9,7 @@ SELECT GET_NEXT_SEQUENCE_VALUE(SEQUENCE my_sequence) as next_id
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.CallExpr{

--- a/testdata/result/query/select_with_sequence_function.sql.txt
+++ b/testdata/result/query/select_with_sequence_function.sql.txt
@@ -8,7 +8,6 @@ SELECT GET_NEXT_SEQUENCE_VALUE(SEQUENCE my_sequence) as next_id
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{

--- a/testdata/result/query/select_with_trailing_comma.sql.txt
+++ b/testdata/result/query/select_with_trailing_comma.sql.txt
@@ -8,6 +8,7 @@ SELECT 1, 2,
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.IntLiteral{

--- a/testdata/result/query/select_with_trailing_comma.sql.txt
+++ b/testdata/result/query/select_with_trailing_comma.sql.txt
@@ -7,7 +7,6 @@ SELECT 1, 2,
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/create_or_replace_view.sql.txt
+++ b/testdata/result/statement/create_or_replace_view.sql.txt
@@ -19,7 +19,6 @@ from singers
   Query:        &ast.Select{
     Select:   59,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{

--- a/testdata/result/statement/create_or_replace_view.sql.txt
+++ b/testdata/result/statement/create_or_replace_view.sql.txt
@@ -20,6 +20,7 @@ from singers
     Select:   59,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.Path{

--- a/testdata/result/statement/create_view.sql.txt
+++ b/testdata/result/statement/create_view.sql.txt
@@ -19,7 +19,6 @@ from singers
   Query:        &ast.Select{
     Select:   48,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{

--- a/testdata/result/statement/create_view.sql.txt
+++ b/testdata/result/statement/create_view.sql.txt
@@ -20,6 +20,7 @@ from singers
     Select:   48,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.Path{

--- a/testdata/result/statement/create_view_sql_security_definer.sql.txt
+++ b/testdata/result/statement/create_view_sql_security_definer.sql.txt
@@ -19,7 +19,6 @@ from singers
   Query:        &ast.Select{
     Select:   48,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{

--- a/testdata/result/statement/create_view_sql_security_definer.sql.txt
+++ b/testdata/result/statement/create_view_sql_security_definer.sql.txt
@@ -20,6 +20,7 @@ from singers
     Select:   48,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.Path{

--- a/testdata/result/statement/insert_select.sql.txt
+++ b/testdata/result/statement/insert_select.sql.txt
@@ -26,7 +26,6 @@ select * from unnest([(1, 2), (3, 4)])
     Query: &ast.Select{
       Select:   22,
       Distinct: false,
-      AsStruct: false,
       As:       nil,
       Results:  []ast.SelectItem{
         &ast.Star{

--- a/testdata/result/statement/insert_select.sql.txt
+++ b/testdata/result/statement/insert_select.sql.txt
@@ -27,6 +27,7 @@ select * from unnest([(1, 2), (3, 4)])
       Select:   22,
       Distinct: false,
       AsStruct: false,
+      As:       nil,
       Results:  []ast.SelectItem{
         &ast.Star{
           Star: 29,

--- a/testdata/result/statement/select_album_with_index_directive.sql.txt
+++ b/testdata/result/statement/select_album_with_index_directive.sql.txt
@@ -11,6 +11,7 @@ WHERE AlbumTitle >= @startTitle AND AlbumTitle < @endTitle
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Ident{

--- a/testdata/result/statement/select_album_with_index_directive.sql.txt
+++ b/testdata/result/statement/select_album_with_index_directive.sql.txt
@@ -10,7 +10,6 @@ WHERE AlbumTitle >= @startTitle AND AlbumTitle < @endTitle
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_alias_without_as.sql.txt
+++ b/testdata/result/statement/select_alias_without_as.sql.txt
@@ -9,6 +9,7 @@ select 1 A
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.IntLiteral{

--- a/testdata/result/statement/select_alias_without_as.sql.txt
+++ b/testdata/result/statement/select_alias_without_as.sql.txt
@@ -8,7 +8,6 @@ select 1 A
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{

--- a/testdata/result/statement/select_array_with_struct.sql.txt
+++ b/testdata/result/statement/select_array_with_struct.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_array_with_struct.sql.txt
+++ b/testdata/result/statement/select_array_with_struct.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_call_with_named_expr.sql.txt
+++ b/testdata/result/statement/select_call_with_named_expr.sql.txt
@@ -10,6 +10,7 @@ WHERE a.SingerId = 1 AND SEARCH(a.DescriptionTokens, 'classic albums', enhance_q
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Path{

--- a/testdata/result/statement/select_call_with_named_expr.sql.txt
+++ b/testdata/result/statement/select_call_with_named_expr.sql.txt
@@ -9,7 +9,6 @@ WHERE a.SingerId = 1 AND SEARCH(a.DescriptionTokens, 'classic albums', enhance_q
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_cast.sql.txt
+++ b/testdata/result/statement/select_cast.sql.txt
@@ -12,7 +12,6 @@ limit cast(1 as INT64) offset cast(@foo as INT64)
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_cast.sql.txt
+++ b/testdata/result/statement/select_cast.sql.txt
@@ -13,6 +13,7 @@ limit cast(1 as INT64) offset cast(@foo as INT64)
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.CastExpr{

--- a/testdata/result/statement/select_complex_with_array_path.sql.txt
+++ b/testdata/result/statement/select_complex_with_array_path.sql.txt
@@ -12,7 +12,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_complex_with_array_path.sql.txt
+++ b/testdata/result/statement/select_complex_with_array_path.sql.txt
@@ -13,6 +13,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_complex_with_unnest_array_path.sql.txt
+++ b/testdata/result/statement/select_complex_with_unnest_array_path.sql.txt
@@ -12,7 +12,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_complex_with_unnest_array_path.sql.txt
+++ b/testdata/result/statement/select_complex_with_unnest_array_path.sql.txt
@@ -13,6 +13,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_count_asterisk.sql.txt
+++ b/testdata/result/statement/select_count_asterisk.sql.txt
@@ -9,6 +9,7 @@ select count(*) from singers
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.CountStarExpr{

--- a/testdata/result/statement/select_count_asterisk.sql.txt
+++ b/testdata/result/statement/select_count_asterisk.sql.txt
@@ -8,7 +8,6 @@ select count(*) from singers
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_count_distinct.sql.txt
+++ b/testdata/result/statement/select_count_distinct.sql.txt
@@ -7,7 +7,6 @@ select count(distinct x) from foo
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_count_distinct.sql.txt
+++ b/testdata/result/statement/select_count_distinct.sql.txt
@@ -8,6 +8,7 @@ select count(distinct x) from foo
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.CallExpr{

--- a/testdata/result/statement/select_expr.sql.txt
+++ b/testdata/result/statement/select_expr.sql.txt
@@ -37,6 +37,7 @@ select 1 + 2, 1 - 2,
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.BinaryExpr{
@@ -331,6 +332,7 @@ select 1 + 2, 1 - 2,
               Select:   195,
               Distinct: false,
               AsStruct: false,
+              As:       nil,
               Results:  []ast.SelectItem{
                 &ast.Alias{
                   Expr: &ast.IntLiteral{
@@ -754,6 +756,7 @@ select 1 + 2, 1 - 2,
                   Select:   698,
                   Distinct: false,
                   AsStruct: false,
+                  As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{
                       Expr: &ast.IntLiteral{
@@ -775,6 +778,7 @@ select 1 + 2, 1 - 2,
                   Select:   717,
                   Distinct: false,
                   AsStruct: false,
+                  As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{
                       Expr: &ast.IntLiteral{
@@ -796,6 +800,7 @@ select 1 + 2, 1 - 2,
                   Select:   736,
                   Distinct: false,
                   AsStruct: false,
+                  As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{
                       Expr: &ast.IntLiteral{

--- a/testdata/result/statement/select_expr.sql.txt
+++ b/testdata/result/statement/select_expr.sql.txt
@@ -36,7 +36,6 @@ select 1 + 2, 1 - 2,
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -331,7 +330,6 @@ select 1 + 2, 1 - 2,
             Query:  &ast.Select{
               Select:   195,
               Distinct: false,
-              AsStruct: false,
               As:       nil,
               Results:  []ast.SelectItem{
                 &ast.Alias{
@@ -755,7 +753,6 @@ select 1 + 2, 1 - 2,
                 &ast.Select{
                   Select:   698,
                   Distinct: false,
-                  AsStruct: false,
                   As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{
@@ -777,7 +774,6 @@ select 1 + 2, 1 - 2,
                 &ast.Select{
                   Select:   717,
                   Distinct: false,
-                  AsStruct: false,
                   As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{
@@ -799,7 +795,6 @@ select 1 + 2, 1 - 2,
                 &ast.Select{
                   Select:   736,
                   Distinct: false,
-                  AsStruct: false,
                   As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{

--- a/testdata/result/statement/select_expr_extract.sql.txt
+++ b/testdata/result/statement/select_expr_extract.sql.txt
@@ -27,6 +27,7 @@ select
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ExtractExpr{

--- a/testdata/result/statement/select_expr_extract.sql.txt
+++ b/testdata/result/statement/select_expr_extract.sql.txt
@@ -26,7 +26,6 @@ select
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_hint.sql.txt
+++ b/testdata/result/statement/select_hint.sql.txt
@@ -39,6 +39,7 @@
     Select:   24,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Ident{

--- a/testdata/result/statement/select_hint.sql.txt
+++ b/testdata/result/statement/select_hint.sql.txt
@@ -38,7 +38,6 @@
   Query: &ast.Select{
     Select:   24,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_literals_all.sql.txt
+++ b/testdata/result/statement/select_literals_all.sql.txt
@@ -55,6 +55,7 @@ lines''',
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.StringLiteral{
@@ -390,6 +391,7 @@ lines''',
             Select:   460,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -437,6 +439,7 @@ lines''',
             Select:   493,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{

--- a/testdata/result/statement/select_literals_all.sql.txt
+++ b/testdata/result/statement/select_literals_all.sql.txt
@@ -54,7 +54,6 @@ lines''',
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -390,7 +389,6 @@ lines''',
           Query:  &ast.Select{
             Select:   460,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -438,7 +436,6 @@ lines''',
           Query:  &ast.Select{
             Select:   493,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{

--- a/testdata/result/statement/select_literals_array.sql.txt
+++ b/testdata/result/statement/select_literals_array.sql.txt
@@ -13,7 +13,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_literals_array.sql.txt
+++ b/testdata/result/statement/select_literals_array.sql.txt
@@ -14,6 +14,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ArrayLiteral{

--- a/testdata/result/statement/select_literals_array_invalid.sql.txt
+++ b/testdata/result/statement/select_literals_array_invalid.sql.txt
@@ -10,6 +10,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ArrayLiteral{

--- a/testdata/result/statement/select_literals_array_invalid.sql.txt
+++ b/testdata/result/statement/select_literals_array_invalid.sql.txt
@@ -9,7 +9,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_literals_bytes.sql.txt
+++ b/testdata/result/statement/select_literals_bytes.sql.txt
@@ -19,6 +19,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.BytesLiteral{

--- a/testdata/result/statement/select_literals_bytes.sql.txt
+++ b/testdata/result/statement/select_literals_bytes.sql.txt
@@ -18,7 +18,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_literals_date.sql.txt
+++ b/testdata/result/statement/select_literals_date.sql.txt
@@ -18,7 +18,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_literals_date.sql.txt
+++ b/testdata/result/statement/select_literals_date.sql.txt
@@ -19,6 +19,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.DateLiteral{

--- a/testdata/result/statement/select_literals_float.sql.txt
+++ b/testdata/result/statement/select_literals_float.sql.txt
@@ -12,7 +12,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_literals_float.sql.txt
+++ b/testdata/result/statement/select_literals_float.sql.txt
@@ -13,6 +13,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.FloatLiteral{

--- a/testdata/result/statement/select_literals_int.sql.txt
+++ b/testdata/result/statement/select_literals_int.sql.txt
@@ -12,7 +12,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_literals_int.sql.txt
+++ b/testdata/result/statement/select_literals_int.sql.txt
@@ -13,6 +13,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.IntLiteral{

--- a/testdata/result/statement/select_literals_paren.sql.txt
+++ b/testdata/result/statement/select_literals_paren.sql.txt
@@ -8,7 +8,6 @@ SELECT (1)
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_literals_paren.sql.txt
+++ b/testdata/result/statement/select_literals_paren.sql.txt
@@ -9,6 +9,7 @@ SELECT (1)
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ParenExpr{

--- a/testdata/result/statement/select_literals_paren_with_operator.sql.txt
+++ b/testdata/result/statement/select_literals_paren_with_operator.sql.txt
@@ -9,6 +9,7 @@ SELECT (1+1)
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ParenExpr{

--- a/testdata/result/statement/select_literals_paren_with_operator.sql.txt
+++ b/testdata/result/statement/select_literals_paren_with_operator.sql.txt
@@ -8,7 +8,6 @@ SELECT (1+1)
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_literals_string.sql.txt
+++ b/testdata/result/statement/select_literals_string.sql.txt
@@ -31,6 +31,7 @@ lines''',
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.StringLiteral{

--- a/testdata/result/statement/select_literals_string.sql.txt
+++ b/testdata/result/statement/select_literals_string.sql.txt
@@ -30,7 +30,6 @@ lines''',
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_literals_struct.sql.txt
+++ b/testdata/result/statement/select_literals_struct.sql.txt
@@ -17,6 +17,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ArraySubQuery{
@@ -26,6 +27,7 @@ SELECT
             Select:   15,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -73,6 +75,7 @@ SELECT
             Select:   48,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -118,6 +121,7 @@ SELECT
             Select:   84,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -199,6 +203,7 @@ SELECT
             Select:   144,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -268,6 +273,7 @@ SELECT
             Select:   198,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -341,6 +347,7 @@ SELECT
             Select:   254,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -388,6 +395,7 @@ SELECT
             Select:   281,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{
@@ -417,6 +425,7 @@ SELECT
             Select:   310,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.StructLiteral{

--- a/testdata/result/statement/select_literals_struct.sql.txt
+++ b/testdata/result/statement/select_literals_struct.sql.txt
@@ -16,7 +16,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -26,7 +25,6 @@ SELECT
           Query:  &ast.Select{
             Select:   15,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -74,7 +72,6 @@ SELECT
           Query:  &ast.Select{
             Select:   48,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -120,7 +117,6 @@ SELECT
           Query:  &ast.Select{
             Select:   84,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -202,7 +198,6 @@ SELECT
           Query:  &ast.Select{
             Select:   144,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -272,7 +267,6 @@ SELECT
           Query:  &ast.Select{
             Select:   198,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -346,7 +340,6 @@ SELECT
           Query:  &ast.Select{
             Select:   254,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -394,7 +387,6 @@ SELECT
           Query:  &ast.Select{
             Select:   281,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
@@ -424,7 +416,6 @@ SELECT
           Query:  &ast.Select{
             Select:   310,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{

--- a/testdata/result/statement/select_nest_complex.sql.txt
+++ b/testdata/result/statement/select_nest_complex.sql.txt
@@ -13,7 +13,6 @@ from (
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
@@ -49,7 +48,6 @@ from (
                         &ast.Select{
                           Select:   23,
                           Distinct: false,
-                          AsStruct: false,
                           As:       nil,
                           Results:  []ast.SelectItem{
                             &ast.Alias{
@@ -82,7 +80,6 @@ from (
                           Query:  &ast.Select{
                             Select:   45,
                             Distinct: false,
-                            AsStruct: false,
                             As:       nil,
                             Results:  []ast.SelectItem{
                               &ast.ExprSelectItem{
@@ -117,7 +114,6 @@ from (
                     Query:  &ast.Select{
                       Select:   72,
                       Distinct: false,
-                      AsStruct: false,
                       As:       nil,
                       Results:  []ast.SelectItem{
                         &ast.ExprSelectItem{
@@ -164,7 +160,6 @@ from (
             Query:  &ast.Select{
               Select:   104,
               Distinct: false,
-              AsStruct: false,
               As:       nil,
               Results:  []ast.SelectItem{
                 &ast.Alias{

--- a/testdata/result/statement/select_nest_complex.sql.txt
+++ b/testdata/result/statement/select_nest_complex.sql.txt
@@ -14,6 +14,7 @@ from (
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 7,
@@ -49,6 +50,7 @@ from (
                           Select:   23,
                           Distinct: false,
                           AsStruct: false,
+                          As:       nil,
                           Results:  []ast.SelectItem{
                             &ast.Alias{
                               Expr: &ast.IntLiteral{
@@ -81,6 +83,7 @@ from (
                             Select:   45,
                             Distinct: false,
                             AsStruct: false,
+                            As:       nil,
                             Results:  []ast.SelectItem{
                               &ast.ExprSelectItem{
                                 Expr: &ast.IntLiteral{
@@ -115,6 +118,7 @@ from (
                       Select:   72,
                       Distinct: false,
                       AsStruct: false,
+                      As:       nil,
                       Results:  []ast.SelectItem{
                         &ast.ExprSelectItem{
                           Expr: &ast.IntLiteral{
@@ -161,6 +165,7 @@ from (
               Select:   104,
               Distinct: false,
               AsStruct: false,
+              As:       nil,
               Results:  []ast.SelectItem{
                 &ast.Alias{
                   Expr: &ast.IntLiteral{

--- a/testdata/result/statement/select_select_limit_expr.sql.txt
+++ b/testdata/result/statement/select_select_limit_expr.sql.txt
@@ -9,6 +9,7 @@ select ((select 1) limit 1 offset 0) + 3
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.BinaryExpr{
@@ -23,6 +24,7 @@ select ((select 1) limit 1 offset 0) + 3
                 Select:   9,
                 Distinct: false,
                 AsStruct: false,
+                As:       nil,
                 Results:  []ast.SelectItem{
                   &ast.ExprSelectItem{
                     Expr: &ast.IntLiteral{

--- a/testdata/result/statement/select_select_limit_expr.sql.txt
+++ b/testdata/result/statement/select_select_limit_expr.sql.txt
@@ -8,7 +8,6 @@ select ((select 1) limit 1 offset 0) + 3
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -23,7 +22,6 @@ select ((select 1) limit 1 offset 0) + 3
               Query:  &ast.Select{
                 Select:   9,
                 Distinct: false,
-                AsStruct: false,
                 As:       nil,
                 Results:  []ast.SelectItem{
                   &ast.ExprSelectItem{

--- a/testdata/result/statement/select_select_set_operator_expr.sql.txt
+++ b/testdata/result/statement/select_select_set_operator_expr.sql.txt
@@ -10,7 +10,6 @@ select ((select 1) union all (select 2)) + 3,
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -29,7 +28,6 @@ select ((select 1) union all (select 2)) + 3,
                   Query:  &ast.Select{
                     Select:   9,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
@@ -57,7 +55,6 @@ select ((select 1) union all (select 2)) + 3,
                   Query:  &ast.Select{
                     Select:   30,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
@@ -108,7 +105,6 @@ select ((select 1) union all (select 2)) + 3,
                   Query:  &ast.Select{
                     Select:   55,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
@@ -136,7 +132,6 @@ select ((select 1) union all (select 2)) + 3,
                   Query:  &ast.Select{
                     Select:   80,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
@@ -187,7 +182,6 @@ select ((select 1) union all (select 2)) + 3,
                   Query:  &ast.Select{
                     Select:   105,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
@@ -215,7 +209,6 @@ select ((select 1) union all (select 2)) + 3,
                   Query:  &ast.Select{
                     Select:   127,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_select_set_operator_expr.sql.txt
+++ b/testdata/result/statement/select_select_set_operator_expr.sql.txt
@@ -11,6 +11,7 @@ select ((select 1) union all (select 2)) + 3,
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.BinaryExpr{
@@ -29,6 +30,7 @@ select ((select 1) union all (select 2)) + 3,
                     Select:   9,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
                         Expr: &ast.IntLiteral{
@@ -56,6 +58,7 @@ select ((select 1) union all (select 2)) + 3,
                     Select:   30,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
                         Expr: &ast.IntLiteral{
@@ -106,6 +109,7 @@ select ((select 1) union all (select 2)) + 3,
                     Select:   55,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
                         Expr: &ast.IntLiteral{
@@ -133,6 +137,7 @@ select ((select 1) union all (select 2)) + 3,
                     Select:   80,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
                         Expr: &ast.IntLiteral{
@@ -183,6 +188,7 @@ select ((select 1) union all (select 2)) + 3,
                     Select:   105,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
                         Expr: &ast.IntLiteral{
@@ -210,6 +216,7 @@ select ((select 1) union all (select 2)) + 3,
                     Select:   127,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.ExprSelectItem{
                         Expr: &ast.IntLiteral{

--- a/testdata/result/statement/select_singer_with_as_struct_subquery.sql.txt
+++ b/testdata/result/statement/select_singer_with_as_struct_subquery.sql.txt
@@ -15,7 +15,6 @@ SELECT
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -28,7 +27,6 @@ SELECT
             Query:  &ast.Select{
               Select:   28,
               Distinct: false,
-              AsStruct: true,
               As:       &ast.AsStruct{
                 As:     35,
                 Struct: 38,

--- a/testdata/result/statement/select_singer_with_as_struct_subquery.sql.txt
+++ b/testdata/result/statement/select_singer_with_as_struct_subquery.sql.txt
@@ -16,6 +16,7 @@ SELECT
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ArraySubQuery{
@@ -28,7 +29,11 @@ SELECT
               Select:   28,
               Distinct: false,
               AsStruct: true,
-              Results:  []ast.SelectItem{
+              As:       &ast.AsStruct{
+                As:     35,
+                Struct: 38,
+              },
+              Results: []ast.SelectItem{
                 &ast.Star{
                   Star: 53,
                 },

--- a/testdata/result/statement/select_singer_with_asterisk.sql.txt
+++ b/testdata/result/statement/select_singer_with_asterisk.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_asterisk.sql.txt
+++ b/testdata/result/statement/select_singer_with_asterisk.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_column_and_asterisk.sql.txt
+++ b/testdata/result/statement/select_singer_with_column_and_asterisk.sql.txt
@@ -13,6 +13,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Ident{

--- a/testdata/result/statement/select_singer_with_column_and_asterisk.sql.txt
+++ b/testdata/result/statement/select_singer_with_column_and_asterisk.sql.txt
@@ -12,7 +12,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_singer_with_column_names.sql.txt
+++ b/testdata/result/statement/select_singer_with_column_names.sql.txt
@@ -15,6 +15,7 @@ FROM Singers
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.Ident{

--- a/testdata/result/statement/select_singer_with_column_names.sql.txt
+++ b/testdata/result/statement/select_singer_with_column_names.sql.txt
@@ -14,7 +14,6 @@ FROM Singers
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{

--- a/testdata/result/statement/select_singer_with_cross_join.sql.txt
+++ b/testdata/result/statement/select_singer_with_cross_join.sql.txt
@@ -14,6 +14,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_cross_join.sql.txt
+++ b/testdata/result/statement/select_singer_with_cross_join.sql.txt
@@ -13,7 +13,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_distinct.sql.txt
+++ b/testdata/result/statement/select_singer_with_distinct.sql.txt
@@ -13,6 +13,7 @@ FROM
     Select:   0,
     Distinct: true,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 20,

--- a/testdata/result/statement/select_singer_with_distinct.sql.txt
+++ b/testdata/result/statement/select_singer_with_distinct.sql.txt
@@ -12,7 +12,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: true,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_full_join.sql.txt
+++ b/testdata/result/statement/select_singer_with_full_join.sql.txt
@@ -12,7 +12,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_full_join.sql.txt
+++ b/testdata/result/statement/select_singer_with_full_join.sql.txt
@@ -13,6 +13,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_groupby.sql.txt
+++ b/testdata/result/statement/select_singer_with_groupby.sql.txt
@@ -14,6 +14,7 @@ GROUP BY
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Ident{

--- a/testdata/result/statement/select_singer_with_groupby.sql.txt
+++ b/testdata/result/statement/select_singer_with_groupby.sql.txt
@@ -13,7 +13,6 @@ GROUP BY
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_singer_with_hash_join.sql.txt
+++ b/testdata/result/statement/select_singer_with_hash_join.sql.txt
@@ -20,7 +20,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_hash_join.sql.txt
+++ b/testdata/result/statement/select_singer_with_hash_join.sql.txt
@@ -21,6 +21,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_having.sql.txt
+++ b/testdata/result/statement/select_singer_with_having.sql.txt
@@ -16,6 +16,7 @@ HAVING
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Ident{

--- a/testdata/result/statement/select_singer_with_having.sql.txt
+++ b/testdata/result/statement/select_singer_with_having.sql.txt
@@ -15,7 +15,6 @@ HAVING
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_singer_with_in_and_unnest.sql.txt
+++ b/testdata/result/statement/select_singer_with_in_and_unnest.sql.txt
@@ -14,6 +14,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_in_and_unnest.sql.txt
+++ b/testdata/result/statement/select_singer_with_in_and_unnest.sql.txt
@@ -13,7 +13,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_in_and_unnest_with_query_parameter.sql.txt
+++ b/testdata/result/statement/select_singer_with_in_and_unnest_with_query_parameter.sql.txt
@@ -14,6 +14,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_in_and_unnest_with_query_parameter.sql.txt
+++ b/testdata/result/statement/select_singer_with_in_and_unnest_with_query_parameter.sql.txt
@@ -13,7 +13,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_join.sql.txt
+++ b/testdata/result/statement/select_singer_with_join.sql.txt
@@ -14,7 +14,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_join.sql.txt
+++ b/testdata/result/statement/select_singer_with_join.sql.txt
@@ -15,6 +15,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_join_hint.sql.txt
+++ b/testdata/result/statement/select_singer_with_join_hint.sql.txt
@@ -23,7 +23,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_join_hint.sql.txt
+++ b/testdata/result/statement/select_singer_with_join_hint.sql.txt
@@ -24,6 +24,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_join_twice.sql.txt
+++ b/testdata/result/statement/select_singer_with_join_twice.sql.txt
@@ -18,6 +18,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_join_twice.sql.txt
+++ b/testdata/result/statement/select_singer_with_join_twice.sql.txt
@@ -17,7 +17,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_join_using.sql.txt
+++ b/testdata/result/statement/select_singer_with_join_using.sql.txt
@@ -14,7 +14,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_join_using.sql.txt
+++ b/testdata/result/statement/select_singer_with_join_using.sql.txt
@@ -15,6 +15,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_join_various.sql.txt
+++ b/testdata/result/statement/select_singer_with_join_various.sql.txt
@@ -37,7 +37,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_join_various.sql.txt
+++ b/testdata/result/statement/select_singer_with_join_various.sql.txt
@@ -38,6 +38,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_limit.sql.txt
+++ b/testdata/result/statement/select_singer_with_limit.sql.txt
@@ -13,6 +13,7 @@ LIMIT 100
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_limit.sql.txt
+++ b/testdata/result/statement/select_singer_with_limit.sql.txt
@@ -12,7 +12,6 @@ LIMIT 100
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_limit_and_skiprows.sql.txt
+++ b/testdata/result/statement/select_singer_with_limit_and_skiprows.sql.txt
@@ -13,7 +13,6 @@ OFFSET 10
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_limit_and_skiprows.sql.txt
+++ b/testdata/result/statement/select_singer_with_limit_and_skiprows.sql.txt
@@ -14,6 +14,7 @@ OFFSET 10
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_orderby.sql.txt
+++ b/testdata/result/statement/select_singer_with_orderby.sql.txt
@@ -14,7 +14,6 @@ ORDER BY
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_orderby.sql.txt
+++ b/testdata/result/statement/select_singer_with_orderby.sql.txt
@@ -15,6 +15,7 @@ ORDER BY
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_query_parameter.sql.txt
+++ b/testdata/result/statement/select_singer_with_query_parameter.sql.txt
@@ -14,7 +14,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_query_parameter.sql.txt
+++ b/testdata/result/statement/select_singer_with_query_parameter.sql.txt
@@ -15,6 +15,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_root_parent.sql.txt
+++ b/testdata/result/statement/select_singer_with_root_parent.sql.txt
@@ -12,6 +12,7 @@
       Select:   2,
       Distinct: false,
       AsStruct: false,
+      As:       nil,
       Results:  []ast.SelectItem{
         &ast.Star{
           Star: 9,

--- a/testdata/result/statement/select_singer_with_root_parent.sql.txt
+++ b/testdata/result/statement/select_singer_with_root_parent.sql.txt
@@ -11,7 +11,6 @@
     Query:  &ast.Select{
       Select:   2,
       Distinct: false,
-      AsStruct: false,
       As:       nil,
       Results:  []ast.SelectItem{
         &ast.Star{

--- a/testdata/result/statement/select_singer_with_select_in_from.sql.txt
+++ b/testdata/result/statement/select_singer_with_select_in_from.sql.txt
@@ -18,6 +18,7 @@ FROM (
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,
@@ -32,6 +33,7 @@ FROM (
           Select:   20,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.Star{
               Star: 31,

--- a/testdata/result/statement/select_singer_with_select_in_from.sql.txt
+++ b/testdata/result/statement/select_singer_with_select_in_from.sql.txt
@@ -17,7 +17,6 @@ FROM (
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
@@ -32,7 +31,6 @@ FROM (
         Query:  &ast.Select{
           Select:   20,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.Star{

--- a/testdata/result/statement/select_singer_with_select_in_from_and_as.sql.txt
+++ b/testdata/result/statement/select_singer_with_select_in_from_and_as.sql.txt
@@ -18,6 +18,7 @@ FROM (
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,
@@ -32,6 +33,7 @@ FROM (
           Select:   20,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.Star{
               Star: 31,

--- a/testdata/result/statement/select_singer_with_select_in_from_and_as.sql.txt
+++ b/testdata/result/statement/select_singer_with_select_in_from_and_as.sql.txt
@@ -17,7 +17,6 @@ FROM (
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
@@ -32,7 +31,6 @@ FROM (
         Query:  &ast.Select{
           Select:   20,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.Star{

--- a/testdata/result/statement/select_singer_with_single_column_subquery.sql.txt
+++ b/testdata/result/statement/select_singer_with_single_column_subquery.sql.txt
@@ -12,6 +12,7 @@ SELECT (
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ScalarSubQuery{
@@ -21,6 +22,7 @@ SELECT (
             Select:   11,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.Ident{

--- a/testdata/result/statement/select_singer_with_single_column_subquery.sql.txt
+++ b/testdata/result/statement/select_singer_with_single_column_subquery.sql.txt
@@ -11,7 +11,6 @@ SELECT (
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -21,7 +20,6 @@ SELECT (
           Query:  &ast.Select{
             Select:   11,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{

--- a/testdata/result/statement/select_singer_with_single_column_subquery_with_at.sql.txt
+++ b/testdata/result/statement/select_singer_with_single_column_subquery_with_at.sql.txt
@@ -11,7 +11,6 @@ SELECT (
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
@@ -21,7 +20,6 @@ SELECT (
           Query:  &ast.Select{
             Select:   11,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{

--- a/testdata/result/statement/select_singer_with_single_column_subquery_with_at.sql.txt
+++ b/testdata/result/statement/select_singer_with_single_column_subquery_with_at.sql.txt
@@ -12,6 +12,7 @@ SELECT (
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.ScalarSubQuery{
@@ -21,6 +22,7 @@ SELECT (
             Select:   11,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.Ident{

--- a/testdata/result/statement/select_singer_with_table_alias.sql.txt
+++ b/testdata/result/statement/select_singer_with_table_alias.sql.txt
@@ -13,6 +13,7 @@ FROM Singers S
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.DotStar{
         Star: 11,

--- a/testdata/result/statement/select_singer_with_table_alias.sql.txt
+++ b/testdata/result/statement/select_singer_with_table_alias.sql.txt
@@ -12,7 +12,6 @@ FROM Singers S
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.DotStar{

--- a/testdata/result/statement/select_singer_with_table_alias_with_hint.sql.txt
+++ b/testdata/result/statement/select_singer_with_table_alias_with_hint.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_table_alias_with_hint.sql.txt
+++ b/testdata/result/statement/select_singer_with_table_alias_with_hint.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_table_hint.sql.txt
+++ b/testdata/result/statement/select_singer_with_table_hint.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_table_hint.sql.txt
+++ b/testdata/result/statement/select_singer_with_table_hint.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_tablesample.sql.txt
+++ b/testdata/result/statement/select_singer_with_tablesample.sql.txt
@@ -14,6 +14,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_tablesample.sql.txt
+++ b/testdata/result/statement/select_singer_with_tablesample.sql.txt
@@ -13,7 +13,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_tableset.sql.txt
+++ b/testdata/result/statement/select_singer_with_tableset.sql.txt
@@ -15,6 +15,7 @@ SELECT * FROM Singers
         Select:   0,
         Distinct: false,
         AsStruct: false,
+        As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
             Star: 7,
@@ -43,6 +44,7 @@ SELECT * FROM Singers
         Select:   32,
         Distinct: false,
         AsStruct: false,
+        As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
             Star: 39,

--- a/testdata/result/statement/select_singer_with_tableset.sql.txt
+++ b/testdata/result/statement/select_singer_with_tableset.sql.txt
@@ -14,7 +14,6 @@ SELECT * FROM Singers
       &ast.Select{
         Select:   0,
         Distinct: false,
-        AsStruct: false,
         As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
@@ -43,7 +42,6 @@ SELECT * FROM Singers
       &ast.Select{
         Select:   32,
         Distinct: false,
-        AsStruct: false,
         As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{

--- a/testdata/result/statement/select_singer_with_tableset_complex.sql.txt
+++ b/testdata/result/statement/select_singer_with_tableset_complex.sql.txt
@@ -34,7 +34,6 @@ UNION ALL
       &ast.Select{
         Select:   0,
         Distinct: false,
-        AsStruct: false,
         As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
@@ -70,7 +69,6 @@ UNION ALL
             &ast.Select{
               Select:   36,
               Distinct: false,
-              AsStruct: false,
               As:       nil,
               Results:  []ast.SelectItem{
                 &ast.Star{
@@ -106,7 +104,6 @@ UNION ALL
                   &ast.Select{
                     Select:   83,
                     Distinct: false,
-                    AsStruct: false,
                     As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.Star{
@@ -142,7 +139,6 @@ UNION ALL
                         &ast.Select{
                           Select:   135,
                           Distinct: false,
-                          AsStruct: false,
                           As:       nil,
                           Results:  []ast.SelectItem{
                             &ast.Star{
@@ -178,7 +174,6 @@ UNION ALL
                               &ast.Select{
                                 Select:   198,
                                 Distinct: false,
-                                AsStruct: false,
                                 As:       nil,
                                 Results:  []ast.SelectItem{
                                   &ast.Star{
@@ -214,7 +209,6 @@ UNION ALL
                                     &ast.Select{
                                       Select:   259,
                                       Distinct: false,
-                                      AsStruct: false,
                                       As:       nil,
                                       Results:  []ast.SelectItem{
                                         &ast.Star{
@@ -243,7 +237,6 @@ UNION ALL
                                     &ast.Select{
                                       Select:   317,
                                       Distinct: false,
-                                      AsStruct: false,
                                       As:       nil,
                                       Results:  []ast.SelectItem{
                                         &ast.Star{

--- a/testdata/result/statement/select_singer_with_tableset_complex.sql.txt
+++ b/testdata/result/statement/select_singer_with_tableset_complex.sql.txt
@@ -35,6 +35,7 @@ UNION ALL
         Select:   0,
         Distinct: false,
         AsStruct: false,
+        As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
             Star: 7,
@@ -70,6 +71,7 @@ UNION ALL
               Select:   36,
               Distinct: false,
               AsStruct: false,
+              As:       nil,
               Results:  []ast.SelectItem{
                 &ast.Star{
                   Star: 43,
@@ -105,6 +107,7 @@ UNION ALL
                     Select:   83,
                     Distinct: false,
                     AsStruct: false,
+                    As:       nil,
                     Results:  []ast.SelectItem{
                       &ast.Star{
                         Star: 90,
@@ -140,6 +143,7 @@ UNION ALL
                           Select:   135,
                           Distinct: false,
                           AsStruct: false,
+                          As:       nil,
                           Results:  []ast.SelectItem{
                             &ast.Star{
                               Star: 142,
@@ -175,6 +179,7 @@ UNION ALL
                                 Select:   198,
                                 Distinct: false,
                                 AsStruct: false,
+                                As:       nil,
                                 Results:  []ast.SelectItem{
                                   &ast.Star{
                                     Star: 205,
@@ -210,6 +215,7 @@ UNION ALL
                                       Select:   259,
                                       Distinct: false,
                                       AsStruct: false,
+                                      As:       nil,
                                       Results:  []ast.SelectItem{
                                         &ast.Star{
                                           Star: 266,
@@ -238,6 +244,7 @@ UNION ALL
                                       Select:   317,
                                       Distinct: false,
                                       AsStruct: false,
+                                      As:       nil,
                                       Results:  []ast.SelectItem{
                                         &ast.Star{
                                           Star: 324,

--- a/testdata/result/statement/select_singer_with_tableset_with_where.sql.txt
+++ b/testdata/result/statement/select_singer_with_tableset_with_where.sql.txt
@@ -19,6 +19,7 @@ ORDER BY
         Select:   0,
         Distinct: false,
         AsStruct: false,
+        As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
             Star: 7,
@@ -47,6 +48,7 @@ ORDER BY
         Select:   32,
         Distinct: false,
         AsStruct: false,
+        As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
             Star: 39,

--- a/testdata/result/statement/select_singer_with_tableset_with_where.sql.txt
+++ b/testdata/result/statement/select_singer_with_tableset_with_where.sql.txt
@@ -18,7 +18,6 @@ ORDER BY
       &ast.Select{
         Select:   0,
         Distinct: false,
-        AsStruct: false,
         As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{
@@ -47,7 +46,6 @@ ORDER BY
       &ast.Select{
         Select:   32,
         Distinct: false,
-        AsStruct: false,
         As:       nil,
         Results:  []ast.SelectItem{
           &ast.Star{

--- a/testdata/result/statement/select_singer_with_toplevel_join_hint.sql.txt
+++ b/testdata/result/statement/select_singer_with_toplevel_join_hint.sql.txt
@@ -31,7 +31,6 @@ FROM
   Query: &ast.Select{
     Select:   25,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_toplevel_join_hint.sql.txt
+++ b/testdata/result/statement/select_singer_with_toplevel_join_hint.sql.txt
@@ -32,6 +32,7 @@ FROM
     Select:   25,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 34,

--- a/testdata/result/statement/select_singer_with_value_hex.sql.txt
+++ b/testdata/result/statement/select_singer_with_value_hex.sql.txt
@@ -14,6 +14,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_value_hex.sql.txt
+++ b/testdata/result/statement/select_singer_with_value_hex.sql.txt
@@ -13,7 +13,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_where.sql.txt
+++ b/testdata/result/statement/select_singer_with_where.sql.txt
@@ -14,6 +14,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_where.sql.txt
+++ b/testdata/result/statement/select_singer_with_where.sql.txt
@@ -13,7 +13,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_where_and_comparison.sql.txt
+++ b/testdata/result/statement/select_singer_with_where_and_comparison.sql.txt
@@ -30,7 +30,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_singer_with_where_and_comparison.sql.txt
+++ b/testdata/result/statement/select_singer_with_where_and_comparison.sql.txt
@@ -31,6 +31,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_where_and_op.sql.txt
+++ b/testdata/result/statement/select_singer_with_where_and_op.sql.txt
@@ -14,6 +14,7 @@ WHERE
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_singer_with_where_and_op.sql.txt
+++ b/testdata/result/statement/select_singer_with_where_and_op.sql.txt
@@ -13,7 +13,6 @@ WHERE
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_struct_compare_eq.sql.txt
+++ b/testdata/result/statement/select_struct_compare_eq.sql.txt
@@ -14,7 +14,6 @@ SELECT ARRAY(
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -24,7 +23,6 @@ SELECT ARRAY(
           Query:  &ast.Select{
             Select:   16,
             Distinct: false,
-            AsStruct: false,
             As:       nil,
             Results:  []ast.SelectItem{
               &ast.Star{
@@ -39,7 +37,6 @@ SELECT ARRAY(
                 Query:  &ast.Select{
                   Select:   41,
                   Distinct: false,
-                  AsStruct: false,
                   As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{

--- a/testdata/result/statement/select_struct_compare_eq.sql.txt
+++ b/testdata/result/statement/select_struct_compare_eq.sql.txt
@@ -15,6 +15,7 @@ SELECT ARRAY(
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.ArraySubQuery{
@@ -24,6 +25,7 @@ SELECT ARRAY(
             Select:   16,
             Distinct: false,
             AsStruct: false,
+            As:       nil,
             Results:  []ast.SelectItem{
               &ast.Star{
                 Star: 27,
@@ -38,6 +40,7 @@ SELECT ARRAY(
                   Select:   41,
                   Distinct: false,
                   AsStruct: false,
+                  As:       nil,
                   Results:  []ast.SelectItem{
                     &ast.ExprSelectItem{
                       Expr: &ast.StructLiteral{

--- a/testdata/result/statement/select_tablesample_with_cross_join.sql.txt
+++ b/testdata/result/statement/select_tablesample_with_cross_join.sql.txt
@@ -14,7 +14,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_tablesample_with_cross_join.sql.txt
+++ b/testdata/result/statement/select_tablesample_with_cross_join.sql.txt
@@ -15,6 +15,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_tablesample_with_subquery.sql.txt
+++ b/testdata/result/statement/select_tablesample_with_subquery.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
@@ -26,7 +25,6 @@ FROM
         Query:  &ast.Select{
           Select:   19,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.Star{

--- a/testdata/result/statement/select_tablesample_with_subquery.sql.txt
+++ b/testdata/result/statement/select_tablesample_with_subquery.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,
@@ -26,6 +27,7 @@ FROM
           Select:   19,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.Star{
               Star: 26,

--- a/testdata/result/statement/select_tablesample_with_table.sql.txt
+++ b/testdata/result/statement/select_tablesample_with_table.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_tablesample_with_table.sql.txt
+++ b/testdata/result/statement/select_tablesample_with_table.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_tablesample_with_table_alias.sql.txt
+++ b/testdata/result/statement/select_tablesample_with_table_alias.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_tablesample_with_table_alias.sql.txt
+++ b/testdata/result/statement/select_tablesample_with_table_alias.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_tablesample_with_unnest_invalid.sql.txt
+++ b/testdata/result/statement/select_tablesample_with_unnest_invalid.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_tablesample_with_unnest_invalid.sql.txt
+++ b/testdata/result/statement/select_tablesample_with_unnest_invalid.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_union_chain.sql.txt
+++ b/testdata/result/statement/select_union_chain.sql.txt
@@ -15,7 +15,6 @@
         Query:  &ast.Select{
           Select:   1,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
@@ -43,7 +42,6 @@
         Query:  &ast.Select{
           Select:   22,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
@@ -71,7 +69,6 @@
         Query:  &ast.Select{
           Select:   43,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{

--- a/testdata/result/statement/select_union_chain.sql.txt
+++ b/testdata/result/statement/select_union_chain.sql.txt
@@ -16,6 +16,7 @@
           Select:   1,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
               Expr: &ast.IntLiteral{
@@ -43,6 +44,7 @@
           Select:   22,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
               Expr: &ast.IntLiteral{
@@ -70,6 +72,7 @@
           Select:   43,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
               Expr: &ast.IntLiteral{

--- a/testdata/result/statement/select_unnest_with_offset.sql.txt
+++ b/testdata/result/statement/select_unnest_with_offset.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_unnest_with_offset.sql.txt
+++ b/testdata/result/statement/select_unnest_with_offset.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_unnest_with_offset_and_alias.sql.txt
+++ b/testdata/result/statement/select_unnest_with_offset_and_alias.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_unnest_with_offset_and_alias.sql.txt
+++ b/testdata/result/statement/select_unnest_with_offset_and_alias.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_unnest_with_offset_and_alias_min.sql.txt
+++ b/testdata/result/statement/select_unnest_with_offset_and_alias_min.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_unnest_with_offset_and_alias_min.sql.txt
+++ b/testdata/result/statement/select_unnest_with_offset_and_alias_min.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_with_after_hint.sql.txt
+++ b/testdata/result/statement/select_with_after_hint.sql.txt
@@ -36,6 +36,7 @@
           Select:   28,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
               Expr: &ast.Ident{
@@ -71,6 +72,7 @@
     Select:   48,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 55,

--- a/testdata/result/statement/select_with_after_hint.sql.txt
+++ b/testdata/result/statement/select_with_after_hint.sql.txt
@@ -35,7 +35,6 @@
         QueryExpr: &ast.Select{
           Select:   28,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
@@ -71,7 +70,6 @@
   Query: &ast.Select{
     Select:   48,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_with_comment.sql.txt
+++ b/testdata/result/statement/select_with_comment.sql.txt
@@ -9,7 +9,6 @@ select 1
   Query: &ast.Select{
     Select:   10,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{

--- a/testdata/result/statement/select_with_comment.sql.txt
+++ b/testdata/result/statement/select_with_comment.sql.txt
@@ -10,6 +10,7 @@ select 1
     Select:   10,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.IntLiteral{

--- a/testdata/result/statement/select_with_field_path.sql.txt
+++ b/testdata/result/statement/select_with_field_path.sql.txt
@@ -24,7 +24,6 @@ WHERE A.z.a = 2
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
@@ -114,7 +113,6 @@ WHERE A.z.a = 2
           Query:  &ast.Select{
             Select:   70,
             Distinct: false,
-            AsStruct: true,
             As:       &ast.AsStruct{
               As:     77,
               Struct: 80,

--- a/testdata/result/statement/select_with_field_path.sql.txt
+++ b/testdata/result/statement/select_with_field_path.sql.txt
@@ -25,6 +25,7 @@ WHERE A.z.a = 2
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.Path{
@@ -114,7 +115,11 @@ WHERE A.z.a = 2
             Select:   70,
             Distinct: false,
             AsStruct: true,
-            Results:  []ast.SelectItem{
+            As:       &ast.AsStruct{
+              As:     77,
+              Struct: 80,
+            },
+            Results: []ast.SelectItem{
               &ast.ExprSelectItem{
                 Expr: &ast.Ident{
                   NamePos: 95,

--- a/testdata/result/statement/select_with_multiple_ctes.sql.txt
+++ b/testdata/result/statement/select_with_multiple_ctes.sql.txt
@@ -18,6 +18,7 @@ with subq1 as (select c1 from foo), subq2 as (select c2 from foo) select * from 
           Select:   15,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
               Expr: &ast.Ident{
@@ -58,6 +59,7 @@ with subq1 as (select c1 from foo), subq2 as (select c2 from foo) select * from 
           Select:   46,
           Distinct: false,
           AsStruct: false,
+          As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
               Expr: &ast.Ident{
@@ -93,6 +95,7 @@ with subq1 as (select c1 from foo), subq2 as (select c2 from foo) select * from 
     Select:   66,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 73,

--- a/testdata/result/statement/select_with_multiple_ctes.sql.txt
+++ b/testdata/result/statement/select_with_multiple_ctes.sql.txt
@@ -17,7 +17,6 @@ with subq1 as (select c1 from foo), subq2 as (select c2 from foo) select * from 
         QueryExpr: &ast.Select{
           Select:   15,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
@@ -58,7 +57,6 @@ with subq1 as (select c1 from foo), subq2 as (select c2 from foo) select * from 
         QueryExpr: &ast.Select{
           Select:   46,
           Distinct: false,
-          AsStruct: false,
           As:       nil,
           Results:  []ast.SelectItem{
             &ast.ExprSelectItem{
@@ -94,7 +92,6 @@ with subq1 as (select c1 from foo), subq2 as (select c2 from foo) select * from 
   Query: &ast.Select{
     Select:   66,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_with_reservedword.sql.txt
+++ b/testdata/result/statement/select_with_reservedword.sql.txt
@@ -12,6 +12,7 @@ FROM
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{
         Star: 9,

--- a/testdata/result/statement/select_with_reservedword.sql.txt
+++ b/testdata/result/statement/select_with_reservedword.sql.txt
@@ -11,7 +11,6 @@ FROM
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Star{

--- a/testdata/result/statement/select_with_sequence_function.sql.txt
+++ b/testdata/result/statement/select_with_sequence_function.sql.txt
@@ -9,6 +9,7 @@ SELECT GET_NEXT_SEQUENCE_VALUE(SEQUENCE my_sequence) as next_id
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{
         Expr: &ast.CallExpr{

--- a/testdata/result/statement/select_with_sequence_function.sql.txt
+++ b/testdata/result/statement/select_with_sequence_function.sql.txt
@@ -8,7 +8,6 @@ SELECT GET_NEXT_SEQUENCE_VALUE(SEQUENCE my_sequence) as next_id
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.Alias{

--- a/testdata/result/statement/select_with_trailing_comma.sql.txt
+++ b/testdata/result/statement/select_with_trailing_comma.sql.txt
@@ -8,6 +8,7 @@ SELECT 1, 2,
     Select:   0,
     Distinct: false,
     AsStruct: false,
+    As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{
         Expr: &ast.IntLiteral{

--- a/testdata/result/statement/select_with_trailing_comma.sql.txt
+++ b/testdata/result/statement/select_with_trailing_comma.sql.txt
@@ -7,7 +7,6 @@ SELECT 1, 2,
   Query: &ast.Select{
     Select:   0,
     Distinct: false,
-    AsStruct: false,
     As:       nil,
     Results:  []ast.SelectItem{
       &ast.ExprSelectItem{


### PR DESCRIPTION
This PR add support of `SELECT AS VALUE` #97  and `SELECT AS typename` #89.

`SELECT AS VALUE`
https://cloud.google.com/spanner/docs/reference/standard-sql/query-syntax#select_as_value

`SELECT AS typename`
https://cloud.google.com/spanner/docs/reference/standard-sql/query-syntax#select_as_typename

They and `SELECT AS STRUCT` are generalized as `ast.SelectAs`.

~Note: This PR depends on `ast.NamedType` in #121, so it is needed to rebase after #121 is merged.~ rebased

fix #97 