### PR TITLE
Implement SYNONYM in CREATE TABLE

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1653,9 +1653,11 @@ type CreateTable struct {
 //	SYNONYM ({.Name | sql})
 type Synonym struct {
 	// pos = Synonym
-	// end = Name.end
+	// end = Rparen + 1
+
 	Synonym token.Pos // position of "SYNONYM" pseudo keyword
-	Rparen  token.Pos
+	Rparen  token.Pos // position of ")"
+
 	Name    *Ident
 }
 

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1620,15 +1620,16 @@ type CreateDatabase struct {
 // CreateTable is CREATE TABLE statement node.
 //
 //	CREATE TABLE {{if .IfNotExists}}IF NOT EXISTS{{end}} {{.Name | sql}} (
-//	  {{.Columns | sqlJoin ","}}
-//	  {{if and .Columns .TableConstrains}},{{end}}{{.TableConstraints | sqlJoin ","}}
+//	  {{.Columns | sqlJoin ","}}{{if and .Columns (or .TableConstrains .Synonym)}},{{end}}
+//	  {{.TableConstraints | sqlJoin ","}}{{if and .TableConstraints .Synonym}},{{end}}
+//	  {{.Synonym | sqlJoin ","}}
 //	)
 //	PRIMARY KEY ({{.PrimaryKeys | sqlJoin ","}})
 //	{{.Cluster | sqlOpt}}
 //	{{.CreateRowDeletionPolicy | sqlOpt}}
 //
-// Spanner SQL allows to mix `Columns` and `TableConstraints`, however they are
-// separated in AST definition for historical reasons. If you want to get
+// Spanner SQL allows to mix `Columns` and `TableConstraints` and `Synonyms`,
+// however they are separated in AST definition for historical reasons. If you want to get
 // the original order of them, please sort them by their `Pos()`.
 type CreateTable struct {
 	// pos = Create
@@ -1642,8 +1643,20 @@ type CreateTable struct {
 	Columns           []*ColumnDef
 	TableConstraints  []*TableConstraint
 	PrimaryKeys       []*IndexKey
+	Synonyms          []*Synonym
 	Cluster           *Cluster                 // optional
 	RowDeletionPolicy *CreateRowDeletionPolicy // optional
+}
+
+// Synonym is SYNONYM node in CREATE TABLE
+//
+//	SYNONYM ({.Name | sql})
+type Synonym struct {
+	// pos = Synonym
+	// end = Name.end
+	Synonym token.Pos // position of "SYNONYM" pseudo keyword
+	Rparen  token.Pos
+	Name    *Ident
 }
 
 // CreateSequence is CREATE SEQUENCE statement node.

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -559,7 +559,7 @@ func (c *CreateTable) End() token.Pos {
 }
 
 func (s *Synonym) Pos() token.Pos { return s.Synonym }
-func (s *Synonym) End() token.Pos { return s.Name.End() }
+func (s *Synonym) End() token.Pos { return s.Rparen + 1 }
 
 func (c *CreateSequence) Pos() token.Pos {
 	return c.Create

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -558,6 +558,9 @@ func (c *CreateTable) End() token.Pos {
 	return c.Rparen + 1
 }
 
+func (s *Synonym) Pos() token.Pos { return s.Synonym }
+func (s *Synonym) End() token.Pos { return s.Name.End() }
+
 func (c *CreateSequence) Pos() token.Pos {
 	return c.Create
 }

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -785,7 +785,7 @@ func (c *CreateTable) SQL() string {
 		sqlOpt("", c.RowDeletionPolicy, "")
 }
 
-func (s *Synonym) SQL() string { return "SYNONYM (" + s.Name.SQL() + " )" }
+func (s *Synonym) SQL() string { return "SYNONYM (" + s.Name.SQL() + ")" }
 
 func (c *CreateSequence) SQL() string {
 	sql := "CREATE SEQUENCE "

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -774,37 +774,18 @@ func (c *CreateDatabase) SQL() string {
 }
 
 func (c *CreateTable) SQL() string {
-	sql := "CREATE TABLE "
-	if c.IfNotExists {
-		sql += "IF NOT EXISTS "
-	}
-	sql += c.Name.SQL() + " ("
-	for i, c := range c.Columns {
-		if i != 0 {
-			sql += ", "
-		}
-		sql += c.SQL()
-	}
-	for _, c := range c.TableConstraints {
-		sql += ", " + c.SQL()
-	}
-	sql += ") "
-	sql += "PRIMARY KEY ("
-	for i, k := range c.PrimaryKeys {
-		if i != 0 {
-			sql += ", "
-		}
-		sql += k.SQL()
-	}
-	sql += ")"
-	if c.Cluster != nil {
-		sql += c.Cluster.SQL()
-	}
-	if c.RowDeletionPolicy != nil {
-		sql += c.RowDeletionPolicy.SQL()
-	}
-	return sql
+	return "CREATE TABLE " +
+		strOpt(c.IfNotExists, "IF NOT EXISTS ") +
+		c.Name.SQL() + " (" +
+		sqlJoin(c.Columns, ", ") + strOpt(len(c.Columns) > 0 && (len(c.TableConstraints) > 0 || len(c.Synonyms) > 0), ", ") +
+		sqlJoin(c.TableConstraints, ", ") + strOpt(len(c.TableConstraints) > 0 && len(c.Synonyms) > 0, ", ") +
+		sqlJoin(c.Synonyms, ", ") +
+		") PRIMARY KEY (" + sqlJoin(c.PrimaryKeys, ", ") + ")" +
+		sqlOpt("", c.Cluster, "") +
+		sqlOpt("", c.RowDeletionPolicy, "")
 }
+
+func (s *Synonym) SQL() string { return "SYNONYM (" + s.Name.SQL() + " )" }
 
 func (c *CreateSequence) SQL() string {
 	sql := "CREATE SEQUENCE "

--- a/parser.go
+++ b/parser.go
@@ -2219,6 +2219,7 @@ func (p *Parser) parseCreateTable(pos token.Pos) *ast.CreateTable {
 	p.expect("(")
 	var columns []*ast.ColumnDef
 	var constraints []*ast.TableConstraint
+	var synonyms []*ast.Synonym
 	for p.Token.Kind != token.TokenEOF {
 		if p.Token.Kind == ")" {
 			break
@@ -2238,6 +2239,9 @@ func (p *Parser) parseCreateTable(pos token.Pos) *ast.CreateTable {
 				ConstraintPos: token.InvalidPos,
 				Constraint:    c,
 			})
+		case p.Token.IsKeywordLike("SYNONYM"):
+			synonym := p.parseSynonym()
+			synonyms = append(synonyms, synonym)
 		default:
 			columns = append(columns, p.parseColumnDef())
 		}
@@ -2275,6 +2279,7 @@ func (p *Parser) parseCreateTable(pos token.Pos) *ast.CreateTable {
 		Name:              name,
 		Columns:           columns,
 		TableConstraints:  constraints,
+		Synonyms:          synonyms,
 		PrimaryKeys:       keys,
 		Cluster:           cluster,
 		RowDeletionPolicy: rdp,
@@ -2416,6 +2421,19 @@ func (p *Parser) parseCheck() *ast.Check {
 		Check:  pos,
 		Rparen: rparen,
 		Expr:   expr,
+	}
+}
+
+func (p *Parser) parseSynonym() *ast.Synonym {
+	pos := p.expectKeywordLike("SYNONYM").Pos
+	p.expect("(")
+	name := p.parseIdent()
+	rparen := p.expect(")").Pos
+
+	return &ast.Synonym{
+		Synonym: pos,
+		Rparen:  rparen,
+		Name:    name,
 	}
 }
 

--- a/testdata/input/ddl/create_table_synonyms.sql
+++ b/testdata/input/ddl/create_table_synonyms.sql
@@ -1,0 +1,5 @@
+CREATE TABLE Singers (
+    SingerId INT64 NOT NULL,
+    SingerName STRING(1024),
+    SYNONYM (Artists)
+) PRIMARY KEY (SingerId)

--- a/testdata/input/ddl/create_table_synonyms_abnormal.sql
+++ b/testdata/input/ddl/create_table_synonyms_abnormal.sql
@@ -1,0 +1,7 @@
+-- It is still valid CREATE TABLE statement.
+CREATE TABLE Singers (
+    SYNONYM (Ignored),
+    SingerId INT64 NOT NULL,
+    SingerName STRING(1024),
+    SYNONYM (Artists)
+) PRIMARY KEY (SingerId)

--- a/testdata/result/ddl/create_table.sql.txt
+++ b/testdata/result/ddl/create_table.sql.txt
@@ -400,6 +400,7 @@ create table foo (
       Dir: "",
     },
   },
+  Synonyms:          []*ast.Synonym(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }

--- a/testdata/result/ddl/create_table_cluster.sql.txt
+++ b/testdata/result/ddl/create_table_cluster.sql.txt
@@ -51,6 +51,7 @@ create table foo (
   },
   TableConstraints: []*ast.TableConstraint(nil),
   PrimaryKeys:      []*ast.IndexKey(nil),
+  Synonyms:         []*ast.Synonym(nil),
   Cluster:          &ast.Cluster{
     Comma:       60,
     OnDeleteEnd: -1,

--- a/testdata/result/ddl/create_table_cluster_and_row_deletion_policy.sql.txt
+++ b/testdata/result/ddl/create_table_cluster_and_row_deletion_policy.sql.txt
@@ -69,6 +69,7 @@ create table foo (
   },
   TableConstraints: []*ast.TableConstraint(nil),
   PrimaryKeys:      []*ast.IndexKey(nil),
+  Synonyms:         []*ast.Synonym(nil),
   Cluster:          &ast.Cluster{
     Comma:       78,
     OnDeleteEnd: -1,

--- a/testdata/result/ddl/create_table_cluster_on_delete_no_action.sql.txt
+++ b/testdata/result/ddl/create_table_cluster_on_delete_no_action.sql.txt
@@ -44,7 +44,8 @@ create table foo (
       Dir: "",
     },
   },
-  Cluster: &ast.Cluster{
+  Synonyms: []*ast.Synonym(nil),
+  Cluster:  &ast.Cluster{
     Comma:       51,
     OnDeleteEnd: 115,
     TableName:   &ast.Ident{

--- a/testdata/result/ddl/create_table_cluster_set_on_delete.sql.txt
+++ b/testdata/result/ddl/create_table_cluster_set_on_delete.sql.txt
@@ -44,7 +44,8 @@ create table foo (
       Dir: "",
     },
   },
-  Cluster: &ast.Cluster{
+  Synonyms: []*ast.Synonym(nil),
+  Cluster:  &ast.Cluster{
     Comma:       50,
     OnDeleteEnd: 112,
     TableName:   &ast.Ident{

--- a/testdata/result/ddl/create_table_if_not_exists.sql.txt
+++ b/testdata/result/ddl/create_table_if_not_exists.sql.txt
@@ -69,6 +69,7 @@ create table if not exists foo (
       Dir: "",
     },
   },
+  Synonyms:          []*ast.Synonym(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }

--- a/testdata/result/ddl/create_table_row_deletion_policy.sql.txt
+++ b/testdata/result/ddl/create_table_row_deletion_policy.sql.txt
@@ -68,6 +68,7 @@ create table foo (
   },
   TableConstraints:  []*ast.TableConstraint(nil),
   PrimaryKeys:       []*ast.IndexKey(nil),
+  Synonyms:          []*ast.Synonym(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: &ast.CreateRowDeletionPolicy{
     Comma:             78,

--- a/testdata/result/ddl/create_table_synonyms.sql.txt
+++ b/testdata/result/ddl/create_table_synonyms.sql.txt
@@ -1,0 +1,87 @@
+--- create_table_synonyms.sql
+CREATE TABLE Singers (
+    SingerId INT64 NOT NULL,
+    SingerName STRING(1024),
+    SYNONYM (Artists)
+) PRIMARY KEY (SingerId)
+--- AST
+&ast.CreateTable{
+  Create:      0,
+  Rparen:      126,
+  IfNotExists: false,
+  Name:        &ast.Ident{
+    NamePos: 13,
+    NameEnd: 20,
+    Name:    "Singers",
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: 46,
+      Name: &ast.Ident{
+        NamePos: 27,
+        NameEnd: 35,
+        Name:    "SingerId",
+      },
+      Type: &ast.ScalarSchemaType{
+        NamePos: 36,
+        Name:    "INT64",
+      },
+      NotNull:       true,
+      DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
+      GeneratedExpr: (*ast.GeneratedColumnExpr)(nil),
+      Options:       (*ast.Options)(nil),
+    },
+    &ast.ColumnDef{
+      Null: -1,
+      Name: &ast.Ident{
+        NamePos: 56,
+        NameEnd: 66,
+        Name:    "SingerName",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 67,
+        Rparen:  78,
+        Name:    "STRING",
+        Max:     false,
+        Size:    &ast.IntLiteral{
+          ValuePos: 74,
+          ValueEnd: 78,
+          Base:     10,
+          Value:    "1024",
+        },
+      },
+      NotNull:       false,
+      DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
+      GeneratedExpr: (*ast.GeneratedColumnExpr)(nil),
+      Options:       (*ast.Options)(nil),
+    },
+  },
+  TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 118,
+        NameEnd: 126,
+        Name:    "SingerId",
+      },
+      Dir: "",
+    },
+  },
+  Synonyms: []*ast.Synonym{
+    &ast.Synonym{
+      Synonym: 85,
+      Rparen:  101,
+      Name:    &ast.Ident{
+        NamePos: 94,
+        NameEnd: 101,
+        Name:    "Artists",
+      },
+    },
+  },
+  Cluster:           (*ast.Cluster)(nil),
+  RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
+}
+
+--- SQL
+CREATE TABLE Singers (SingerId INT64 NOT NULL, SingerName STRING(1024), SYNONYM (Artists )) PRIMARY KEY (SingerId)

--- a/testdata/result/ddl/create_table_synonyms.sql.txt
+++ b/testdata/result/ddl/create_table_synonyms.sql.txt
@@ -84,4 +84,4 @@ CREATE TABLE Singers (
 }
 
 --- SQL
-CREATE TABLE Singers (SingerId INT64 NOT NULL, SingerName STRING(1024), SYNONYM (Artists )) PRIMARY KEY (SingerId)
+CREATE TABLE Singers (SingerId INT64 NOT NULL, SingerName STRING(1024), SYNONYM (Artists)) PRIMARY KEY (SingerId)

--- a/testdata/result/ddl/create_table_synonyms_abnormal.sql.txt
+++ b/testdata/result/ddl/create_table_synonyms_abnormal.sql.txt
@@ -1,0 +1,98 @@
+--- create_table_synonyms_abnormal.sql
+-- It is still valid CREATE TABLE statement.
+CREATE TABLE Singers (
+    SYNONYM (Ignored),
+    SingerId INT64 NOT NULL,
+    SingerName STRING(1024),
+    SYNONYM (Artists)
+) PRIMARY KEY (SingerId)
+--- AST
+&ast.CreateTable{
+  Create:      45,
+  Rparen:      194,
+  IfNotExists: false,
+  Name:        &ast.Ident{
+    NamePos: 58,
+    NameEnd: 65,
+    Name:    "Singers",
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: 114,
+      Name: &ast.Ident{
+        NamePos: 95,
+        NameEnd: 103,
+        Name:    "SingerId",
+      },
+      Type: &ast.ScalarSchemaType{
+        NamePos: 104,
+        Name:    "INT64",
+      },
+      NotNull:       true,
+      DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
+      GeneratedExpr: (*ast.GeneratedColumnExpr)(nil),
+      Options:       (*ast.Options)(nil),
+    },
+    &ast.ColumnDef{
+      Null: -1,
+      Name: &ast.Ident{
+        NamePos: 124,
+        NameEnd: 134,
+        Name:    "SingerName",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 135,
+        Rparen:  146,
+        Name:    "STRING",
+        Max:     false,
+        Size:    &ast.IntLiteral{
+          ValuePos: 142,
+          ValueEnd: 146,
+          Base:     10,
+          Value:    "1024",
+        },
+      },
+      NotNull:       false,
+      DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
+      GeneratedExpr: (*ast.GeneratedColumnExpr)(nil),
+      Options:       (*ast.Options)(nil),
+    },
+  },
+  TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 186,
+        NameEnd: 194,
+        Name:    "SingerId",
+      },
+      Dir: "",
+    },
+  },
+  Synonyms: []*ast.Synonym{
+    &ast.Synonym{
+      Synonym: 72,
+      Rparen:  88,
+      Name:    &ast.Ident{
+        NamePos: 81,
+        NameEnd: 88,
+        Name:    "Ignored",
+      },
+    },
+    &ast.Synonym{
+      Synonym: 153,
+      Rparen:  169,
+      Name:    &ast.Ident{
+        NamePos: 162,
+        NameEnd: 169,
+        Name:    "Artists",
+      },
+    },
+  },
+  Cluster:           (*ast.Cluster)(nil),
+  RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
+}
+
+--- SQL
+CREATE TABLE Singers (SingerId INT64 NOT NULL, SingerName STRING(1024), SYNONYM (Ignored ), SYNONYM (Artists )) PRIMARY KEY (SingerId)

--- a/testdata/result/ddl/create_table_synonyms_abnormal.sql.txt
+++ b/testdata/result/ddl/create_table_synonyms_abnormal.sql.txt
@@ -95,4 +95,4 @@ CREATE TABLE Singers (
 }
 
 --- SQL
-CREATE TABLE Singers (SingerId INT64 NOT NULL, SingerName STRING(1024), SYNONYM (Ignored ), SYNONYM (Artists )) PRIMARY KEY (SingerId)
+CREATE TABLE Singers (SingerId INT64 NOT NULL, SingerName STRING(1024), SYNONYM (Ignored), SYNONYM (Artists)) PRIMARY KEY (SingerId)

--- a/testdata/result/ddl/create_table_trailing_comma.sql.txt
+++ b/testdata/result/ddl/create_table_trailing_comma.sql.txt
@@ -72,6 +72,7 @@ create table foo (
       Dir: "DESC",
     },
   },
+  Synonyms:          []*ast.Synonym(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }

--- a/testdata/result/ddl/create_table_types.sql.txt
+++ b/testdata/result/ddl/create_table_types.sql.txt
@@ -290,6 +290,7 @@ create table types (
       Dir: "",
     },
   },
+  Synonyms:          []*ast.Synonym(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }

--- a/testdata/result/ddl/create_table_with_sequence_function.sql.txt
+++ b/testdata/result/ddl/create_table_with_sequence_function.sql.txt
@@ -106,6 +106,7 @@ CREATE TABLE foo
       Dir: "",
     },
   },
+  Synonyms:          []*ast.Synonym(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }

--- a/testdata/result/statement/create_table.sql.txt
+++ b/testdata/result/statement/create_table.sql.txt
@@ -400,6 +400,7 @@ create table foo (
       Dir: "",
     },
   },
