### PR TITLE
Fix (*FromQuery).SQL() placement

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -775,10 +775,6 @@ type FromQuery struct {
 	From *From
 }
 
-func (f *FromQuery) SQL() string {
-	return f.From.SQL()
-}
-
 // CompoundQuery is query expression node compounded by set operators.
 // Note: A single CompoundQuery can express query expressions compounded by the same set operator.
 // If there are mixed Op or Distinct in query expression, CompoundQuery will be nested.

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -231,6 +231,10 @@ func (a *AsValue) SQL() string { return "AS VALUE" }
 
 func (a *AsTypeName) SQL() string { return "AS " + a.TypeName.SQL() }
 
+func (f *FromQuery) SQL() string {
+	return f.From.SQL()
+}
+
 func (c *CompoundQuery) SQL() string {
 	return sqlJoin(c.Queries, " "+string(c.Op)+" "+strOpt(c.AllOrDistinct != "", string(c.AllOrDistinct)+" "))
 }


### PR DESCRIPTION
This PR moves misplaced `(*FromQuery).SQL()` into `ast/sql.go` from `ast/ast.go`.