### PR TITLE
Support ADD/DROP SYNONYM and RENAME TO in ALTER TABLE

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -300,6 +300,9 @@ type TableAlteration interface {
 	isTableAlteration()
 }
 
+func (AddSynonym) isTableAlteration()               {}
+func (DropSynonym) isTableAlteration()              {}
+func (RenameTo) isTableAlteration()                 {}
 func (AddColumn) isTableAlteration()                {}
 func (AddTableConstraint) isTableAlteration()       {}
 func (AddRowDeletionPolicy) isTableAlteration()     {}
@@ -1880,6 +1883,42 @@ type AlterChangeStream struct {
 
 	Name                   *Ident
 	ChangeStreamAlteration ChangeStreamAlteration
+}
+
+// AddSynonym is ADD SYNONYM node in ALTER TABLE.
+//
+//	ADD SYNONYM {{.Name | sql}}
+type AddSynonym struct {
+	// pos = Add
+	// end = Name.end
+
+	Add  token.Pos // position of "ADD" pseudo keyword
+	Name *Ident
+}
+
+// DropSynonym is DROP SYNONYM node in ALTER TABLE.
+//
+//	DROP SYNONYM {{.Name | sql}}
+type DropSynonym struct {
+	// pos = Drop
+	// end = Name.end
+
+	Drop token.Pos // position of "DROP" pseudo keyword
+	Name *Ident
+}
+
+
+// RenameTo is DROP TO node in ALTER TABLE.
+//
+//	RENAME TO {{.Name | sql}}{{if .AddSynonym | isnil | not}}, {{.AddSynonym | sql}}{{end}}
+type RenameTo struct {
+	// pos = Rename
+	// end = (AddSynonym ?? Name).end
+
+	Rename token.Pos // position of "RENAME" pseudo keyword
+
+	Name       *Ident
+	AddSynonym *AddSynonym // optional
 }
 
 // AddColumn is ADD COLUMN clause in ALTER TABLE.

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1907,10 +1907,9 @@ type DropSynonym struct {
 	Name *Ident
 }
 
-
 // RenameTo is DROP TO node in ALTER TABLE.
 //
