### PR TITLE
Sync lexer punctuations with ZetaSQL

### DIFF
--- a/lexer_test.go
+++ b/lexer_test.go
@@ -11,35 +11,48 @@ import (
 	. "github.com/cloudspannerecosystem/memefish/token"
 )
 
+// Keep same order https://github.com/google/zetasql/blob/master/zetasql/parser/flex_tokenizer.l
 var symbols = []string{
-	".",
-	",",
-	";",
 	"(",
-	")",
-	"{",
-	"}",
 	"[",
+	"{",
+	")",
 	"]",
-	"@",
-	"~",
+	"}",
+	"*",
+	",",
+	"=",
+	"+=",
+	"-=",
+	"!=",
+	"<=",
+	"<<",
+	"=>",
+	"->",
+	"<",
+	">",
+	">=",
+	"||",
+	"|",
+	"^",
+	"&",
 	"+",
 	"-",
-	"*",
 	"/",
-	"&",
-	"^",
-	"|",
-	"||",
-	"=",
-	"<",
-	"<<",
-	"<=",
-	"<>",
-	">",
-	">>",
-	">=",
-	"!=",
+	"~",
+	"?",
+	"!",
+	"%",
+	"|>",
+	"@",
+	"@@",
+	".",
+	":",
+	"\\",
+	";",
+	"$",
+	"<>", // <> is not a valid token in ZetaSQL, but it is a token in memefish
+	">>", // >> is not a valid token in ZetaSQL, but it is a token in memefish.
 }
 
 var lexerTestCases = []struct {
@@ -132,7 +145,6 @@ var lexerWrongTestCase = []struct {
 	pos     Pos
 	message string
 }{
-	{"?", 0, "illegal input character: '?'"},
 	{`"foo`, 0, "unclosed string literal"},
 	{`R"foo`, 1, "unclosed raw string literal"},
 	{"'foo\n", 0, "unclosed string literal: newline appears in non triple-quoted"},

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -145,6 +145,7 @@ var lexerWrongTestCase = []struct {
 	pos     Pos
 	message string
 }{
+	{"\b", 0, "illegal input character: '\\b'"},
 	{`"foo`, 0, "unclosed string literal"},
 	{`R"foo`, 1, "unclosed raw string literal"},
 	{"'foo\n", 0, "unclosed string literal: newline appears in non triple-quoted"},

--- a/split_test.go
+++ b/split_test.go
@@ -69,8 +69,6 @@ func TestSplitRawStatements(t *testing.T) {
 			want: []*memefish.RawStatement{
 				{Statement: "SELECT `1;2;3`", End: token.Pos(14)},
 			}},
-		// $` may become a valid token in the future, but it's reasonable to check its current behavior.
-		{desc: "unknown token", input: "SELECT $;", errRe: regexp.MustCompile(`illegal input character: '\$'`)},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			stmts, err := memefish.SplitRawStatements("", test.input)


### PR DESCRIPTION
This PR adds all ZetaSQL punctuations as memefish tokens.

`MACRO_*` are not yet implemented because they are not yet used and can be tokenized as `"$" Ident`, `"$" IntLiteral`, but they are not trivial to implement.

fixes #181