### PR TITLE
Support DMLs with named schema

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -3644,7 +3644,7 @@ type Insert struct {
 
 	InsertOrType InsertOrType
 
-	TableName  *Ident
+	TableName  *Path
 	Columns    []*Ident
 	Input      InsertInput
 	ThenReturn *ThenReturn // optional
@@ -3707,7 +3707,7 @@ type Delete struct {
 
 	Delete token.Pos // position of "DELETE" keyword
 
-	TableName  *Ident
+	TableName  *Path
 	As         *AsAlias // optional
 	Where      *Where
 	ThenReturn *ThenReturn // optional
@@ -3724,7 +3724,7 @@ type Update struct {
 
 	Update token.Pos // position of "UPDATE" keyword
 
-	TableName  *Ident
+	TableName  *Path
 	As         *AsAlias      // optional
 	Updates    []*UpdateItem // len(Updates) > 0
 	Where      *Where

--- a/parser.go
+++ b/parser.go
@@ -4754,7 +4754,7 @@ func (p *Parser) parseInsert(pos token.Pos) *ast.Insert {
 		p.nextToken()
 	}
 
-	name := p.parseIdent()
+	name := p.parsePath()
 
 	p.expect("(")
 	var columns []*ast.Ident
@@ -4849,7 +4849,7 @@ func (p *Parser) parseDelete(pos token.Pos) *ast.Delete {
 		p.nextToken()
 	}
 
-	name := p.parseIdent()
+	name := p.parsePath()
 	as := p.tryParseAsAlias(withOptionalAs)
 	where := p.parseWhere()
 	thenReturn := p.tryParseThenReturn()
@@ -4864,7 +4864,7 @@ func (p *Parser) parseDelete(pos token.Pos) *ast.Delete {
 }
 
 func (p *Parser) parseUpdate(pos token.Pos) *ast.Update {
-	name := p.parseIdent()
+	name := p.parsePath()
 	as := p.tryParseAsAlias(withOptionalAs)
 
 	p.expect("SET")

--- a/testdata/input/dml/delete_fqn.sql
+++ b/testdata/input/dml/delete_fqn.sql
@@ -1,0 +1,1 @@
+delete sch1.foo where foo = 1 and bar = 2

--- a/testdata/input/dml/insert_fqn_values.sql
+++ b/testdata/input/dml/insert_fqn_values.sql
@@ -1,0 +1,3 @@
+insert sch1.foo (foo, bar, baz)
+values (1, 2, 3),
+       (4, 5, 6)

--- a/testdata/input/dml/update_fqn.sql
+++ b/testdata/input/dml/update_fqn.sql
@@ -1,0 +1,1 @@
+update sch1.foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1

--- a/testdata/result/dml/!bad_insert.sql.txt
+++ b/testdata/result/dml/!bad_insert.sql.txt
@@ -10,10 +10,14 @@ syntax error: testdata/input/dml/!bad_insert.sql:2:1: expected beginning of simp
 
 --- AST
 &ast.Insert{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/dml/delete.sql.txt
+++ b/testdata/result/dml/delete.sql.txt
@@ -2,10 +2,14 @@
 delete foo where foo = 1 and bar = 2
 --- AST
 &ast.Delete{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Where: &ast.Where{
     Where: 11,

--- a/testdata/result/dml/delete_as.sql.txt
+++ b/testdata/result/dml/delete_as.sql.txt
@@ -2,10 +2,14 @@
 delete foo as F where F.foo = 1
 --- AST
 &ast.Delete{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   As: &ast.AsAlias{
     As:    11,

--- a/testdata/result/dml/delete_fqn.sql.txt
+++ b/testdata/result/dml/delete_fqn.sql.txt
@@ -1,9 +1,14 @@
---- delete _from.sql
-delete from foo where foo = 1 and bar = 2
+--- delete_fqn.sql
+delete sch1.foo where foo = 1 and bar = 2
 --- AST
 &ast.Delete{
   TableName: &ast.Path{
     Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 11,
+        Name:    "sch1",
+      },
       &ast.Ident{
         NamePos: 12,
         NameEnd: 15,
@@ -48,4 +53,4 @@ delete from foo where foo = 1 and bar = 2
 }
 
 --- SQL
-DELETE FROM foo WHERE foo = 1 AND bar = 2
+DELETE FROM sch1.foo WHERE foo = 1 AND bar = 2

--- a/testdata/result/dml/delete_then_return.sql.txt
+++ b/testdata/result/dml/delete_then_return.sql.txt
@@ -2,10 +2,14 @@
 delete foo where foo = 1 and bar = 2 then return *
 --- AST
 &ast.Delete{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Where: &ast.Where{
     Where: 11,

--- a/testdata/result/dml/insert_cte_select.sql.txt
+++ b/testdata/result/dml/insert_cte_select.sql.txt
@@ -4,10 +4,14 @@ with cte AS (select 1 as foo, 2 as bar)
 select *
 --- AST
 &ast.Insert{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/dml/insert_fqn_values.sql.txt
+++ b/testdata/result/dml/insert_fqn_values.sql.txt
@@ -1,5 +1,5 @@
---- insert_values.sql
-insert foo (foo, bar, baz)
+--- insert_fqn_values.sql
+insert sch1.foo (foo, bar, baz)
 values (1, 2, 3),
        (4, 5, 6)
 --- AST
@@ -8,40 +8,45 @@ values (1, 2, 3),
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 7,
-        NameEnd: 10,
+        NameEnd: 11,
+        Name:    "sch1",
+      },
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 15,
         Name:    "foo",
       },
     },
   },
   Columns: []*ast.Ident{
     &ast.Ident{
-      NamePos: 12,
-      NameEnd: 15,
-      Name:    "foo",
-    },
-    &ast.Ident{
       NamePos: 17,
       NameEnd: 20,
-      Name:    "bar",
+      Name:    "foo",
     },
     &ast.Ident{
       NamePos: 22,
       NameEnd: 25,
+      Name:    "bar",
+    },
+    &ast.Ident{
+      NamePos: 27,
+      NameEnd: 30,
       Name:    "baz",
     },
   },
   Input: &ast.ValuesInput{
-    Values: 27,
+    Values: 32,
     Rows:   []*ast.ValuesRow{
       &ast.ValuesRow{
-        Lparen: 34,
-        Rparen: 42,
+        Lparen: 39,
+        Rparen: 47,
         Exprs:  []*ast.DefaultExpr{
           &ast.DefaultExpr{
             DefaultPos: -1,
             Expr:       &ast.IntLiteral{
-              ValuePos: 35,
-              ValueEnd: 36,
+              ValuePos: 40,
+              ValueEnd: 41,
               Base:     10,
               Value:    "1",
             },
@@ -49,8 +54,8 @@ values (1, 2, 3),
           &ast.DefaultExpr{
             DefaultPos: -1,
             Expr:       &ast.IntLiteral{
-              ValuePos: 38,
-              ValueEnd: 39,
+              ValuePos: 43,
+              ValueEnd: 44,
               Base:     10,
               Value:    "2",
             },
@@ -58,8 +63,8 @@ values (1, 2, 3),
           &ast.DefaultExpr{
             DefaultPos: -1,
             Expr:       &ast.IntLiteral{
-              ValuePos: 41,
-              ValueEnd: 42,
+              ValuePos: 46,
+              ValueEnd: 47,
               Base:     10,
               Value:    "3",
             },
@@ -67,14 +72,14 @@ values (1, 2, 3),
         },
       },
       &ast.ValuesRow{
-        Lparen: 52,
-        Rparen: 60,
+        Lparen: 57,
+        Rparen: 65,
         Exprs:  []*ast.DefaultExpr{
           &ast.DefaultExpr{
             DefaultPos: -1,
             Expr:       &ast.IntLiteral{
-              ValuePos: 53,
-              ValueEnd: 54,
+              ValuePos: 58,
+              ValueEnd: 59,
               Base:     10,
               Value:    "4",
             },
@@ -82,8 +87,8 @@ values (1, 2, 3),
           &ast.DefaultExpr{
             DefaultPos: -1,
             Expr:       &ast.IntLiteral{
-              ValuePos: 56,
-              ValueEnd: 57,
+              ValuePos: 61,
+              ValueEnd: 62,
               Base:     10,
               Value:    "5",
             },
@@ -91,8 +96,8 @@ values (1, 2, 3),
           &ast.DefaultExpr{
             DefaultPos: -1,
             Expr:       &ast.IntLiteral{
-              ValuePos: 59,
-              ValueEnd: 60,
+              ValuePos: 64,
+              ValueEnd: 65,
               Base:     10,
               Value:    "6",
             },
@@ -104,4 +109,4 @@ values (1, 2, 3),
 }
 
 --- SQL
-INSERT INTO foo (foo, bar, baz) VALUES (1, 2, 3), (4, 5, 6)
+INSERT INTO sch1.foo (foo, bar, baz) VALUES (1, 2, 3), (4, 5, 6)

--- a/testdata/result/dml/insert_into_values.sql.txt
+++ b/testdata/result/dml/insert_into_values.sql.txt
@@ -4,10 +4,14 @@ values (1, 2, 3),
        (4, 5, 6)
 --- AST
 &ast.Insert{
-  TableName: &ast.Ident{
-    NamePos: 12,
-    NameEnd: 15,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 15,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/dml/insert_or_ignore.sql.txt
+++ b/testdata/result/dml/insert_or_ignore.sql.txt
@@ -4,10 +4,14 @@ INSERT OR IGNORE INTO foo
 --- AST
 &ast.Insert{
   InsertOrType: "IGNORE",
-  TableName:    &ast.Ident{
-    NamePos: 22,
-    NameEnd: 25,
-    Name:    "foo",
+  TableName:    &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 22,
+        NameEnd: 25,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/dml/insert_or_update.sql.txt
+++ b/testdata/result/dml/insert_or_update.sql.txt
@@ -4,10 +4,14 @@ INSERT OR UPDATE INTO foo
 --- AST
 &ast.Insert{
   InsertOrType: "UPDATE",
-  TableName:    &ast.Ident{
-    NamePos: 22,
-    NameEnd: 25,
-    Name:    "foo",
+  TableName:    &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 22,
+        NameEnd: 25,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/dml/insert_or_update_then_return_with_action_as.sql.txt
+++ b/testdata/result/dml/insert_or_update_then_return_with_action_as.sql.txt
@@ -5,10 +5,14 @@ THEN RETURN WITH ACTION AS act *
 --- AST
 &ast.Insert{
   InsertOrType: "UPDATE",
-  TableName:    &ast.Ident{
-    NamePos: 22,
-    NameEnd: 25,
-    Name:    "foo",
+  TableName:    &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 22,
+        NameEnd: 25,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/dml/insert_select.sql.txt
+++ b/testdata/result/dml/insert_select.sql.txt
@@ -3,10 +3,14 @@ insert foo (foo, bar)
 select * from unnest([(1, 2), (3, 4)])
 --- AST
 &ast.Insert{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/dml/insert_values_default.sql.txt
+++ b/testdata/result/dml/insert_values_default.sql.txt
@@ -3,10 +3,14 @@ insert foo (foo, bar)
 values (1, default)
 --- AST
 &ast.Insert{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/dml/insert_with_sequence_function.sql.txt
+++ b/testdata/result/dml/insert_with_sequence_function.sql.txt
@@ -3,10 +3,14 @@ INSERT INTO foo(bar) VALUES (GET_NEXT_SEQUENCE_VALUE(SEQUENCE my_sequence))
 
 --- AST
 &ast.Insert{
-  TableName: &ast.Ident{
-    NamePos: 12,
-    NameEnd: 15,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 15,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/dml/update_as.sql.txt
+++ b/testdata/result/dml/update_as.sql.txt
@@ -2,10 +2,14 @@
 update foo as F set F.foo = F.bar + 1 where foo = F.bar
 --- AST
 &ast.Update{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   As: &ast.AsAlias{
     As:    11,

--- a/testdata/result/dml/update_fqn.sql.txt
+++ b/testdata/result/dml/update_fqn.sql.txt
@@ -1,12 +1,17 @@
---- update.sql
-update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
+--- update_fqn.sql
+update sch1.foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
 --- AST
 &ast.Update{
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 7,
-        NameEnd: 10,
+        NameEnd: 11,
+        Name:    "sch1",
+      },
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 15,
         Name:    "foo",
       },
     },
@@ -15,33 +20,33 @@ update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
     &ast.UpdateItem{
       Path: []*ast.Ident{
         &ast.Ident{
-          NamePos: 15,
-          NameEnd: 18,
+          NamePos: 20,
+          NameEnd: 23,
           Name:    "foo",
         },
       },
       DefaultExpr: &ast.DefaultExpr{
         DefaultPos: -1,
         Expr:       &ast.Ident{
-          NamePos: 21,
-          NameEnd: 24,
-          Name:    "bar",
-        },
-      },
-    },
-    &ast.UpdateItem{
-      Path: []*ast.Ident{
-        &ast.Ident{
           NamePos: 26,
           NameEnd: 29,
           Name:    "bar",
         },
       },
+    },
+    &ast.UpdateItem{
+      Path: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 31,
+          NameEnd: 34,
+          Name:    "bar",
+        },
+      },
       DefaultExpr: &ast.DefaultExpr{
         DefaultPos: -1,
         Expr:       &ast.Ident{
-          NamePos: 32,
-          NameEnd: 35,
+          NamePos: 37,
+          NameEnd: 40,
           Name:    "foo",
         },
       },
@@ -49,29 +54,29 @@ update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
     &ast.UpdateItem{
       Path: []*ast.Ident{
         &ast.Ident{
-          NamePos: 37,
-          NameEnd: 40,
+          NamePos: 42,
+          NameEnd: 45,
           Name:    "baz",
         },
       },
       DefaultExpr: &ast.DefaultExpr{
-        DefaultPos: 43,
+        DefaultPos: 48,
         Default:    true,
       },
     },
   },
   Where: &ast.Where{
-    Where: 51,
+    Where: 56,
     Expr:  &ast.BinaryExpr{
       Op:   "=",
       Left: &ast.Ident{
-        NamePos: 57,
-        NameEnd: 60,
+        NamePos: 62,
+        NameEnd: 65,
         Name:    "foo",
       },
       Right: &ast.IntLiteral{
-        ValuePos: 63,
-        ValueEnd: 64,
+        ValuePos: 68,
+        ValueEnd: 69,
         Base:     10,
         Value:    "1",
       },
@@ -80,4 +85,4 @@ update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
 }
 
 --- SQL
-UPDATE foo SET foo = bar, bar = foo, baz = DEFAULT WHERE foo = 1
+UPDATE sch1.foo SET foo = bar, bar = foo, baz = DEFAULT WHERE foo = 1

--- a/testdata/result/dml/update_then_return_with_action.sql.txt
+++ b/testdata/result/dml/update_then_return_with_action.sql.txt
@@ -2,10 +2,14 @@
 update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1 then return with action *
 --- AST
 &ast.Update{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Updates: []*ast.UpdateItem{
     &ast.UpdateItem{

--- a/testdata/result/dml/update_with_safe_ml_predict.sql.txt
+++ b/testdata/result/dml/update_with_safe_ml_predict.sql.txt
@@ -14,10 +14,14 @@ WHERE products.desc_embed IS NULL
 --- AST
 &ast.Update{
   Update:    76,
-  TableName: &ast.Ident{
-    NamePos: 83,
-    NameEnd: 91,
-    Name:    "products",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 83,
+        NameEnd: 91,
+        Name:    "products",
+      },
+    },
   },
   Updates: []*ast.UpdateItem{
     &ast.UpdateItem{

--- a/testdata/result/statement/!bad_insert.sql.txt
+++ b/testdata/result/statement/!bad_insert.sql.txt
@@ -10,10 +10,14 @@ syntax error: testdata/input/dml/!bad_insert.sql:2:1: expected beginning of simp
 
 --- AST
 &ast.Insert{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/statement/delete _from.sql.txt
+++ b/testdata/result/statement/delete _from.sql.txt
@@ -2,10 +2,14 @@
 delete from foo where foo = 1 and bar = 2
 --- AST
 &ast.Delete{
-  TableName: &ast.Ident{
-    NamePos: 12,
-    NameEnd: 15,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 15,
+        Name:    "foo",
+      },
+    },
   },
   Where: &ast.Where{
     Where: 16,

--- a/testdata/result/statement/delete.sql.txt
+++ b/testdata/result/statement/delete.sql.txt
@@ -2,10 +2,14 @@
 delete foo where foo = 1 and bar = 2
 --- AST
 &ast.Delete{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Where: &ast.Where{
     Where: 11,

--- a/testdata/result/statement/delete_as.sql.txt
+++ b/testdata/result/statement/delete_as.sql.txt
@@ -2,10 +2,14 @@
 delete foo as F where F.foo = 1
 --- AST
 &ast.Delete{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   As: &ast.AsAlias{
     As:    11,

--- a/testdata/result/statement/delete_fqn.sql.txt
+++ b/testdata/result/statement/delete_fqn.sql.txt
@@ -1,9 +1,14 @@
---- delete _from.sql
-delete from foo where foo = 1 and bar = 2
+--- delete_fqn.sql
+delete sch1.foo where foo = 1 and bar = 2
 --- AST
 &ast.Delete{
   TableName: &ast.Path{
     Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 11,
+        Name:    "sch1",
+      },
       &ast.Ident{
         NamePos: 12,
         NameEnd: 15,
@@ -48,4 +53,4 @@ delete from foo where foo = 1 and bar = 2
 }
 
 --- SQL
-DELETE FROM foo WHERE foo = 1 AND bar = 2
+DELETE FROM sch1.foo WHERE foo = 1 AND bar = 2

--- a/testdata/result/statement/delete_then_return.sql.txt
+++ b/testdata/result/statement/delete_then_return.sql.txt
@@ -2,10 +2,14 @@
 delete foo where foo = 1 and bar = 2 then return *
 --- AST
 &ast.Delete{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Where: &ast.Where{
     Where: 11,

--- a/testdata/result/statement/insert_cte_select.sql.txt
+++ b/testdata/result/statement/insert_cte_select.sql.txt
@@ -4,10 +4,14 @@ with cte AS (select 1 as foo, 2 as bar)
 select *
 --- AST
 &ast.Insert{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/statement/insert_fqn_values.sql.txt
+++ b/testdata/result/statement/insert_fqn_values.sql.txt
@@ -1,5 +1,5 @@
---- insert_values.sql
-insert foo (foo, bar, baz)
+--- insert_fqn_values.sql
+insert sch1.foo (foo, bar, baz)
 values (1, 2, 3),
        (4, 5, 6)
 --- AST
@@ -8,40 +8,45 @@ values (1, 2, 3),
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 7,
-        NameEnd: 10,
+        NameEnd: 11,
+        Name:    "sch1",
+      },
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 15,
         Name:    "foo",
       },
     },
   },
   Columns: []*ast.Ident{
     &ast.Ident{
-      NamePos: 12,
-      NameEnd: 15,
-      Name:    "foo",
-    },
-    &ast.Ident{
       NamePos: 17,
       NameEnd: 20,
-      Name:    "bar",
+      Name:    "foo",
     },
     &ast.Ident{
       NamePos: 22,
       NameEnd: 25,
+      Name:    "bar",
+    },
+    &ast.Ident{
+      NamePos: 27,
+      NameEnd: 30,
       Name:    "baz",
     },
   },
   Input: &ast.ValuesInput{
-    Values: 27,
+    Values: 32,
     Rows:   []*ast.ValuesRow{
       &ast.ValuesRow{
-        Lparen: 34,
-        Rparen: 42,
+        Lparen: 39,
+        Rparen: 47,
         Exprs:  []*ast.DefaultExpr{
           &ast.DefaultExpr{
             DefaultPos: -1,
             Expr:       &ast.IntLiteral{
-              ValuePos: 35,
-              ValueEnd: 36,
+              ValuePos: 40,
+              ValueEnd: 41,
               Base:     10,
               Value:    "1",
             },
@@ -49,8 +54,8 @@ values (1, 2, 3),
           &ast.DefaultExpr{
             DefaultPos: -1,
             Expr:       &ast.IntLiteral{
-              ValuePos: 38,
-              ValueEnd: 39,
+              ValuePos: 43,
+              ValueEnd: 44,
               Base:     10,
               Value:    "2",
             },
@@ -58,8 +63,8 @@ values (1, 2, 3),
           &ast.DefaultExpr{
             DefaultPos: -1,
             Expr:       &ast.IntLiteral{
-              ValuePos: 41,
-              ValueEnd: 42,
+              ValuePos: 46,
+              ValueEnd: 47,
               Base:     10,
               Value:    "3",
             },
@@ -67,14 +72,14 @@ values (1, 2, 3),
         },
       },
       &ast.ValuesRow{
-        Lparen: 52,
-        Rparen: 60,
+        Lparen: 57,
+        Rparen: 65,
         Exprs:  []*ast.DefaultExpr{
           &ast.DefaultExpr{
             DefaultPos: -1,
             Expr:       &ast.IntLiteral{
-              ValuePos: 53,
-              ValueEnd: 54,
+              ValuePos: 58,
+              ValueEnd: 59,
               Base:     10,
               Value:    "4",
             },
@@ -82,8 +87,8 @@ values (1, 2, 3),
           &ast.DefaultExpr{
             DefaultPos: -1,
             Expr:       &ast.IntLiteral{
-              ValuePos: 56,
-              ValueEnd: 57,
+              ValuePos: 61,
+              ValueEnd: 62,
               Base:     10,
               Value:    "5",
             },
@@ -91,8 +96,8 @@ values (1, 2, 3),
           &ast.DefaultExpr{
             DefaultPos: -1,
             Expr:       &ast.IntLiteral{
-              ValuePos: 59,
-              ValueEnd: 60,
+              ValuePos: 64,
+              ValueEnd: 65,
               Base:     10,
               Value:    "6",
             },
@@ -104,4 +109,4 @@ values (1, 2, 3),
 }
 
 --- SQL
-INSERT INTO foo (foo, bar, baz) VALUES (1, 2, 3), (4, 5, 6)
+INSERT INTO sch1.foo (foo, bar, baz) VALUES (1, 2, 3), (4, 5, 6)

--- a/testdata/result/statement/insert_into_values.sql.txt
+++ b/testdata/result/statement/insert_into_values.sql.txt
@@ -4,10 +4,14 @@ values (1, 2, 3),
        (4, 5, 6)
 --- AST
 &ast.Insert{
-  TableName: &ast.Ident{
-    NamePos: 12,
-    NameEnd: 15,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 15,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/statement/insert_or_ignore.sql.txt
+++ b/testdata/result/statement/insert_or_ignore.sql.txt
@@ -4,10 +4,14 @@ INSERT OR IGNORE INTO foo
 --- AST
 &ast.Insert{
   InsertOrType: "IGNORE",
-  TableName:    &ast.Ident{
-    NamePos: 22,
-    NameEnd: 25,
-    Name:    "foo",
+  TableName:    &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 22,
+        NameEnd: 25,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/statement/insert_or_update.sql.txt
+++ b/testdata/result/statement/insert_or_update.sql.txt
@@ -4,10 +4,14 @@ INSERT OR UPDATE INTO foo
 --- AST
 &ast.Insert{
   InsertOrType: "UPDATE",
-  TableName:    &ast.Ident{
-    NamePos: 22,
-    NameEnd: 25,
-    Name:    "foo",
+  TableName:    &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 22,
+        NameEnd: 25,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/statement/insert_or_update_then_return_with_action_as.sql.txt
+++ b/testdata/result/statement/insert_or_update_then_return_with_action_as.sql.txt
@@ -5,10 +5,14 @@ THEN RETURN WITH ACTION AS act *
 --- AST
 &ast.Insert{
   InsertOrType: "UPDATE",
-  TableName:    &ast.Ident{
-    NamePos: 22,
-    NameEnd: 25,
-    Name:    "foo",
+  TableName:    &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 22,
+        NameEnd: 25,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/statement/insert_select.sql.txt
+++ b/testdata/result/statement/insert_select.sql.txt
@@ -3,10 +3,14 @@ insert foo (foo, bar)
 select * from unnest([(1, 2), (3, 4)])
 --- AST
 &ast.Insert{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/statement/insert_values.sql.txt
+++ b/testdata/result/statement/insert_values.sql.txt
@@ -4,10 +4,14 @@ values (1, 2, 3),
        (4, 5, 6)
 --- AST
 &ast.Insert{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/statement/insert_values_default.sql.txt
+++ b/testdata/result/statement/insert_values_default.sql.txt
@@ -3,10 +3,14 @@ insert foo (foo, bar)
 values (1, default)
 --- AST
 &ast.Insert{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/statement/insert_with_sequence_function.sql.txt
+++ b/testdata/result/statement/insert_with_sequence_function.sql.txt
@@ -3,10 +3,14 @@ INSERT INTO foo(bar) VALUES (GET_NEXT_SEQUENCE_VALUE(SEQUENCE my_sequence))
 
 --- AST
 &ast.Insert{
-  TableName: &ast.Ident{
-    NamePos: 12,
-    NameEnd: 15,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 15,
+        Name:    "foo",
+      },
+    },
   },
   Columns: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/statement/update.sql.txt
+++ b/testdata/result/statement/update.sql.txt
@@ -2,10 +2,14 @@
 update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
 --- AST
 &ast.Update{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Updates: []*ast.UpdateItem{
     &ast.UpdateItem{

--- a/testdata/result/statement/update_as.sql.txt
+++ b/testdata/result/statement/update_as.sql.txt
@@ -2,10 +2,14 @@
 update foo as F set F.foo = F.bar + 1 where foo = F.bar
 --- AST
 &ast.Update{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   As: &ast.AsAlias{
     As:    11,

--- a/testdata/result/statement/update_fqn.sql.txt
+++ b/testdata/result/statement/update_fqn.sql.txt
@@ -1,12 +1,17 @@
---- update.sql
-update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
+--- update_fqn.sql
+update sch1.foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
 --- AST
 &ast.Update{
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 7,
-        NameEnd: 10,
+        NameEnd: 11,
+        Name:    "sch1",
+      },
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 15,
         Name:    "foo",
       },
     },
@@ -15,33 +20,33 @@ update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
     &ast.UpdateItem{
       Path: []*ast.Ident{
         &ast.Ident{
-          NamePos: 15,
-          NameEnd: 18,
+          NamePos: 20,
+          NameEnd: 23,
           Name:    "foo",
         },
       },
       DefaultExpr: &ast.DefaultExpr{
         DefaultPos: -1,
         Expr:       &ast.Ident{
-          NamePos: 21,
-          NameEnd: 24,
-          Name:    "bar",
-        },
-      },
-    },
-    &ast.UpdateItem{
-      Path: []*ast.Ident{
-        &ast.Ident{
           NamePos: 26,
           NameEnd: 29,
           Name:    "bar",
         },
       },
+    },
+    &ast.UpdateItem{
+      Path: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 31,
+          NameEnd: 34,
+          Name:    "bar",
+        },
+      },
       DefaultExpr: &ast.DefaultExpr{
         DefaultPos: -1,
         Expr:       &ast.Ident{
-          NamePos: 32,
-          NameEnd: 35,
+          NamePos: 37,
+          NameEnd: 40,
           Name:    "foo",
         },
       },
@@ -49,29 +54,29 @@ update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
     &ast.UpdateItem{
       Path: []*ast.Ident{
         &ast.Ident{
-          NamePos: 37,
-          NameEnd: 40,
+          NamePos: 42,
+          NameEnd: 45,
           Name:    "baz",
         },
       },
       DefaultExpr: &ast.DefaultExpr{
-        DefaultPos: 43,
+        DefaultPos: 48,
         Default:    true,
       },
     },
   },
   Where: &ast.Where{
-    Where: 51,
+    Where: 56,
     Expr:  &ast.BinaryExpr{
       Op:   "=",
       Left: &ast.Ident{
-        NamePos: 57,
-        NameEnd: 60,
+        NamePos: 62,
+        NameEnd: 65,
         Name:    "foo",
       },
       Right: &ast.IntLiteral{
-        ValuePos: 63,
-        ValueEnd: 64,
+        ValuePos: 68,
+        ValueEnd: 69,
         Base:     10,
         Value:    "1",
       },
@@ -80,4 +85,4 @@ update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
 }
 
 --- SQL
-UPDATE foo SET foo = bar, bar = foo, baz = DEFAULT WHERE foo = 1
+UPDATE sch1.foo SET foo = bar, bar = foo, baz = DEFAULT WHERE foo = 1

--- a/testdata/result/statement/update_then_return_with_action.sql.txt
+++ b/testdata/result/statement/update_then_return_with_action.sql.txt
@@ -2,10 +2,14 @@
 update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1 then return with action *
 --- AST
 &ast.Update{
-  TableName: &ast.Ident{
-    NamePos: 7,
-    NameEnd: 10,
-    Name:    "foo",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 7,
+        NameEnd: 10,
+        Name:    "foo",
+      },
+    },
   },
   Updates: []*ast.UpdateItem{
     &ast.UpdateItem{

--- a/testdata/result/statement/update_with_safe_ml_predict.sql.txt
+++ b/testdata/result/statement/update_with_safe_ml_predict.sql.txt
@@ -14,10 +14,14 @@ WHERE products.desc_embed IS NULL
 --- AST
 &ast.Update{
   Update:    76,
-  TableName: &ast.Ident{
-    NamePos: 83,
-    NameEnd: 91,
-    Name:    "products",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 83,
+        NameEnd: 91,
+        Name:    "products",
+      },
+    },
   },
   Updates: []*ast.UpdateItem{
     &ast.UpdateItem{


### PR DESCRIPTION
This PR adds support of named schema in DMLs.

## Breaking changes

- `TableName` in `Update`, `Delete`, `Insert` are changed to `*ast.Path` from `*ast.Ident`.
## Related Issues

- close #261 