### PR TITLE
Execute tools/parse only when NArg == 1

### DIFF
--- a/tools/parse/main.go
+++ b/tools/parse/main.go
@@ -51,7 +51,7 @@ func main() {
 	}
 
 	flag.Parse()
-	if flag.NArg() < 1 {
+	if flag.NArg() != 1 {
 		flag.Usage()
 		os.Exit(1)
 		return


### PR DESCRIPTION
I have repeatedly mistaken to use `tools/parse` because I have forgotten Go `flag` behavior.
I think it is better to print usages when there are flags after positional parameter.

Current behavior
```
# -dig and -pos are ignored
$ go run ./tools/parse/main.go "SELECT 1 AS x" -dig "Query.Results.0" -pos "As.end"
```

Fixed behavior
```
$ go run ./tools/parse/main.go "SELECT 1 AS x" -dig "Query.Results.0" -pos "As.end"
Usage of tools/parse.go

A testing tool for parsing Spanner SQL.

Example:
...
```