### PR TITLE
Improve error messages on parsing POS of `gen-ast-pos`

### DIFF
--- a/tools/gen-ast-pos/main.go
+++ b/tools/gen-ast-pos/main.go
@@ -80,6 +80,7 @@ func main() {
 			e := m[1]
 			expr, err := poslang.Parse(e)
 			if err != nil {
+				log.Printf("Error at node %s, pos = %s", nodes[len(nodes)-1].name, e)
 				log.Fatal(err)
 			}
 			nodes[len(nodes)-1].posExpr = expr
@@ -90,6 +91,7 @@ func main() {
 			e := m[1]
 			expr, err := poslang.Parse(e)
 			if err != nil {
+				log.Printf("Error at node %s, end = %s", nodes[len(nodes)-1].name, e)
 				log.Fatal(err)
 			}
 			nodes[len(nodes)-1].endExpr = expr


### PR DESCRIPTION
This PR fixes error message on parsing POS expressions to show a node name and an expression. I believe this fix helps our development.