+  Synonyms:          []*ast.Synonym(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }

--- a/testdata/result/statement/create_table_cluster.sql.txt
+++ b/testdata/result/statement/create_table_cluster.sql.txt
@@ -51,6 +51,7 @@ create table foo (
   },
   TableConstraints: []*ast.TableConstraint(nil),
   PrimaryKeys:      []*ast.IndexKey(nil),
+  Synonyms:         []*ast.Synonym(nil),
   Cluster:          &ast.Cluster{
     Comma:       60,
     OnDeleteEnd: -1,

--- a/testdata/result/statement/create_table_cluster_and_row_deletion_policy.sql.txt
+++ b/testdata/result/statement/create_table_cluster_and_row_deletion_policy.sql.txt
@@ -69,6 +69,7 @@ create table foo (
   },
   TableConstraints: []*ast.TableConstraint(nil),
   PrimaryKeys:      []*ast.IndexKey(nil),
+  Synonyms:         []*ast.Synonym(nil),
   Cluster:          &ast.Cluster{
     Comma:       78,
     OnDeleteEnd: -1,

--- a/testdata/result/statement/create_table_cluster_on_delete_no_action.sql.txt
+++ b/testdata/result/statement/create_table_cluster_on_delete_no_action.sql.txt
@@ -44,7 +44,8 @@ create table foo (
       Dir: "",
     },
   },
-  Cluster: &ast.Cluster{
+  Synonyms: []*ast.Synonym(nil),
+  Cluster:  &ast.Cluster{
     Comma:       51,
     OnDeleteEnd: 115,
     TableName:   &ast.Ident{

--- a/testdata/result/statement/create_table_cluster_set_on_delete.sql.txt
+++ b/testdata/result/statement/create_table_cluster_set_on_delete.sql.txt
@@ -44,7 +44,8 @@ create table foo (
       Dir: "",
     },
   },
-  Cluster: &ast.Cluster{
+  Synonyms: []*ast.Synonym(nil),
+  Cluster:  &ast.Cluster{
     Comma:       50,
     OnDeleteEnd: 112,
     TableName:   &ast.Ident{

--- a/testdata/result/statement/create_table_if_not_exists.sql.txt
+++ b/testdata/result/statement/create_table_if_not_exists.sql.txt
@@ -69,6 +69,7 @@ create table if not exists foo (
       Dir: "",
     },
   },
+  Synonyms:          []*ast.Synonym(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }

--- a/testdata/result/statement/create_table_row_deletion_policy.sql.txt
+++ b/testdata/result/statement/create_table_row_deletion_policy.sql.txt
@@ -68,6 +68,7 @@ create table foo (
   },
   TableConstraints:  []*ast.TableConstraint(nil),
   PrimaryKeys:       []*ast.IndexKey(nil),
+  Synonyms:          []*ast.Synonym(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: &ast.CreateRowDeletionPolicy{
     Comma:             78,

--- a/testdata/result/statement/create_table_synonyms.sql.txt
+++ b/testdata/result/statement/create_table_synonyms.sql.txt
@@ -1,0 +1,87 @@
+--- create_table_synonyms.sql
+CREATE TABLE Singers (
+    SingerId INT64 NOT NULL,
+    SingerName STRING(1024),
+    SYNONYM (Artists)
+) PRIMARY KEY (SingerId)
+--- AST
+&ast.CreateTable{
+  Create:      0,
+  Rparen:      126,
+  IfNotExists: false,
+  Name:        &ast.Ident{
+    NamePos: 13,
+    NameEnd: 20,
+    Name:    "Singers",
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: 46,
+      Name: &ast.Ident{
+        NamePos: 27,
+        NameEnd: 35,
+        Name:    "SingerId",
+      },
+      Type: &ast.ScalarSchemaType{
+        NamePos: 36,
+        Name:    "INT64",
+      },
+      NotNull:       true,
+      DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
+      GeneratedExpr: (*ast.GeneratedColumnExpr)(nil),
+      Options:       (*ast.Options)(nil),
+    },
+    &ast.ColumnDef{
+      Null: -1,
+      Name: &ast.Ident{
+        NamePos: 56,
+        NameEnd: 66,
+        Name:    "SingerName",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 67,
+        Rparen:  78,
+        Name:    "STRING",
+        Max:     false,
+        Size:    &ast.IntLiteral{
+          ValuePos: 74,
+          ValueEnd: 78,
+          Base:     10,
+          Value:    "1024",
+        },
+      },
+      NotNull:       false,
+      DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
+      GeneratedExpr: (*ast.GeneratedColumnExpr)(nil),
+      Options:       (*ast.Options)(nil),
+    },
+  },
+  TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 118,
+        NameEnd: 126,
+        Name:    "SingerId",
+      },
+      Dir: "",
+    },
+  },
+  Synonyms: []*ast.Synonym{
+    &ast.Synonym{
+      Synonym: 85,
+      Rparen:  101,
+      Name:    &ast.Ident{
+        NamePos: 94,
+        NameEnd: 101,
+        Name:    "Artists",
+      },
+    },
+  },
+  Cluster:           (*ast.Cluster)(nil),
+  RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
+}
+
+--- SQL
+CREATE TABLE Singers (SingerId INT64 NOT NULL, SingerName STRING(1024), SYNONYM (Artists )) PRIMARY KEY (SingerId)

--- a/testdata/result/statement/create_table_synonyms.sql.txt
+++ b/testdata/result/statement/create_table_synonyms.sql.txt
@@ -84,4 +84,4 @@ CREATE TABLE Singers (
 }
 
 --- SQL
-CREATE TABLE Singers (SingerId INT64 NOT NULL, SingerName STRING(1024), SYNONYM (Artists )) PRIMARY KEY (SingerId)
+CREATE TABLE Singers (SingerId INT64 NOT NULL, SingerName STRING(1024), SYNONYM (Artists)) PRIMARY KEY (SingerId)

--- a/testdata/result/statement/create_table_synonyms_abnormal.sql.txt
+++ b/testdata/result/statement/create_table_synonyms_abnormal.sql.txt
@@ -1,0 +1,98 @@
+--- create_table_synonyms_abnormal.sql
+-- It is still valid CREATE TABLE statement.
+CREATE TABLE Singers (
+    SYNONYM (Ignored),
+    SingerId INT64 NOT NULL,
+    SingerName STRING(1024),
+    SYNONYM (Artists)
+) PRIMARY KEY (SingerId)
+--- AST
+&ast.CreateTable{
+  Create:      45,
+  Rparen:      194,
+  IfNotExists: false,
+  Name:        &ast.Ident{
+    NamePos: 58,
+    NameEnd: 65,
+    Name:    "Singers",
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: 114,
+      Name: &ast.Ident{
+        NamePos: 95,
+        NameEnd: 103,
+        Name:    "SingerId",
+      },
+      Type: &ast.ScalarSchemaType{
+        NamePos: 104,
+        Name:    "INT64",
+      },
+      NotNull:       true,
+      DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
+      GeneratedExpr: (*ast.GeneratedColumnExpr)(nil),
+      Options:       (*ast.Options)(nil),
+    },
+    &ast.ColumnDef{
+      Null: -1,
+      Name: &ast.Ident{
+        NamePos: 124,
+        NameEnd: 134,
+        Name:    "SingerName",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 135,
+        Rparen:  146,
+        Name:    "STRING",
+        Max:     false,
+        Size:    &ast.IntLiteral{
+          ValuePos: 142,
+          ValueEnd: 146,
+          Base:     10,
+          Value:    "1024",
+        },
+      },
+      NotNull:       false,
+      DefaultExpr:   (*ast.ColumnDefaultExpr)(nil),
+      GeneratedExpr: (*ast.GeneratedColumnExpr)(nil),
+      Options:       (*ast.Options)(nil),
+    },
+  },
+  TableConstraints: []*ast.TableConstraint(nil),
+  PrimaryKeys:      []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 186,
+        NameEnd: 194,
+        Name:    "SingerId",
+      },
+      Dir: "",
+    },
+  },
+  Synonyms: []*ast.Synonym{
+    &ast.Synonym{
+      Synonym: 72,
+      Rparen:  88,
+      Name:    &ast.Ident{
+        NamePos: 81,
+        NameEnd: 88,
+        Name:    "Ignored",
+      },
+    },
+    &ast.Synonym{
+      Synonym: 153,
+      Rparen:  169,
+      Name:    &ast.Ident{
+        NamePos: 162,
+        NameEnd: 169,
+        Name:    "Artists",
+      },
+    },
+  },
+  Cluster:           (*ast.Cluster)(nil),
+  RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
+}
+
+--- SQL
+CREATE TABLE Singers (SingerId INT64 NOT NULL, SingerName STRING(1024), SYNONYM (Ignored ), SYNONYM (Artists )) PRIMARY KEY (SingerId)

