### PR TITLE
Fix (*ast.Query).End()

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -649,7 +649,7 @@ type QueryStatement struct {
 // https://cloud.google.com/spanner/docs/query-syntax
 type Query struct {
 	// pos = (With ?? Query).pos
-	// end = Query.end
+	// end = (PipeOperators[$] ?? Limit ?? OrderBy ?? Query).end
 
 	With  *With
 	Query QueryExpr

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -75,7 +75,7 @@ func (q *Query) Pos() token.Pos {
 }
 
 func (q *Query) End() token.Pos {
-	return nodeEnd(wrapNode(q.Query))
+	return nodeEnd(nodeChoice(nodeSliceLast(q.PipeOperators), wrapNode(q.Limit), wrapNode(q.OrderBy), wrapNode(q.Query)))
 }
 
 func (h *Hint) Pos() token.Pos {


### PR DESCRIPTION
This PR fixes `(*ast.Query).End()`. It didn't include after `.Query.End()`.