### PR TITLE
Implement SAFE_CAST in CastExpr

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1159,15 +1159,17 @@ type AtTimeZone struct {
 	Expr Expr
 }
 
-// CastExpr is CAST call expression node.
+// CastExpr is CAST/SAFE_CAST call expression node.
 //
-//	CAST({{.Expr | sql}} AS {{.Type | sql}})
+//	{{if .Safe}}SAFE_{{end}}CAST({{.Expr | sql}} AS {{.Type | sql}})
 type CastExpr struct {
 	// pos = Cast
 	// end = Rparen + 1
 
-	Cast   token.Pos // position of "CAST" keyword
+	Cast   token.Pos // position of "CAST" keyword or "SAFE_CAST" pseudo keyword
 	Rparen token.Pos // position of ")"
+
+	Safe bool
 
 	Expr Expr
 	Type Type

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -555,7 +555,7 @@ func (a *AtTimeZone) SQL() string {
 }
 
 func (c *CastExpr) SQL() string {
-	return "CAST(" + c.Expr.SQL() + " AS " + c.Type.SQL() + ")"
+	return strOpt(c.Safe, "SAFE_") + "CAST(" + c.Expr.SQL() + " AS " + c.Type.SQL() + ")"
 }
 
 func (c *CaseExpr) SQL() string {

--- a/testdata/input/expr/conversion_functions_safe_cast.sql
+++ b/testdata/input/expr/conversion_functions_safe_cast.sql
@@ -1,0 +1,1 @@
+SAFE_CAST("apple" AS INT64)

--- a/testdata/result/expr/cast_as_typename.sql.txt
+++ b/testdata/result/expr/cast_as_typename.sql.txt
@@ -4,6 +4,7 @@ CAST('order_number: "123"' AS examples.shipping.`Order`)
 &ast.CastExpr{
   Cast:   0,
   Rparen: 55,
+  Safe:   false,
   Expr:   &ast.StringLiteral{
     ValuePos: 5,
     ValueEnd: 26,

--- a/testdata/result/expr/conversion_functions_safe_cast.sql.txt
+++ b/testdata/result/expr/conversion_functions_safe_cast.sql.txt
@@ -1,0 +1,20 @@
+--- conversion_functions_safe_cast.sql
+SAFE_CAST("apple" AS INT64)
+--- AST
+&ast.CastExpr{
+  Cast:   0,
+  Rparen: 26,
+  Safe:   true,
+  Expr:   &ast.StringLiteral{
+    ValuePos: 10,
+    ValueEnd: 17,
+    Value:    "apple",
+  },
+  Type: &ast.SimpleType{
+    NamePos: 21,
+    Name:    "INT64",
+  },
+}
+
+--- SQL
+SAFE_CAST("apple" AS INT64)

--- a/testdata/result/query/select_cast.sql.txt
+++ b/testdata/result/query/select_cast.sql.txt
@@ -18,6 +18,7 @@ limit cast(1 as INT64) offset cast(@foo as INT64)
         Expr: &ast.CastExpr{
           Cast:   7,
           Rparen: 22,
+          Safe:   false,
           Expr:   &ast.IntLiteral{
             ValuePos: 12,
             ValueEnd: 13,
@@ -34,6 +35,7 @@ limit cast(1 as INT64) offset cast(@foo as INT64)
         Expr: &ast.CastExpr{
           Cast:   25,
           Rparen: 44,
+          Safe:   false,
           Expr:   &ast.FloatLiteral{
             ValuePos: 30,
             ValueEnd: 33,
@@ -49,6 +51,7 @@ limit cast(1 as INT64) offset cast(@foo as INT64)
         Expr: &ast.CastExpr{
           Cast:   47,
           Rparen: 147,
+          Safe:   false,
           Expr:   &ast.StructLiteral{
             Struct: 0,
             Lparen: 52,

--- a/testdata/result/statement/select_cast.sql.txt
+++ b/testdata/result/statement/select_cast.sql.txt
@@ -18,6 +18,7 @@ limit cast(1 as INT64) offset cast(@foo as INT64)
         Expr: &ast.CastExpr{
           Cast:   7,
           Rparen: 22,
+          Safe:   false,
           Expr:   &ast.IntLiteral{
             ValuePos: 12,
             ValueEnd: 13,
@@ -34,6 +35,7 @@ limit cast(1 as INT64) offset cast(@foo as INT64)
         Expr: &ast.CastExpr{
           Cast:   25,
           Rparen: 44,
+          Safe:   false,
           Expr:   &ast.FloatLiteral{
             ValuePos: 30,
             ValueEnd: 33,
@@ -49,6 +51,7 @@ limit cast(1 as INT64) offset cast(@foo as INT64)
         Expr: &ast.CastExpr{
           Cast:   47,
           Rparen: 147,
+          Safe:   false,
           Expr:   &ast.StructLiteral{
             Struct: 0,
             Lparen: 52,


### PR DESCRIPTION
This PR implements `SAFE_CAST` as `Safe` flag in `CastExpr`.

part of #94 