--- a/testdata/result/statement/create_table_synonyms_abnormal.sql.txt
+++ b/testdata/result/statement/create_table_synonyms_abnormal.sql.txt
@@ -95,4 +95,4 @@ CREATE TABLE Singers (
 }
 
 --- SQL
-CREATE TABLE Singers (SingerId INT64 NOT NULL, SingerName STRING(1024), SYNONYM (Ignored ), SYNONYM (Artists )) PRIMARY KEY (SingerId)
+CREATE TABLE Singers (SingerId INT64 NOT NULL, SingerName STRING(1024), SYNONYM (Ignored), SYNONYM (Artists)) PRIMARY KEY (SingerId)

--- a/testdata/result/statement/create_table_trailing_comma.sql.txt
+++ b/testdata/result/statement/create_table_trailing_comma.sql.txt
@@ -72,6 +72,7 @@ create table foo (
       Dir: "DESC",
     },
   },
+  Synonyms:          []*ast.Synonym(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }

--- a/testdata/result/statement/create_table_types.sql.txt
+++ b/testdata/result/statement/create_table_types.sql.txt
@@ -290,6 +290,7 @@ create table types (
       Dir: "",
     },
   },
+  Synonyms:          []*ast.Synonym(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }

--- a/testdata/result/statement/create_table_with_sequence_function.sql.txt
+++ b/testdata/result/statement/create_table_with_sequence_function.sql.txt
@@ -106,6 +106,7 @@ CREATE TABLE foo
       Dir: "",
     },
   },
+  Synonyms:          []*ast.Synonym(nil),
   Cluster:           (*ast.Cluster)(nil),
   RowDeletionPolicy: (*ast.CreateRowDeletionPolicy)(nil),
 }


### PR DESCRIPTION
This PR implements `SYNONYM` in `CREATE TABLE`.

fix #125