### PR TITLE
Fix some bad `.End` usages in `parser.go`

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1581,7 +1581,7 @@ type ColumnDefaultExpr struct {
 //	AS ({{.Expr | sql}}) STORED
 type GeneratedColumnExpr struct {
 	// pos = As
-	// end = Stored
+	// end = Stored + 6
 
 	As     token.Pos // position of "AS" keyword
 	Stored token.Pos // position of "STORED" keyword

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -580,7 +580,7 @@ func (g *ColumnDefaultExpr) Pos() token.Pos { return g.Default }
 func (g *ColumnDefaultExpr) End() token.Pos { return g.Rparen }
 
 func (g *GeneratedColumnExpr) Pos() token.Pos { return g.As }
-func (g *GeneratedColumnExpr) End() token.Pos { return g.Stored }
+func (g *GeneratedColumnExpr) End() token.Pos { return g.Stored + 6 }
 
 func (c *ColumnDefOptions) Pos() token.Pos { return c.Options }
 func (c *ColumnDefOptions) End() token.Pos { return c.Rparen + 1 }

--- a/parser.go
+++ b/parser.go
@@ -2406,15 +2406,15 @@ func (p *Parser) tryParseGeneratedColumnExpr() *ast.GeneratedColumnExpr {
 		return nil
 	}
 
-	posAs := p.expect("AS").Pos
+	pos := p.expect("AS").Pos
 	p.expect("(")
 	expr := p.parseExpr()
 	p.expect(")")
-	posEnd := p.expectKeywordLike("STORED").End
+	stored := p.expectKeywordLike("STORED").Pos
 
 	return &ast.GeneratedColumnExpr{
-		As:     posAs,
-		Stored: posEnd,
+		As:     pos,
+		Stored: stored,
 		Expr:   expr,
 	}
 }
@@ -3275,7 +3275,7 @@ func (p *Parser) parseSchemaType() ast.SchemaType {
 		pos := p.expect("ARRAY").Pos
 		p.expect("<")
 		t := p.parseScalarSchemaType()
-		end := p.expect(">").End
+		end := p.expect(">").Pos
 		return &ast.ArraySchemaType{
 			Array: pos,
 			Gt:    end,

--- a/testdata/result/ddl/alter_table_add_column_with_if_expression.sql.txt
+++ b/testdata/result/ddl/alter_table_add_column_with_if_expression.sql.txt
@@ -26,7 +26,7 @@ ALTER TABLE foo ADD COLUMN expired_at TIMESTAMP AS (IF (status != "OPEN" AND sta
       DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
       GeneratedExpr: &ast.GeneratedColumnExpr{
         As:     48,
-        Stored: 159,
+        Stored: 153,
         Expr:   &ast.CallExpr{
           Rparen: 150,
           Func:   &ast.Ident{

--- a/testdata/result/ddl/create_table.sql.txt
+++ b/testdata/result/ddl/create_table.sql.txt
@@ -108,7 +108,7 @@ create table foo (
       DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
       GeneratedExpr: &ast.GeneratedColumnExpr{
         As:     150,
-        Stored: 178,
+        Stored: 172,
         Expr:   &ast.CallExpr{
           Rparen: 169,
           Func:   &ast.Ident{

--- a/testdata/result/ddl/create_table_types.sql.txt
+++ b/testdata/result/ddl/create_table_types.sql.txt
@@ -217,7 +217,7 @@ create table types (
       },
       Type: &ast.ArraySchemaType{
         Array: 174,
-        Gt:    185,
+        Gt:    184,
         Item:  &ast.ScalarSchemaType{
           NamePos: 180,
           Name:    "BOOL",
@@ -237,7 +237,7 @@ create table types (
       },
       Type: &ast.ArraySchemaType{
         Array: 193,
-        Gt:    210,
+        Gt:    209,
         Item:  &ast.SizedSchemaType{
           NamePos: 199,
           Rparen:  208,

--- a/testdata/result/statement/alter_table_add_column_with_if_expression.sql.txt
+++ b/testdata/result/statement/alter_table_add_column_with_if_expression.sql.txt
@@ -26,7 +26,7 @@ ALTER TABLE foo ADD COLUMN expired_at TIMESTAMP AS (IF (status != "OPEN" AND sta
       DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
       GeneratedExpr: &ast.GeneratedColumnExpr{
         As:     48,
-        Stored: 159,
+        Stored: 153,
         Expr:   &ast.CallExpr{
           Rparen: 150,
           Func:   &ast.Ident{

--- a/testdata/result/statement/create_table.sql.txt
+++ b/testdata/result/statement/create_table.sql.txt
@@ -108,7 +108,7 @@ create table foo (
       DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
       GeneratedExpr: &ast.GeneratedColumnExpr{
         As:     150,
-        Stored: 178,
+        Stored: 172,
         Expr:   &ast.CallExpr{
           Rparen: 169,
           Func:   &ast.Ident{

--- a/testdata/result/statement/create_table_types.sql.txt
+++ b/testdata/result/statement/create_table_types.sql.txt
@@ -217,7 +217,7 @@ create table types (
       },
       Type: &ast.ArraySchemaType{
         Array: 174,
-        Gt:    185,
+        Gt:    184,
         Item:  &ast.ScalarSchemaType{
           NamePos: 180,
           Name:    "BOOL",
@@ -237,7 +237,7 @@ create table types (
       },
       Type: &ast.ArraySchemaType{
         Array: 193,
-        Gt:    210,
+        Gt:    209,
         Item:  &ast.SizedSchemaType{
           NamePos: 199,
           Rparen:  208,


### PR DESCRIPTION
Related to #149

- This fixes `GeneratedColumnExpr.End()`, and now `Stored` points to the head position of the `STORED` token.
- `ArraySchemeType.Gt` points to the head position of the `>` token.