### PR TITLE
Support all subscription operator pattern in IndexExpr

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1119,7 +1119,7 @@ type IndexExpr struct {
 	Index SubscriptSpecifier
 }
 
-// SubscriptSpecifierKeyword is a positional keyword node for subscript specifier.
+// SubscriptSpecifierKeyword is subscript specifier with position keyword.
 //
 //	{{string(.Keyword)}}({{.Expr | sql}})
 type SubscriptSpecifierKeyword struct {

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1129,9 +1129,8 @@ type SubscriptSpecifierKeyword struct {
 	KeywordPos token.Pos // position of Keyword
 	Rparen     token.Pos // position of ")"
 
-	Keyword PositionKeyword // one of "OFFSET" or "SAFE_OFFSET" or "ORDINAL" OR "SAFE_ORDINAL"
-
-	Expr Expr
+	Keyword PositionKeyword
+	Expr    Expr
 }
 
 // CallExpr is function call expression node.

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -199,6 +199,15 @@ func (NewConstructor) isExpr()        {}
 func (BracedNewConstructor) isExpr()  {}
 func (BracedConstructor) isExpr()     {}
 
+// SubscriptSpecifier represents specifier of subscript operators.
+type SubscriptSpecifier interface {
+	Node
+	isSubscriptSpecifier()
+}
+
+func (ExprArg) isSubscriptSpecifier()                   {}
+func (SubscriptSpecifierKeyword) isSubscriptSpecifier() {}
+
 // Arg represents argument of function call.
 type Arg interface {
 	Node
@@ -1107,38 +1116,13 @@ type IndexExpr struct {
 	Rbrack token.Pos // position of "]"
 
 	Expr  Expr
-	Index IndexSpecifier
+	Index SubscriptSpecifier
 }
 
-type IndexSpecifier interface {
-	Node
-	isIndexSpecifier()
-}
-
-func (ExprArg) isIndexSpecifier()               {}
-func (IndexSpecifierKeyword) isIndexSpecifier() {}
-
-// IndexSpecifierOffset is an OFFSET node for subscript specifier.
-//
-//	OFFSET({{.Expr | sql}})
-type IndexSpecifierOffset struct {
-	// pos = Offset
-	// end = Rparen + 1
-
-	Offset token.Pos // position of "OFFSET"
-	Rparen token.Pos // position of ")"
-
-	Expr Expr
-}
-
-func (i *IndexSpecifierOffset) SQL() string {
-	return "OFFSET(" + i.Expr.SQL() + ")"
-}
-
-// IndexSpecifierKeyword is a positional keyword node for subscript specifier.
+// SubscriptSpecifierKeyword is a positional keyword node for subscript specifier.
 //
 //	{{string(.Keyword)}}({{.Expr | sql}})
-type IndexSpecifierKeyword struct {
+type SubscriptSpecifierKeyword struct {
 	// pos = KeywordPos
 	// end = Rparen + 1
 
@@ -1148,10 +1132,6 @@ type IndexSpecifierKeyword struct {
 	Keyword PositionKeyword // one of "OFFSET" or "SAFE_OFFSET" or "ORDINAL" OR "SAFE_ORDINAL"
 
 	Expr Expr
-}
-
-func (i *IndexSpecifierKeyword) SQL() string {
-	return string(i.Keyword) + "(" + i.Expr.SQL() + ")"
 }
 
 // CallExpr is function call expression node.

--- a/ast/const.go
+++ b/ast/const.go
@@ -22,6 +22,15 @@ const (
 	LoopJoinMethod  JoinMethod = "LOOP" // Undocumented, but the Spanner accept this value at least.
 )
 
+type PositionKeyword string
+
+const (
+	PositionKeywordOffset      PositionKeyword = "OFFSET"
+	PositionKeywordSafeOffset  PositionKeyword = "SAFE_OFFSET"
+	PositionKeywordOrdinal     PositionKeyword = "ORDINAL"
+	PositionKeywordSafeOrdinal PositionKeyword = "SAFE_ORDINAL"
+)
+
 type SetOp string
 
 const (

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -382,6 +382,22 @@ func (i *IndexExpr) End() token.Pos {
 	return posAdd(i.Rbrack, 1)
 }
 
+func (i *IndexSpecifierOffset) Pos() token.Pos {
+	return i.Offset
+}
+
+func (i *IndexSpecifierOffset) End() token.Pos {
+	return posAdd(i.Rparen, 1)
+}
+
+func (i *IndexSpecifierKeyword) Pos() token.Pos {
+	return i.KeywordPos
+}
+
+func (i *IndexSpecifierKeyword) End() token.Pos {
+	return posAdd(i.Rparen, 1)
+}
+
 func (c *CallExpr) Pos() token.Pos {
 	return nodePos(wrapNode(c.Func))
 }

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -382,20 +382,12 @@ func (i *IndexExpr) End() token.Pos {
 	return posAdd(i.Rbrack, 1)
 }
 
-func (i *IndexSpecifierOffset) Pos() token.Pos {
-	return i.Offset
+func (s *SubscriptSpecifierKeyword) Pos() token.Pos {
+	return s.KeywordPos
 }
 
-func (i *IndexSpecifierOffset) End() token.Pos {
-	return posAdd(i.Rparen, 1)
-}
-
-func (i *IndexSpecifierKeyword) Pos() token.Pos {
-	return i.KeywordPos
-}
-
-func (i *IndexSpecifierKeyword) End() token.Pos {
-	return posAdd(i.Rparen, 1)
+func (s *SubscriptSpecifierKeyword) End() token.Pos {
+	return posAdd(s.Rparen, 1)
 }
 
 func (c *CallExpr) Pos() token.Pos {

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -489,13 +489,7 @@ func (s *SelectorExpr) SQL() string {
 
 func (i *IndexExpr) SQL() string {
 	p := exprPrec(i)
-	sql := paren(p, i.Expr) + "["
-	if i.Ordinal {
-		sql += "ORDINAL"
-	} else {
-		sql += "OFFSET"
-	}
-	sql += "(" + i.Index.SQL() + ")]"
+	sql := paren(p, i.Expr) + "[" + i.Index.SQL() + "]"
 	return sql
 }
 

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -489,8 +489,7 @@ func (s *SelectorExpr) SQL() string {
 
 func (i *IndexExpr) SQL() string {
 	p := exprPrec(i)
-	sql := paren(p, i.Expr) + "[" + i.Index.SQL() + "]"
-	return sql
+	return paren(p, i.Expr) + "[" + i.Index.SQL() + "]"
 }
 
 func (s *SubscriptSpecifierKeyword) SQL() string {

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -77,7 +77,10 @@ const (
 
 func exprPrec(e Expr) prec {
 	switch e := e.(type) {
-	case *CallExpr, *CountStarExpr, *CastExpr, *ExtractExpr, *CaseExpr, *IfExpr, *ParenExpr, *ScalarSubQuery, *ArraySubQuery, *ExistsSubQuery, *Param, *Ident, *Path, *ArrayLiteral, *TupleStructLiteral, *TypedStructLiteral, *TypelessStructLiteral, *NullLiteral, *BoolLiteral, *IntLiteral, *FloatLiteral, *StringLiteral, *BytesLiteral, *DateLiteral, *TimestampLiteral, *NumericLiteral:
+	case *CallExpr, *CountStarExpr, *CastExpr, *ExtractExpr, *CaseExpr, *IfExpr, *ParenExpr, *ScalarSubQuery,
+		*ArraySubQuery, *ExistsSubQuery, *Param, *Ident, *Path, *ArrayLiteral, *TupleStructLiteral, *TypedStructLiteral,
+		*TypelessStructLiteral, *NullLiteral, *BoolLiteral, *IntLiteral, *FloatLiteral, *StringLiteral, *BytesLiteral,
+		*DateLiteral, *TimestampLiteral, *NumericLiteral, *JSONLiteral:
 		return precLit
 	case *IndexExpr, *SelectorExpr:
 		return precSelector

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -493,6 +493,10 @@ func (i *IndexExpr) SQL() string {
 	return sql
 }
 
+func (s *SubscriptSpecifierKeyword) SQL() string {
+	return string(s.Keyword) + "(" + s.Expr.SQL() + ")"
+}
+
 func (c *CallExpr) SQL() string {
 	return c.Func.SQL() + "(" + strOpt(c.Distinct, "DISTINCT ") +
 		sqlJoin(c.Args, ", ") +

--- a/parser.go
+++ b/parser.go
@@ -1395,7 +1395,7 @@ func (p *Parser) parseSelector() ast.Expr {
 	}
 }
 
-func (p *Parser) parseIndexSpecifier() ast.IndexSpecifier {
+func (p *Parser) parseIndexSpecifier() ast.SubscriptSpecifier {
 	pos := p.Token.Pos
 	switch {
 	case p.Token.IsIdent("OFFSET"), p.Token.IsIdent("ORDINAL"),
@@ -1417,7 +1417,7 @@ func (p *Parser) parseIndexSpecifier() ast.IndexSpecifier {
 		expr := p.parseExpr()
 		rparen := p.expect(")").Pos
 
-		return &ast.IndexSpecifierKeyword{
+		return &ast.SubscriptSpecifierKeyword{
 			KeywordPos: pos,
 			Keyword:    keyword,
 			Rparen:     rparen,

--- a/testdata/input/query/select_subscript_operators.sql
+++ b/testdata/input/query/select_subscript_operators.sql
@@ -1,0 +1,13 @@
+select
+    [1, 2, 3][offset(1)],
+    [1, 2, 3][ordinal(1)],
+    [1, 2, 3][safe_offset(1)],
+    [1, 2, 3][ordinal(1)],
+    [1, 2, 3][1],
+    STRUCT(1, 2, 3)[offset(1)],
+    STRUCT(1, 2, 3)[ordinal(1)],
+    STRUCT(1, 2, 3)[safe_offset(1)],
+    STRUCT(1, 2, 3)[ordinal(1)],
+    STRUCT(1, 2, 3)[1],
+    JSON '[1, 2, 3]'[1],
+    JSON '{"a": 1, "b": 2, "c": 3}'['a']

--- a/testdata/result/query/select_expr.sql.txt
+++ b/testdata/result/query/select_expr.sql.txt
@@ -407,7 +407,7 @@ select 1 + 2, 1 - 2,
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 250,
             Rparen:     258,
             Keyword:    "OFFSET",
@@ -449,7 +449,7 @@ select 1 + 2, 1 - 2,
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 279,
             Rparen:     289,
             Keyword:    "OFFSET",
@@ -491,7 +491,7 @@ select 1 + 2, 1 - 2,
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 310,
             Rparen:     319,
             Keyword:    "ORDINAL",

--- a/testdata/result/query/select_expr.sql.txt
+++ b/testdata/result/query/select_expr.sql.txt
@@ -380,9 +380,8 @@ select 1 + 2, 1 - 2,
       },
       &ast.ExprSelectItem{
         Expr: &ast.IndexExpr{
-          Rbrack:  259,
-          Ordinal: false,
-          Expr:    &ast.ArrayLiteral{
+          Rbrack: 259,
+          Expr:   &ast.ArrayLiteral{
             Array:  -1,
             Lbrack: 240,
             Rbrack: 248,
@@ -408,19 +407,23 @@ select 1 + 2, 1 - 2,
               },
             },
           },
-          Index: &ast.IntLiteral{
-            ValuePos: 257,
-            ValueEnd: 258,
-            Base:     10,
-            Value:    "1",
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 250,
+            Rparen:     258,
+            Keyword:    "OFFSET",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 257,
+              ValueEnd: 258,
+              Base:     10,
+              Value:    "1",
+            },
           },
         },
       },
       &ast.ExprSelectItem{
         Expr: &ast.IndexExpr{
-          Rbrack:  290,
-          Ordinal: false,
-          Expr:    &ast.ArrayLiteral{
+          Rbrack: 290,
+          Expr:   &ast.ArrayLiteral{
             Array:  -1,
             Lbrack: 269,
             Rbrack: 277,
@@ -446,19 +449,23 @@ select 1 + 2, 1 - 2,
               },
             },
           },
-          Index: &ast.IntLiteral{
-            ValuePos: 288,
-            ValueEnd: 289,
-            Base:     10,
-            Value:    "1",
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 279,
+            Rparen:     289,
+            Keyword:    "OFFSET",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 288,
+              ValueEnd: 289,
+              Base:     10,
+              Value:    "1",
+            },
           },
         },
       },
       &ast.ExprSelectItem{
         Expr: &ast.IndexExpr{
-          Rbrack:  320,
-          Ordinal: true,
-          Expr:    &ast.ArrayLiteral{
+          Rbrack: 320,
+          Expr:   &ast.ArrayLiteral{
             Array:  -1,
             Lbrack: 300,
             Rbrack: 308,
@@ -484,11 +491,16 @@ select 1 + 2, 1 - 2,
               },
             },
           },
-          Index: &ast.IntLiteral{
-            ValuePos: 318,
-            ValueEnd: 319,
-            Base:     10,
-            Value:    "1",
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 310,
+            Rparen:     319,
+            Keyword:    "ORDINAL",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 318,
+              ValueEnd: 319,
+              Base:     10,
+              Value:    "1",
+            },
           },
         },
       },

--- a/testdata/result/query/select_subscript_operators.sql.txt
+++ b/testdata/result/query/select_subscript_operators.sql.txt
@@ -1,0 +1,511 @@
+--- select_subscript_operators.sql
+select
+    [1, 2, 3][offset(1)],
+    [1, 2, 3][ordinal(1)],
+    [1, 2, 3][safe_offset(1)],
+    [1, 2, 3][ordinal(1)],
+    [1, 2, 3][1],
+    STRUCT(1, 2, 3)[offset(1)],
+    STRUCT(1, 2, 3)[ordinal(1)],
+    STRUCT(1, 2, 3)[safe_offset(1)],
+    STRUCT(1, 2, 3)[ordinal(1)],
+    STRUCT(1, 2, 3)[1],
+    JSON '[1, 2, 3]'[1],
+    JSON '{"a": 1, "b": 2, "c": 3}'['a']
+
+--- AST
+&ast.QueryStatement{
+  Hint:  (*ast.Hint)(nil),
+  With:  (*ast.With)(nil),
+  Query: &ast.Select{
+    Select:   0,
+    Distinct: false,
+    As:       nil,
+    Results:  []ast.SelectItem{
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 30,
+          Expr:   &ast.ArrayLiteral{
+            Array:  -1,
+            Lbrack: 11,
+            Rbrack: 19,
+            Type:   nil,
+            Values: []ast.Expr{
+              &ast.IntLiteral{
+                ValuePos: 12,
+                ValueEnd: 13,
+                Base:     10,
+                Value:    "1",
+              },
+              &ast.IntLiteral{
+                ValuePos: 15,
+                ValueEnd: 16,
+                Base:     10,
+                Value:    "2",
+              },
+              &ast.IntLiteral{
+                ValuePos: 18,
+                ValueEnd: 19,
+                Base:     10,
+                Value:    "3",
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 21,
+            Rparen:     29,
+            Keyword:    "OFFSET",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 28,
+              ValueEnd: 29,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 57,
+          Expr:   &ast.ArrayLiteral{
+            Array:  -1,
+            Lbrack: 37,
+            Rbrack: 45,
+            Type:   nil,
+            Values: []ast.Expr{
+              &ast.IntLiteral{
+                ValuePos: 38,
+                ValueEnd: 39,
+                Base:     10,
+                Value:    "1",
+              },
+              &ast.IntLiteral{
+                ValuePos: 41,
+                ValueEnd: 42,
+                Base:     10,
+                Value:    "2",
+              },
+              &ast.IntLiteral{
+                ValuePos: 44,
+                ValueEnd: 45,
+                Base:     10,
+                Value:    "3",
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 47,
+            Rparen:     56,
+            Keyword:    "ORDINAL",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 55,
+              ValueEnd: 56,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 88,
+          Expr:   &ast.ArrayLiteral{
+            Array:  -1,
+            Lbrack: 64,
+            Rbrack: 72,
+            Type:   nil,
+            Values: []ast.Expr{
+              &ast.IntLiteral{
+                ValuePos: 65,
+                ValueEnd: 66,
+                Base:     10,
+                Value:    "1",
+              },
+              &ast.IntLiteral{
+                ValuePos: 68,
+                ValueEnd: 69,
+                Base:     10,
+                Value:    "2",
+              },
+              &ast.IntLiteral{
+                ValuePos: 71,
+                ValueEnd: 72,
+                Base:     10,
+                Value:    "3",
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 74,
+            Rparen:     87,
+            Keyword:    "SAFE_OFFSET",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 86,
+              ValueEnd: 87,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 115,
+          Expr:   &ast.ArrayLiteral{
+            Array:  -1,
+            Lbrack: 95,
+            Rbrack: 103,
+            Type:   nil,
+            Values: []ast.Expr{
+              &ast.IntLiteral{
+                ValuePos: 96,
+                ValueEnd: 97,
+                Base:     10,
+                Value:    "1",
+              },
+              &ast.IntLiteral{
+                ValuePos: 99,
+                ValueEnd: 100,
+                Base:     10,
+                Value:    "2",
+              },
+              &ast.IntLiteral{
+                ValuePos: 102,
+                ValueEnd: 103,
+                Base:     10,
+                Value:    "3",
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 105,
+            Rparen:     114,
+            Keyword:    "ORDINAL",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 113,
+              ValueEnd: 114,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 133,
+          Expr:   &ast.ArrayLiteral{
+            Array:  -1,
+            Lbrack: 122,
+            Rbrack: 130,
+            Type:   nil,
+            Values: []ast.Expr{
+              &ast.IntLiteral{
+                ValuePos: 123,
+                ValueEnd: 124,
+                Base:     10,
+                Value:    "1",
+              },
+              &ast.IntLiteral{
+                ValuePos: 126,
+                ValueEnd: 127,
+                Base:     10,
+                Value:    "2",
+              },
+              &ast.IntLiteral{
+                ValuePos: 129,
+                ValueEnd: 130,
+                Base:     10,
+                Value:    "3",
+              },
+            },
+          },
+          Index: &ast.ExprArg{
+            Expr: &ast.IntLiteral{
+              ValuePos: 132,
+              ValueEnd: 133,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 165,
+          Expr:   &ast.TypelessStructLiteral{
+            Struct: 140,
+            Rparen: 154,
+            Values: []ast.TypelessStructLiteralArg{
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 147,
+                  ValueEnd: 148,
+                  Base:     10,
+                  Value:    "1",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 150,
+                  ValueEnd: 151,
+                  Base:     10,
+                  Value:    "2",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 153,
+                  ValueEnd: 154,
+                  Base:     10,
+                  Value:    "3",
+                },
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 156,
+            Rparen:     164,
+            Keyword:    "OFFSET",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 163,
+              ValueEnd: 164,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 198,
+          Expr:   &ast.TypelessStructLiteral{
+            Struct: 172,
+            Rparen: 186,
+            Values: []ast.TypelessStructLiteralArg{
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 179,
+                  ValueEnd: 180,
+                  Base:     10,
+                  Value:    "1",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 182,
+                  ValueEnd: 183,
+                  Base:     10,
+                  Value:    "2",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 185,
+                  ValueEnd: 186,
+                  Base:     10,
+                  Value:    "3",
+                },
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 188,
+            Rparen:     197,
+            Keyword:    "ORDINAL",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 196,
+              ValueEnd: 197,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 235,
+          Expr:   &ast.TypelessStructLiteral{
+            Struct: 205,
+            Rparen: 219,
+            Values: []ast.TypelessStructLiteralArg{
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 212,
+                  ValueEnd: 213,
+                  Base:     10,
+                  Value:    "1",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 215,
+                  ValueEnd: 216,
+                  Base:     10,
+                  Value:    "2",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 218,
+                  ValueEnd: 219,
+                  Base:     10,
+                  Value:    "3",
+                },
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 221,
+            Rparen:     234,
+            Keyword:    "SAFE_OFFSET",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 233,
+              ValueEnd: 234,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 268,
+          Expr:   &ast.TypelessStructLiteral{
+            Struct: 242,
+            Rparen: 256,
+            Values: []ast.TypelessStructLiteralArg{
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 249,
+                  ValueEnd: 250,
+                  Base:     10,
+                  Value:    "1",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 252,
+                  ValueEnd: 253,
+                  Base:     10,
+                  Value:    "2",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 255,
+                  ValueEnd: 256,
+                  Base:     10,
+                  Value:    "3",
+                },
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 258,
+            Rparen:     267,
+            Keyword:    "ORDINAL",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 266,
+              ValueEnd: 267,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 292,
+          Expr:   &ast.TypelessStructLiteral{
+            Struct: 275,
+            Rparen: 289,
+            Values: []ast.TypelessStructLiteralArg{
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 282,
+                  ValueEnd: 283,
+                  Base:     10,
+                  Value:    "1",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 285,
+                  ValueEnd: 286,
+                  Base:     10,
+                  Value:    "2",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 288,
+                  ValueEnd: 289,
+                  Base:     10,
+                  Value:    "3",
+                },
+              },
+            },
+          },
+          Index: &ast.ExprArg{
+            Expr: &ast.IntLiteral{
+              ValuePos: 291,
+              ValueEnd: 292,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 317,
+          Expr:   &ast.JSONLiteral{
+            JSON:  299,
+            Value: &ast.StringLiteral{
+              ValuePos: 304,
+              ValueEnd: 315,
+              Value:    "[1, 2, 3]",
+            },
+          },
+          Index: &ast.ExprArg{
+            Expr: &ast.IntLiteral{
+              ValuePos: 316,
+              ValueEnd: 317,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 359,
+          Expr:   &ast.JSONLiteral{
+            JSON:  324,
+            Value: &ast.StringLiteral{
+              ValuePos: 329,
+              ValueEnd: 355,
+              Value:    "{\"a\": 1, \"b\": 2, \"c\": 3}",
+            },
+          },
+          Index: &ast.ExprArg{
+            Expr: &ast.StringLiteral{
+              ValuePos: 356,
+              ValueEnd: 359,
+              Value:    "a",
+            },
+          },
+        },
+      },
+    },
+    From:    (*ast.From)(nil),
+    Where:   (*ast.Where)(nil),
+    GroupBy: (*ast.GroupBy)(nil),
+    Having:  (*ast.Having)(nil),
+    OrderBy: (*ast.OrderBy)(nil),
+    Limit:   (*ast.Limit)(nil),
+  },
+}
+
+--- SQL
+SELECT [1, 2, 3][OFFSET(1)], [1, 2, 3][ORDINAL(1)], [1, 2, 3][SAFE_OFFSET(1)], [1, 2, 3][ORDINAL(1)], [1, 2, 3][1], STRUCT(1, 2, 3)[OFFSET(1)], STRUCT(1, 2, 3)[ORDINAL(1)], STRUCT(1, 2, 3)[SAFE_OFFSET(1)], STRUCT(1, 2, 3)[ORDINAL(1)], STRUCT(1, 2, 3)[1], JSON "[1, 2, 3]"[1], JSON "{\"a\": 1, \"b\": 2, \"c\": 3}"["a"]

--- a/testdata/result/query/select_subscript_operators.sql.txt
+++ b/testdata/result/query/select_subscript_operators.sql.txt
@@ -51,7 +51,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 21,
             Rparen:     29,
             Keyword:    "OFFSET",
@@ -93,7 +93,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 47,
             Rparen:     56,
             Keyword:    "ORDINAL",
@@ -135,7 +135,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 74,
             Rparen:     87,
             Keyword:    "SAFE_OFFSET",
@@ -177,7 +177,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 105,
             Rparen:     114,
             Keyword:    "ORDINAL",
@@ -262,7 +262,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 156,
             Rparen:     164,
             Keyword:    "OFFSET",
@@ -308,7 +308,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 188,
             Rparen:     197,
             Keyword:    "ORDINAL",
@@ -354,7 +354,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 221,
             Rparen:     234,
             Keyword:    "SAFE_OFFSET",
@@ -400,7 +400,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 258,
             Rparen:     267,
             Keyword:    "ORDINAL",

--- a/testdata/result/statement/select_expr.sql.txt
+++ b/testdata/result/statement/select_expr.sql.txt
@@ -407,7 +407,7 @@ select 1 + 2, 1 - 2,
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 250,
             Rparen:     258,
             Keyword:    "OFFSET",
@@ -449,7 +449,7 @@ select 1 + 2, 1 - 2,
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 279,
             Rparen:     289,
             Keyword:    "OFFSET",
@@ -491,7 +491,7 @@ select 1 + 2, 1 - 2,
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 310,
             Rparen:     319,
             Keyword:    "ORDINAL",

--- a/testdata/result/statement/select_expr.sql.txt
+++ b/testdata/result/statement/select_expr.sql.txt
@@ -380,9 +380,8 @@ select 1 + 2, 1 - 2,
       },
       &ast.ExprSelectItem{
         Expr: &ast.IndexExpr{
-          Rbrack:  259,
-          Ordinal: false,
-          Expr:    &ast.ArrayLiteral{
+          Rbrack: 259,
+          Expr:   &ast.ArrayLiteral{
             Array:  -1,
             Lbrack: 240,
             Rbrack: 248,
@@ -408,19 +407,23 @@ select 1 + 2, 1 - 2,
               },
             },
           },
-          Index: &ast.IntLiteral{
-            ValuePos: 257,
-            ValueEnd: 258,
-            Base:     10,
-            Value:    "1",
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 250,
+            Rparen:     258,
+            Keyword:    "OFFSET",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 257,
+              ValueEnd: 258,
+              Base:     10,
+              Value:    "1",
+            },
           },
         },
       },
       &ast.ExprSelectItem{
         Expr: &ast.IndexExpr{
-          Rbrack:  290,
-          Ordinal: false,
-          Expr:    &ast.ArrayLiteral{
+          Rbrack: 290,
+          Expr:   &ast.ArrayLiteral{
             Array:  -1,
             Lbrack: 269,
             Rbrack: 277,
@@ -446,19 +449,23 @@ select 1 + 2, 1 - 2,
               },
             },
           },
-          Index: &ast.IntLiteral{
-            ValuePos: 288,
-            ValueEnd: 289,
-            Base:     10,
-            Value:    "1",
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 279,
+            Rparen:     289,
+            Keyword:    "OFFSET",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 288,
+              ValueEnd: 289,
+              Base:     10,
+              Value:    "1",
+            },
           },
         },
       },
       &ast.ExprSelectItem{
         Expr: &ast.IndexExpr{
-          Rbrack:  320,
-          Ordinal: true,
-          Expr:    &ast.ArrayLiteral{
+          Rbrack: 320,
+          Expr:   &ast.ArrayLiteral{
             Array:  -1,
             Lbrack: 300,
             Rbrack: 308,
@@ -484,11 +491,16 @@ select 1 + 2, 1 - 2,
               },
             },
           },
-          Index: &ast.IntLiteral{
-            ValuePos: 318,
-            ValueEnd: 319,
-            Base:     10,
-            Value:    "1",
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 310,
+            Rparen:     319,
+            Keyword:    "ORDINAL",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 318,
+              ValueEnd: 319,
+              Base:     10,
+              Value:    "1",
+            },
           },
         },
       },

--- a/testdata/result/statement/select_subscript_operators.sql.txt
+++ b/testdata/result/statement/select_subscript_operators.sql.txt
@@ -1,0 +1,511 @@
+--- select_subscript_operators.sql
+select
+    [1, 2, 3][offset(1)],
+    [1, 2, 3][ordinal(1)],
+    [1, 2, 3][safe_offset(1)],
+    [1, 2, 3][ordinal(1)],
+    [1, 2, 3][1],
+    STRUCT(1, 2, 3)[offset(1)],
+    STRUCT(1, 2, 3)[ordinal(1)],
+    STRUCT(1, 2, 3)[safe_offset(1)],
+    STRUCT(1, 2, 3)[ordinal(1)],
+    STRUCT(1, 2, 3)[1],
+    JSON '[1, 2, 3]'[1],
+    JSON '{"a": 1, "b": 2, "c": 3}'['a']
+
+--- AST
+&ast.QueryStatement{
+  Hint:  (*ast.Hint)(nil),
+  With:  (*ast.With)(nil),
+  Query: &ast.Select{
+    Select:   0,
+    Distinct: false,
+    As:       nil,
+    Results:  []ast.SelectItem{
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 30,
+          Expr:   &ast.ArrayLiteral{
+            Array:  -1,
+            Lbrack: 11,
+            Rbrack: 19,
+            Type:   nil,
+            Values: []ast.Expr{
+              &ast.IntLiteral{
+                ValuePos: 12,
+                ValueEnd: 13,
+                Base:     10,
+                Value:    "1",
+              },
+              &ast.IntLiteral{
+                ValuePos: 15,
+                ValueEnd: 16,
+                Base:     10,
+                Value:    "2",
+              },
+              &ast.IntLiteral{
+                ValuePos: 18,
+                ValueEnd: 19,
+                Base:     10,
+                Value:    "3",
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 21,
+            Rparen:     29,
+            Keyword:    "OFFSET",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 28,
+              ValueEnd: 29,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 57,
+          Expr:   &ast.ArrayLiteral{
+            Array:  -1,
+            Lbrack: 37,
+            Rbrack: 45,
+            Type:   nil,
+            Values: []ast.Expr{
+              &ast.IntLiteral{
+                ValuePos: 38,
+                ValueEnd: 39,
+                Base:     10,
+                Value:    "1",
+              },
+              &ast.IntLiteral{
+                ValuePos: 41,
+                ValueEnd: 42,
+                Base:     10,
+                Value:    "2",
+              },
+              &ast.IntLiteral{
+                ValuePos: 44,
+                ValueEnd: 45,
+                Base:     10,
+                Value:    "3",
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 47,
+            Rparen:     56,
+            Keyword:    "ORDINAL",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 55,
+              ValueEnd: 56,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 88,
+          Expr:   &ast.ArrayLiteral{
+            Array:  -1,
+            Lbrack: 64,
+            Rbrack: 72,
+            Type:   nil,
+            Values: []ast.Expr{
+              &ast.IntLiteral{
+                ValuePos: 65,
+                ValueEnd: 66,
+                Base:     10,
+                Value:    "1",
+              },
+              &ast.IntLiteral{
+                ValuePos: 68,
+                ValueEnd: 69,
+                Base:     10,
+                Value:    "2",
+              },
+              &ast.IntLiteral{
+                ValuePos: 71,
+                ValueEnd: 72,
+                Base:     10,
+                Value:    "3",
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 74,
+            Rparen:     87,
+            Keyword:    "SAFE_OFFSET",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 86,
+              ValueEnd: 87,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 115,
+          Expr:   &ast.ArrayLiteral{
+            Array:  -1,
+            Lbrack: 95,
+            Rbrack: 103,
+            Type:   nil,
+            Values: []ast.Expr{
+              &ast.IntLiteral{
+                ValuePos: 96,
+                ValueEnd: 97,
+                Base:     10,
+                Value:    "1",
+              },
+              &ast.IntLiteral{
+                ValuePos: 99,
+                ValueEnd: 100,
+                Base:     10,
+                Value:    "2",
+              },
+              &ast.IntLiteral{
+                ValuePos: 102,
+                ValueEnd: 103,
+                Base:     10,
+                Value:    "3",
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 105,
+            Rparen:     114,
+            Keyword:    "ORDINAL",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 113,
+              ValueEnd: 114,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 133,
+          Expr:   &ast.ArrayLiteral{
+            Array:  -1,
+            Lbrack: 122,
+            Rbrack: 130,
+            Type:   nil,
+            Values: []ast.Expr{
+              &ast.IntLiteral{
+                ValuePos: 123,
+                ValueEnd: 124,
+                Base:     10,
+                Value:    "1",
+              },
+              &ast.IntLiteral{
+                ValuePos: 126,
+                ValueEnd: 127,
+                Base:     10,
+                Value:    "2",
+              },
+              &ast.IntLiteral{
+                ValuePos: 129,
+                ValueEnd: 130,
+                Base:     10,
+                Value:    "3",
+              },
+            },
+          },
+          Index: &ast.ExprArg{
+            Expr: &ast.IntLiteral{
+              ValuePos: 132,
+              ValueEnd: 133,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 165,
+          Expr:   &ast.TypelessStructLiteral{
+            Struct: 140,
+            Rparen: 154,
+            Values: []ast.TypelessStructLiteralArg{
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 147,
+                  ValueEnd: 148,
+                  Base:     10,
+                  Value:    "1",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 150,
+                  ValueEnd: 151,
+                  Base:     10,
+                  Value:    "2",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 153,
+                  ValueEnd: 154,
+                  Base:     10,
+                  Value:    "3",
+                },
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 156,
+            Rparen:     164,
+            Keyword:    "OFFSET",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 163,
+              ValueEnd: 164,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 198,
+          Expr:   &ast.TypelessStructLiteral{
+            Struct: 172,
+            Rparen: 186,
+            Values: []ast.TypelessStructLiteralArg{
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 179,
+                  ValueEnd: 180,
+                  Base:     10,
+                  Value:    "1",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 182,
+                  ValueEnd: 183,
+                  Base:     10,
+                  Value:    "2",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 185,
+                  ValueEnd: 186,
+                  Base:     10,
+                  Value:    "3",
+                },
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 188,
+            Rparen:     197,
+            Keyword:    "ORDINAL",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 196,
+              ValueEnd: 197,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 235,
+          Expr:   &ast.TypelessStructLiteral{
+            Struct: 205,
+            Rparen: 219,
+            Values: []ast.TypelessStructLiteralArg{
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 212,
+                  ValueEnd: 213,
+                  Base:     10,
+                  Value:    "1",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 215,
+                  ValueEnd: 216,
+                  Base:     10,
+                  Value:    "2",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 218,
+                  ValueEnd: 219,
+                  Base:     10,
+                  Value:    "3",
+                },
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 221,
+            Rparen:     234,
+            Keyword:    "SAFE_OFFSET",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 233,
+              ValueEnd: 234,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 268,
+          Expr:   &ast.TypelessStructLiteral{
+            Struct: 242,
+            Rparen: 256,
+            Values: []ast.TypelessStructLiteralArg{
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 249,
+                  ValueEnd: 250,
+                  Base:     10,
+                  Value:    "1",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 252,
+                  ValueEnd: 253,
+                  Base:     10,
+                  Value:    "2",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 255,
+                  ValueEnd: 256,
+                  Base:     10,
+                  Value:    "3",
+                },
+              },
+            },
+          },
+          Index: &ast.IndexSpecifierKeyword{
+            KeywordPos: 258,
+            Rparen:     267,
+            Keyword:    "ORDINAL",
+            Expr:       &ast.IntLiteral{
+              ValuePos: 266,
+              ValueEnd: 267,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 292,
+          Expr:   &ast.TypelessStructLiteral{
+            Struct: 275,
+            Rparen: 289,
+            Values: []ast.TypelessStructLiteralArg{
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 282,
+                  ValueEnd: 283,
+                  Base:     10,
+                  Value:    "1",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 285,
+                  ValueEnd: 286,
+                  Base:     10,
+                  Value:    "2",
+                },
+              },
+              &ast.ExprArg{
+                Expr: &ast.IntLiteral{
+                  ValuePos: 288,
+                  ValueEnd: 289,
+                  Base:     10,
+                  Value:    "3",
+                },
+              },
+            },
+          },
+          Index: &ast.ExprArg{
+            Expr: &ast.IntLiteral{
+              ValuePos: 291,
+              ValueEnd: 292,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 317,
+          Expr:   &ast.JSONLiteral{
+            JSON:  299,
+            Value: &ast.StringLiteral{
+              ValuePos: 304,
+              ValueEnd: 315,
+              Value:    "[1, 2, 3]",
+            },
+          },
+          Index: &ast.ExprArg{
+            Expr: &ast.IntLiteral{
+              ValuePos: 316,
+              ValueEnd: 317,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+        },
+      },
+      &ast.ExprSelectItem{
+        Expr: &ast.IndexExpr{
+          Rbrack: 359,
+          Expr:   &ast.JSONLiteral{
+            JSON:  324,
+            Value: &ast.StringLiteral{
+              ValuePos: 329,
+              ValueEnd: 355,
+              Value:    "{\"a\": 1, \"b\": 2, \"c\": 3}",
+            },
+          },
+          Index: &ast.ExprArg{
+            Expr: &ast.StringLiteral{
+              ValuePos: 356,
+              ValueEnd: 359,
+              Value:    "a",
+            },
+          },
+        },
+      },
+    },
+    From:    (*ast.From)(nil),
+    Where:   (*ast.Where)(nil),
+    GroupBy: (*ast.GroupBy)(nil),
+    Having:  (*ast.Having)(nil),
+    OrderBy: (*ast.OrderBy)(nil),
+    Limit:   (*ast.Limit)(nil),
+  },
+}
+
+--- SQL
+SELECT [1, 2, 3][OFFSET(1)], [1, 2, 3][ORDINAL(1)], [1, 2, 3][SAFE_OFFSET(1)], [1, 2, 3][ORDINAL(1)], [1, 2, 3][1], STRUCT(1, 2, 3)[OFFSET(1)], STRUCT(1, 2, 3)[ORDINAL(1)], STRUCT(1, 2, 3)[SAFE_OFFSET(1)], STRUCT(1, 2, 3)[ORDINAL(1)], STRUCT(1, 2, 3)[1], JSON "[1, 2, 3]"[1], JSON "{\"a\": 1, \"b\": 2, \"c\": 3}"["a"]

--- a/testdata/result/statement/select_subscript_operators.sql.txt
+++ b/testdata/result/statement/select_subscript_operators.sql.txt
@@ -51,7 +51,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 21,
             Rparen:     29,
             Keyword:    "OFFSET",
@@ -93,7 +93,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 47,
             Rparen:     56,
             Keyword:    "ORDINAL",
@@ -135,7 +135,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 74,
             Rparen:     87,
             Keyword:    "SAFE_OFFSET",
@@ -177,7 +177,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 105,
             Rparen:     114,
             Keyword:    "ORDINAL",
@@ -262,7 +262,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 156,
             Rparen:     164,
             Keyword:    "OFFSET",
@@ -308,7 +308,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 188,
             Rparen:     197,
             Keyword:    "ORDINAL",
@@ -354,7 +354,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 221,
             Rparen:     234,
             Keyword:    "SAFE_OFFSET",
@@ -400,7 +400,7 @@ select
               },
             },
           },
-          Index: &ast.IndexSpecifierKeyword{
+          Index: &ast.SubscriptSpecifierKeyword{
             KeywordPos: 258,
             Rparen:     267,
             Keyword:    "ORDINAL",


### PR DESCRIPTION
This PR implements subscription operators in `ast.Expr`.

Breaking change:

- `Index` in `IndexExpr` is now `SubscriptSpecifier` interface.
- `Ordinal` in `IndexExpr` has been removed. See `SubscriptSpecifierKeyword`.

Related issues:

- close #192 