-//	RENAME TO {{.Name | sql}}{{if .AddSynonym | isnil | not}}, {{.AddSynonym | sql}}{{end}}
+//	RENAME TO {{.Name | sql}}{{if .AddSynonym}}, {{.AddSynonym | sql}}{{end}}
 type RenameTo struct {
 	// pos = Rename
 	// end = (AddSynonym ?? Name).end

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1907,7 +1907,7 @@ type DropSynonym struct {
 	Name *Ident
 }
 
-// RenameTo is DROP TO node in ALTER TABLE.
+// RenameTo is RENAME TO node in ALTER TABLE.
 //
 //	RENAME TO {{.Name | sql}}{{if .AddSynonym}}, {{.AddSynonym | sql}}{{end}}
 type RenameTo struct {

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -666,6 +666,15 @@ func (r *RowDeletionPolicy) End() token.Pos {
 func (a *AlterTable) Pos() token.Pos { return a.Alter }
 func (a *AlterTable) End() token.Pos { return a.TableAlteration.End() }
 
+func (s *AddSynonym) Pos() token.Pos { return s.Add }
+func (s *AddSynonym) End() token.Pos { return s.Name.End() }
+
+func (s *DropSynonym) Pos() token.Pos { return s.Drop }
+func (s *DropSynonym) End() token.Pos { return s.Name.End() }
+
+func (t *RenameTo) Pos() token.Pos { return t.Rename }
+func (t *RenameTo) End() token.Pos { return firstValidEnd(t.AddSynonym, t.Name) }
+
 func (a *AddColumn) Pos() token.Pos { return a.Add }
 func (a *AddColumn) End() token.Pos { return a.Column.End() }
 

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -920,6 +920,12 @@ func (a *AlterTable) SQL() string {
 	return "ALTER TABLE " + a.Name.SQL() + " " + a.TableAlteration.SQL()
 }
 
+func (s *AddSynonym) SQL() string { return "ADD SYNONYM " + s.Name.SQL() }
+
+func (s *DropSynonym) SQL() string { return "DROP SYNONYM " + s.Name.SQL() }
+
+func (t *RenameTo) SQL() string { return "RENAME TO " + t.Name.SQL() + sqlOpt(", ", t.AddSynonym, "") }
+
 func (a *AddColumn) SQL() string {
 	sql := "ADD COLUMN "
 	if a.IfNotExists {

--- a/parser.go
+++ b/parser.go
@@ -2818,6 +2818,8 @@ func (p *Parser) parseAlterTable(pos token.Pos) *ast.AlterTable {
 		alteration = p.parseAlterTableAdd()
 	case p.Token.IsKeywordLike("DROP"):
 		alteration = p.parseAlterTableDrop()
+	case p.Token.IsKeywordLike("RENAME"):
+		alteration = p.parseAlterTableRename()
 	case p.Token.IsKeywordLike("REPLACE"):
 		alteration = p.parseAlterTableReplace()
 	case p.Token.Kind == "SET":
@@ -2839,12 +2841,24 @@ func (p *Parser) parseAlterTable(pos token.Pos) *ast.AlterTable {
 	}
 }
 
+func (p *Parser) parseAddSynonym(add token.Pos) *ast.AddSynonym {
+	p.expectKeywordLike("SYNONYM")
+	name := p.parseIdent()
+
+	return &ast.AddSynonym{
+		Add:  add,
+		Name: name,
+	}
+}
+
 func (p *Parser) parseAlterTableAdd() ast.TableAlteration {
 	pos := p.expectKeywordLike("ADD").Pos
 
 	var alteration ast.TableAlteration
 
 	switch {
+	case p.Token.IsKeywordLike("SYNONYM"):
+		alteration = p.parseAddSynonym(pos)
 	case p.Token.IsKeywordLike("COLUMN"):
 		p.expectKeywordLike("COLUMN")
 		ifNotExists := p.parseIfNotExists()
@@ -2895,6 +2909,13 @@ func (p *Parser) parseAlterTableDrop() ast.TableAlteration {
 	var alteration ast.TableAlteration
 
 	switch {
+	case p.Token.IsKeywordLike("SYNONYM"):
+		p.expectKeywordLike("SYNONYM")
+		name := p.parseIdent()
+		alteration = &ast.DropSynonym{
+			Drop: pos,
+			Name: name,
+		}
 	case p.Token.IsKeywordLike("COLUMN"):
 		p.expectKeywordLike("COLUMN")
 		name := p.parseIdent()
@@ -2922,6 +2943,25 @@ func (p *Parser) parseAlterTableDrop() ast.TableAlteration {
 	}
 
 	return alteration
+}
+
+func (p *Parser) parseAlterTableRename() ast.TableAlteration {
+	pos := p.expectKeywordLike("RENAME").Pos
+	p.expect("TO")
+	name := p.parseIdent()
+
+	var addSynonym *ast.AddSynonym
+	if p.Token.Kind == "," {
+		p.nextToken()
+		add := p.expectKeywordLike("ADD").Pos
+		addSynonym = p.parseAddSynonym(add)
+	}
+
+	return &ast.RenameTo{
+		Rename:     pos,
+		Name:       name,
+		AddSynonym: addSynonym,
+	}
 }
 
 func (p *Parser) parseAlterTableReplace() ast.TableAlteration {

--- a/testdata/input/ddl/alter_table_add_synonym.sql
+++ b/testdata/input/ddl/alter_table_add_synonym.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Singers ADD SYNONYM SingersTest

--- a/testdata/input/ddl/alter_table_drop_synonym.sql
+++ b/testdata/input/ddl/alter_table_drop_synonym.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Singers DROP SYNONYM SingersTest

--- a/testdata/input/ddl/alter_table_rename_to.sql
+++ b/testdata/input/ddl/alter_table_rename_to.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Singers RENAME TO SingersNew

--- a/testdata/input/ddl/alter_table_rename_to_add_synonym.sql
+++ b/testdata/input/ddl/alter_table_rename_to_add_synonym.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Singers RENAME TO SingersNew, ADD SYNONYM Singers

--- a/testdata/result/ddl/alter_table_add_synonym.sql.txt
+++ b/testdata/result/ddl/alter_table_add_synonym.sql.txt
@@ -1,0 +1,22 @@
+--- alter_table_add_synonym.sql
+ALTER TABLE Singers ADD SYNONYM SingersTest
+--- AST
+&ast.AlterTable{
+  Alter: 0,
+  Name:  &ast.Ident{
+    NamePos: 12,
+    NameEnd: 19,
+    Name:    "Singers",
+  },
+  TableAlteration: &ast.AddSynonym{
+    Add:  20,
+    Name: &ast.Ident{
+      NamePos: 32,
+      NameEnd: 43,
+      Name:    "SingersTest",
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE Singers ADD SYNONYM SingersTest

--- a/testdata/result/ddl/alter_table_drop_synonym.sql.txt
+++ b/testdata/result/ddl/alter_table_drop_synonym.sql.txt
@@ -1,0 +1,22 @@
+--- alter_table_drop_synonym.sql
+ALTER TABLE Singers DROP SYNONYM SingersTest
+--- AST
+&ast.AlterTable{
+  Alter: 0,
+  Name:  &ast.Ident{
+    NamePos: 12,
+    NameEnd: 19,
+    Name:    "Singers",
+  },
+  TableAlteration: &ast.DropSynonym{
+    Drop: 20,
+    Name: &ast.Ident{
+      NamePos: 33,
+      NameEnd: 44,
+      Name:    "SingersTest",
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE Singers DROP SYNONYM SingersTest

--- a/testdata/result/ddl/alter_table_rename_to.sql.txt
+++ b/testdata/result/ddl/alter_table_rename_to.sql.txt
@@ -1,0 +1,23 @@
+--- alter_table_rename_to.sql
+ALTER TABLE Singers RENAME TO SingersNew
+--- AST
+&ast.AlterTable{
+  Alter: 0,
+  Name:  &ast.Ident{
+    NamePos: 12,
+    NameEnd: 19,
+    Name:    "Singers",
+  },
+  TableAlteration: &ast.RenameTo{
+    Rename: 20,
+    Name:   &ast.Ident{
+      NamePos: 30,
+      NameEnd: 40,
+      Name:    "SingersNew",
+    },
+    AddSynonym: (*ast.AddSynonym)(nil),
+  },
+}
+
+--- SQL
+ALTER TABLE Singers RENAME TO SingersNew

--- a/testdata/result/ddl/alter_table_rename_to_add_synonym.sql.txt
+++ b/testdata/result/ddl/alter_table_rename_to_add_synonym.sql.txt
@@ -1,0 +1,30 @@
+--- alter_table_rename_to_add_synonym.sql
+ALTER TABLE Singers RENAME TO SingersNew, ADD SYNONYM Singers
+--- AST
+&ast.AlterTable{
+  Alter: 0,
+  Name:  &ast.Ident{
+    NamePos: 12,
+    NameEnd: 19,
+    Name:    "Singers",
+  },
+  TableAlteration: &ast.RenameTo{
+    Rename: 20,
+    Name:   &ast.Ident{
+      NamePos: 30,
+      NameEnd: 40,
+      Name:    "SingersNew",
+    },
+    AddSynonym: &ast.AddSynonym{
+      Add:  42,
+      Name: &ast.Ident{
+        NamePos: 54,
+        NameEnd: 61,
+        Name:    "Singers",
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE Singers RENAME TO SingersNew, ADD SYNONYM Singers

--- a/testdata/result/statement/alter_table_add_synonym.sql.txt
+++ b/testdata/result/statement/alter_table_add_synonym.sql.txt
@@ -1,0 +1,22 @@
+--- alter_table_add_synonym.sql
+ALTER TABLE Singers ADD SYNONYM SingersTest
+--- AST
+&ast.AlterTable{
+  Alter: 0,
+  Name:  &ast.Ident{
+    NamePos: 12,
+    NameEnd: 19,
+    Name:    "Singers",
+  },
+  TableAlteration: &ast.AddSynonym{
+    Add:  20,
+    Name: &ast.Ident{
+      NamePos: 32,
+      NameEnd: 43,
+      Name:    "SingersTest",
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE Singers ADD SYNONYM SingersTest

--- a/testdata/result/statement/alter_table_drop_synonym.sql.txt
+++ b/testdata/result/statement/alter_table_drop_synonym.sql.txt
@@ -1,0 +1,22 @@
+--- alter_table_drop_synonym.sql
+ALTER TABLE Singers DROP SYNONYM SingersTest
+--- AST
+&ast.AlterTable{
+  Alter: 0,
+  Name:  &ast.Ident{
+    NamePos: 12,
+    NameEnd: 19,
+    Name:    "Singers",
+  },
+  TableAlteration: &ast.DropSynonym{
+    Drop: 20,
+    Name: &ast.Ident{
+      NamePos: 33,
+      NameEnd: 44,
+      Name:    "SingersTest",
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE Singers DROP SYNONYM SingersTest

--- a/testdata/result/statement/alter_table_rename_to.sql.txt
+++ b/testdata/result/statement/alter_table_rename_to.sql.txt
@@ -1,0 +1,23 @@
+--- alter_table_rename_to.sql
+ALTER TABLE Singers RENAME TO SingersNew
+--- AST
+&ast.AlterTable{
+  Alter: 0,
+  Name:  &ast.Ident{
+    NamePos: 12,
+    NameEnd: 19,
+    Name:    "Singers",
+  },
+  TableAlteration: &ast.RenameTo{
+    Rename: 20,
+    Name:   &ast.Ident{
+      NamePos: 30,
+      NameEnd: 40,
+      Name:    "SingersNew",
+    },
+    AddSynonym: (*ast.AddSynonym)(nil),
+  },
+}
+
+--- SQL
+ALTER TABLE Singers RENAME TO SingersNew

--- a/testdata/result/statement/alter_table_rename_to_add_synonym.sql.txt
+++ b/testdata/result/statement/alter_table_rename_to_add_synonym.sql.txt
@@ -1,0 +1,30 @@
+--- alter_table_rename_to_add_synonym.sql
+ALTER TABLE Singers RENAME TO SingersNew, ADD SYNONYM Singers
+--- AST
+&ast.AlterTable{
+  Alter: 0,
+  Name:  &ast.Ident{
+    NamePos: 12,
+    NameEnd: 19,
+    Name:    "Singers",
+  },
+  TableAlteration: &ast.RenameTo{
+    Rename: 20,
+    Name:   &ast.Ident{
+      NamePos: 30,
+      NameEnd: 40,
+      Name:    "SingersNew",
+    },
+    AddSynonym: &ast.AddSynonym{
+      Add:  42,
+      Name: &ast.Ident{
+        NamePos: 54,
+        NameEnd: 61,
+        Name:    "Singers",
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE Singers RENAME TO SingersNew, ADD SYNONYM Singers


### PR DESCRIPTION
This PR implements table renaming and synonyms `ALTER TABLE` actions:

* `ADD SYNONYM`
* `DROP SYNONYM`
* `RENAME TO [, ADD SYNONYM]`

fixes #128 
fixes #129 