### PR TITLE
Refine file path in syntax error of parser_test.go

### DIFF
--- a/error.go
+++ b/error.go
@@ -18,7 +18,7 @@ func (e *Error) String() string {
 
 func (e *Error) Error() string {
 	var message bytes.Buffer
-	fmt.Fprintf(&message, "syntax error:%s: %s\n", e.Position, e.Message)
+	fmt.Fprintf(&message, "syntax error: %s: %s\n", e.Position, e.Message)
 	if e.Position.Source != "" {
 		fmt.Fprintln(&message)
 		fmt.Fprint(&message, e.Position.Source)

--- a/parser_test.go
+++ b/parser_test.go
@@ -47,14 +47,15 @@ func testParser(t *testing.T, inputPath, resultPath string, parse func(p *memefi
 		t.Run(in.Name(), func(t *testing.T) {
 			t.Parallel()
 
-			b, err := os.ReadFile(filepath.Join(inputPath, in.Name()))
+			inputFilePath := filepath.Join(inputPath, in.Name())
+			b, err := os.ReadFile(inputFilePath)
 			if err != nil {
 				t.Fatalf("error on reading input file: %v", err)
 			}
 
 			p := &memefish.Parser{
 				Lexer: &memefish.Lexer{
-					File: &token.File{FilePath: in.Name(), Buffer: string(b)},
+					File: &token.File{FilePath: inputFilePath, Buffer: string(b)},
 				},
 			}
 


### PR DESCRIPTION
This PR fixes syntax error message and `parser_test.go` to make error message can be treated as a hyperlink to file position in some software(e.g. Goland).

<img width="1204" alt="スクリーンショット 2024-10-16 13 12 42" src="https://github.com/user-attachments/assets/dc38d132-faf3-4d46-b5c1-0326d0be9601">

fixes #138