### PR TITLE
Follow the naming convention for error values

### DIFF
--- a/ast/options.go
+++ b/ast/options.go
@@ -23,11 +23,11 @@ func (o *Options) Field(name string) (expr Expr, found bool) {
 
 // FieldNotFound is returned Options.*Field methods.
 // It can be handled as a non-error.
-var FieldNotFound = errors.New("field not found")
+var ErrFieldNotFound = errors.New("field not found")
 
 // fieldTypeMismatch is only defined for test.
 // It is intentionally unexported.
-var fieldTypeMismatch = errors.New("type mismatched")
+var errFieldTypeMismatch = errors.New("type mismatched")
 
 // BoolField finds name in records, and return its value as *bool.
 // If Options doesn't have a record with name, it returns FieldNotFound error.
@@ -37,7 +37,7 @@ var fieldTypeMismatch = errors.New("type mismatched")
 func (o *Options) BoolField(name string) (*bool, error) {
 	v, ok := o.Field(name)
 	if !ok {
-		return nil, FieldNotFound
+		return nil, ErrFieldNotFound
 	}
 	switch v := v.(type) {
 	case *BoolLiteral:
@@ -45,7 +45,7 @@ func (o *Options) BoolField(name string) (*bool, error) {
 	case *NullLiteral:
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("expect true, false or null, but got unknown type %T: %w", v, fieldTypeMismatch)
+		return nil, fmt.Errorf("expect true, false or null, but got unknown type %T: %w", v, errFieldTypeMismatch)
 	}
 }
 
@@ -57,7 +57,7 @@ func (o *Options) BoolField(name string) (*bool, error) {
 func (o *Options) IntegerField(name string) (*int64, error) {
 	v, ok := o.Field(name)
 	if !ok {
-		return nil, FieldNotFound
+		return nil, ErrFieldNotFound
 	}
 	switch v := v.(type) {
 	case *IntLiteral:
@@ -69,7 +69,7 @@ func (o *Options) IntegerField(name string) (*int64, error) {
 	case *NullLiteral:
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("expect integer or null, but got unknown type %T: %w", v, fieldTypeMismatch)
+		return nil, fmt.Errorf("expect integer or null, but got unknown type %T: %w", v, errFieldTypeMismatch)
 	}
 }
 
@@ -81,7 +81,7 @@ func (o *Options) IntegerField(name string) (*int64, error) {
 func (o *Options) StringField(name string) (*string, error) {
 	v, ok := o.Field(name)
 	if !ok {
-		return nil, FieldNotFound
+		return nil, ErrFieldNotFound
 	}
 	switch v := v.(type) {
 	case *StringLiteral:
@@ -89,6 +89,6 @@ func (o *Options) StringField(name string) (*string, error) {
 	case *NullLiteral:
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("expect string literal or null, but got unknown type %T: %w", v, fieldTypeMismatch)
+		return nil, fmt.Errorf("expect string literal or null, but got unknown type %T: %w", v, errFieldTypeMismatch)
 	}
 }

--- a/ast/options_test.go
+++ b/ast/options_test.go
@@ -2,8 +2,9 @@ package ast
 
 import (
 	"errors"
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestOptions_BoolField(t *testing.T) {
@@ -53,7 +54,7 @@ func TestOptions_BoolField(t *testing.T) {
 			},
 			name:    "bool_option",
 			want:    nil,
-			wantErr: FieldNotFound,
+			wantErr: ErrFieldNotFound,
 		},
 		{
 			desc: "invalid type",
@@ -63,7 +64,7 @@ func TestOptions_BoolField(t *testing.T) {
 				},
 			},
 			name:    "string_option",
-			wantErr: fieldTypeMismatch,
+			wantErr: errFieldTypeMismatch,
 		},
 	}
 
@@ -123,7 +124,7 @@ func TestOptions_StringField(t *testing.T) {
 			},
 			name:    "string_field",
 			want:    nil,
-			wantErr: FieldNotFound,
+			wantErr: ErrFieldNotFound,
 		},
 		{
 			desc: "invalid value",
@@ -133,7 +134,7 @@ func TestOptions_StringField(t *testing.T) {
 				},
 			},
 			name:    "bool_option",
-			wantErr: fieldTypeMismatch,
+			wantErr: errFieldTypeMismatch,
 		},
 	}
 
@@ -193,7 +194,7 @@ func TestOptions_IntegerField(t *testing.T) {
 			},
 			name:    "integer_option",
 			want:    nil,
-			wantErr: FieldNotFound,
+			wantErr: ErrFieldNotFound,
 		},
 		{
 			desc: "invalid value",
@@ -203,7 +204,7 @@ func TestOptions_IntegerField(t *testing.T) {
 				},
 			},
 			name:    "bool_option",
-			wantErr: fieldTypeMismatch,
+			wantErr: errFieldTypeMismatch,
 		},
 	}
 


### PR DESCRIPTION
In many Go libraries, names of error values are prefixed with `Err`. We also follow this convention.