### PR TITLE
Fix pos/end with new pos/end test

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2684,7 +2684,7 @@ type AlterIndex struct {
 //	{{.NoSkipRange | sqlOpt}}
 type AlterSequence struct {
 	// pos = Alter
-	// end = Options.end
+	// end = (NoSkipRange ?? SkipRange ?? RestartCounterWith ?? Options).end
 
 	Alter token.Pos // position of "ALTER" keyword
 

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1232,7 +1232,7 @@ type TableSampleSize struct {
 //	{{.Left | sql}} {{.Op}} {{.Right | sql}}
 type BinaryExpr struct {
 	// pos = Left.pos
-	// end = Right.pos
+	// end = Right.end
 
 	Op BinaryOp
 

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1344,7 +1344,7 @@ type BetweenExpr struct {
 //	{{.Expr | sql}}.{{.Ident | sql}}
 type SelectorExpr struct {
 	// pos = Expr.pos
-	// end = Ident.pos
+	// end = Ident.end
 
 	Expr  Expr
 	Ident *Ident

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2235,7 +2235,7 @@ type CreateDatabase struct {
 //	ALTER DATABASE {{.Name | sql}} SET {{.Options | sql}}
 type AlterDatabase struct {
 	// pos = Alter
-	// end = Name.end
+	// end = Options.end
 
 	Alter token.Pos // position of "ALTER" keyword
 

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -3074,7 +3074,7 @@ type CreateChangeStream struct {
 //	FOR ALL
 type ChangeStreamForAll struct {
 	// pos = For
-	// end = All
+	// end = All + 3
 
 	For token.Pos // position of "FOR" keyword
 	All token.Pos // position of "ALL" keyword
@@ -3097,7 +3097,7 @@ type ChangeStreamForTables struct {
 //	{{.TableName | sql}}{{if .Columns}}({{.Columns | sqlJoin ","}}){{end}}
 type ChangeStreamForTable struct {
 	// pos = TableName.pos
-	// end = TableName.end || Rparen + 1
+	// end = Rparen + 1 || TableName.end
 
 	Rparen token.Pos // position of ")"
 

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2363,10 +2363,11 @@ type DropProtoBundle struct {
 // the original order of them, please sort them by their `Pos()`.
 type CreateTable struct {
 	// pos = Create
-	// end = RowDeletionPolicy.end || Cluster.end || Rparen + 1
+	// end = RowDeletionPolicy.end || Cluster.end || PrimaryKeyRparen + 1 || Rparen + 1
 
-	Create token.Pos // position of "CREATE" keyword
-	Rparen token.Pos // position of ")" of PRIMARY KEY clause
+	Create           token.Pos // position of "CREATE" keyword
+	Rparen           token.Pos // position of ")" of end of column definitions
+	PrimaryKeyRparen token.Pos // position of ")" of PRIMARY KEY clause, optional
 
 	IfNotExists       bool
 	Name              *Path

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1157,7 +1157,7 @@ type ParenTableExpr struct {
 //	{{.Cond | sqlOpt}}
 type Join struct {
 	// pos = Left.pos
-	// end = (Cond ?? Right).pos
+	// end = (Cond ?? Right).end
 
 	Op          JoinOp
 	Method      JoinMethod

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -411,7 +411,7 @@ func (b *BinaryExpr) Pos() token.Pos {
 }
 
 func (b *BinaryExpr) End() token.Pos {
-	return nodePos(wrapNode(b.Right))
+	return nodeEnd(wrapNode(b.Right))
 }
 
 func (u *UnaryExpr) Pos() token.Pos {

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -1083,7 +1083,7 @@ func (c *CreateTable) Pos() token.Pos {
 }
 
 func (c *CreateTable) End() token.Pos {
-	return posChoice(nodeEnd(wrapNode(c.RowDeletionPolicy)), nodeEnd(wrapNode(c.Cluster)), posAdd(c.Rparen, 1))
+	return posChoice(nodeEnd(wrapNode(c.RowDeletionPolicy)), nodeEnd(wrapNode(c.Cluster)), posAdd(c.PrimaryKeyRparen, 1), posAdd(c.Rparen, 1))
 }
 
 func (s *Synonym) Pos() token.Pos {

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -1499,7 +1499,7 @@ func (c *ChangeStreamForAll) Pos() token.Pos {
 }
 
 func (c *ChangeStreamForAll) End() token.Pos {
-	return c.All
+	return posAdd(c.All, 3)
 }
 
 func (c *ChangeStreamForTables) Pos() token.Pos {
@@ -1515,7 +1515,7 @@ func (c *ChangeStreamForTable) Pos() token.Pos {
 }
 
 func (c *ChangeStreamForTable) End() token.Pos {
-	return posChoice(nodeEnd(wrapNode(c.TableName)), posAdd(c.Rparen, 1))
+	return posChoice(posAdd(c.Rparen, 1), nodeEnd(wrapNode(c.TableName)))
 }
 
 func (c *ChangeStreamSetFor) Pos() token.Pos {

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -483,7 +483,7 @@ func (s *SelectorExpr) Pos() token.Pos {
 }
 
 func (s *SelectorExpr) End() token.Pos {
-	return nodePos(wrapNode(s.Ident))
+	return nodeEnd(wrapNode(s.Ident))
 }
 
 func (i *IndexExpr) Pos() token.Pos {
@@ -1011,7 +1011,7 @@ func (a *AlterDatabase) Pos() token.Pos {
 }
 
 func (a *AlterDatabase) End() token.Pos {
-	return nodeEnd(wrapNode(a.Name))
+	return nodeEnd(wrapNode(a.Options))
 }
 
 func (c *CreatePlacement) Pos() token.Pos {
@@ -1259,7 +1259,7 @@ func (a *AlterSequence) Pos() token.Pos {
 }
 
 func (a *AlterSequence) End() token.Pos {
-	return nodeEnd(wrapNode(a.Options))
+	return nodeEnd(nodeChoice(wrapNode(a.NoSkipRange), wrapNode(a.SkipRange), wrapNode(a.RestartCounterWith), wrapNode(a.Options)))
 }
 
 func (a *AlterChangeStream) Pos() token.Pos {

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -371,7 +371,7 @@ func (j *Join) Pos() token.Pos {
 }
 
 func (j *Join) End() token.Pos {
-	return nodePos(nodeChoice(wrapNode(j.Cond), wrapNode(j.Right)))
+	return nodeEnd(nodeChoice(wrapNode(j.Cond), wrapNode(j.Right)))
 }
 
 func (o *On) Pos() token.Pos {

--- a/internal/walk.go
+++ b/internal/walk.go
@@ -1,0 +1,93 @@
+package internal
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+
+	"github.com/cloudspannerecosystem/memefish/ast"
+)
+
+type Visitor interface {
+	Visit(path []string, node ast.Node) Visitor
+}
+
+func Walk(node ast.Node, v Visitor) {
+	walk(node, []string{"$"}, v)
+}
+
+type InspectFuncType = func(path []string, node ast.Node) bool
+type inspectFuncVisitor InspectFuncType
+
+func (i inspectFuncVisitor) Visit(path []string, node ast.Node) Visitor {
+	if !i(path, node) {
+		return nil
+	}
+	return i
+}
+
+func InspectSlice[T ast.Node](nodes []T, f InspectFuncType) {
+	WalkSlice(nodes, inspectFuncVisitor(f))
+}
+
+func Inspect(node ast.Node, f InspectFuncType) {
+	Walk(node, inspectFuncVisitor(f))
+}
+
+type VisitorFunc func(path []string, node ast.Node) Visitor
+
+func (f VisitorFunc) Visit(path []string, node ast.Node) Visitor {
+	return f(path, node)
+}
+
+func WalkSlice[T ast.Node](nodes []T, v Visitor) {
+	for i, node := range nodes {
+		walk(node, []string{fmt.Sprintf("$[%d]", i)}, v)
+	}
+}
+
+func walk(node ast.Node, path []string, v Visitor) {
+	v = v.Visit(path, node)
+	if v == nil {
+		return
+	}
+
+	val := reflect.ValueOf(node)
+	for val.Kind() != reflect.Struct {
+		switch val.Kind() {
+		case reflect.Ptr, reflect.Interface:
+			val = val.Elem()
+		default:
+			return
+		}
+	}
+
+	for i := range val.NumField() {
+		fieldPart := "." + val.Type().Field(i).Name
+		val := val.Field(i)
+		switch {
+		case val.Kind() == reflect.Slice && val.Type().Elem().Implements(reflect.TypeFor[ast.Node]()):
+			// for i, val := range val.Seq2() {
+			for i := range val.Len() {
+				walk(safeCast[ast.Node](val.Index(i)), slices.Concat(path, []string{fieldPart + "[" + fmt.Sprint(i) + "]"}), v)
+			}
+		case val.Type().Implements(reflect.TypeFor[ast.Node]()):
+			walk(safeCast[ast.Node](val), slices.Concat(path, []string{fieldPart}), v)
+		}
+	}
+}
+
+// safeCast returns argument value as parameter type.
+// It is used to avoid typed-nil.
+func safeCast[T comparable](val reflect.Value) T {
+	var zero T
+	if val.IsNil() {
+		return zero
+	}
+
+	v, ok := val.Interface().(T)
+	if !ok {
+		return zero
+	}
+	return v
+}

--- a/parser.go
+++ b/parser.go
@@ -3079,11 +3079,11 @@ func (p *Parser) parseCreateTable(pos token.Pos) *ast.CreateTable {
 		}
 		p.nextToken()
 	}
-	p.expect(")")
+	rparen := p.expect(")").Pos
 
 	// PRIMARY KEY clause is now optional
 	var keys []*ast.IndexKey
-	rparen := token.InvalidPos
+	primaryKeyRparen := token.InvalidPos
 	if p.Token.IsKeywordLike("PRIMARY") {
 		p.nextToken()
 		p.expectKeywordLike("KEY")
@@ -3099,7 +3099,7 @@ func (p *Parser) parseCreateTable(pos token.Pos) *ast.CreateTable {
 			}
 			p.nextToken()
 		}
-		rparen = p.expect(")").Pos
+		primaryKeyRparen = p.expect(")").Pos
 	}
 
 	cluster := p.tryParseCluster()
@@ -3108,6 +3108,7 @@ func (p *Parser) parseCreateTable(pos token.Pos) *ast.CreateTable {
 	return &ast.CreateTable{
 		Create:            pos,
 		Rparen:            rparen,
+		PrimaryKeyRparen:  primaryKeyRparen,
 		IfNotExists:       ifNotExists,
 		Name:              name,
 		Columns:           columns,

--- a/parser.go
+++ b/parser.go
@@ -3752,6 +3752,7 @@ func (p *Parser) parseChangeStreamFor() ast.ChangeStreamFor {
 		tname := p.parseIdent()
 		forTable := ast.ChangeStreamForTable{
 			TableName: tname,
+			Rparen:    token.InvalidPos,
 		}
 
 		if p.Token.Kind == "(" {

--- a/parser.go
+++ b/parser.go
@@ -3874,7 +3874,8 @@ func (p *Parser) parseAlterTableAdd() ast.TableAlteration {
 		alteration = &ast.AddTableConstraint{
 			Add: pos,
 			TableConstraint: &ast.TableConstraint{
-				Constraint: fk,
+				ConstraintPos: token.InvalidPos,
+				Constraint:    fk,
 			},
 		}
 	case p.Token.IsKeywordLike("CHECK"):
@@ -3882,7 +3883,8 @@ func (p *Parser) parseAlterTableAdd() ast.TableAlteration {
 		alteration = &ast.AddTableConstraint{
 			Add: pos,
 			TableConstraint: &ast.TableConstraint{
-				Constraint: c,
+				ConstraintPos: token.InvalidPos,
+				Constraint:    c,
 			},
 		}
 	case p.Token.IsKeywordLike("ROW"):

--- a/parser_test.go
+++ b/parser_test.go
@@ -119,7 +119,7 @@ func testParser(t *testing.T, inputPath, resultPath string, parse func(p *memefi
 					}
 
 					if child.Pos() < node.Pos() || node.End() < child.End() {
-						t.Errorf("pos must be in (%v, %v], but got [%v, %v] on %v: %v", node.Pos(), node.End(), child.Pos(), child.End(), strings.Join(slices.Concat(path, childPath[1:]), ""), child.SQL())
+						t.Errorf("pos must be in (%v, %v], but got (%v, %v] on %v: %v", node.Pos(), node.End(), child.Pos(), child.End(), strings.Join(slices.Concat(path, childPath[1:]), ""), child.SQL())
 					}
 					return false
 				})

--- a/testdata/result/ddl/alter_table_add_check.sql.txt
+++ b/testdata/result/ddl/alter_table_add_check.sql.txt
@@ -15,7 +15,8 @@ alter table foo add check (c1 > 0)
   TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
-      Constraint: &ast.Check{
+      ConstraintPos: -1,
+      Constraint:    &ast.Check{
         Check:  20,
         Rparen: 33,
         Expr:   &ast.BinaryExpr{

--- a/testdata/result/ddl/alter_table_add_foreign_key.sql.txt
+++ b/testdata/result/ddl/alter_table_add_foreign_key.sql.txt
@@ -15,7 +15,8 @@ alter table foo add foreign key (bar) references t2 (t2key1)
   TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
-      Constraint: &ast.ForeignKey{
+      ConstraintPos: -1,
+      Constraint:    &ast.ForeignKey{
         Foreign:     20,
         Rparen:      59,
         OnDeleteEnd: -1,

--- a/testdata/result/ddl/create_change_stream_for_table.sql.txt
+++ b/testdata/result/ddl/create_change_stream_for_table.sql.txt
@@ -12,6 +12,7 @@ CREATE CHANGE STREAM change_stream_name FOR table_name
     For:    40,
     Tables: []*ast.ChangeStreamForTable{
       &ast.ChangeStreamForTable{
+        Rparen:    -1,
         TableName: &ast.Ident{
           NamePos: 44,
           NameEnd: 54,

--- a/testdata/result/ddl/create_change_stream_for_tables.sql.txt
+++ b/testdata/result/ddl/create_change_stream_for_tables.sql.txt
@@ -12,6 +12,7 @@ CREATE CHANGE STREAM change_stream_name FOR table_name1, table_name2
     For:    40,
     Tables: []*ast.ChangeStreamForTable{
       &ast.ChangeStreamForTable{
+        Rparen:    -1,
         TableName: &ast.Ident{
           NamePos: 44,
           NameEnd: 55,
@@ -19,6 +20,7 @@ CREATE CHANGE STREAM change_stream_name FOR table_name1, table_name2
         },
       },
       &ast.ChangeStreamForTable{
+        Rparen:    -1,
         TableName: &ast.Ident{
           NamePos: 57,
           NameEnd: 68,

--- a/testdata/result/ddl/create_table.sql.txt
+++ b/testdata/result/ddl/create_table.sql.txt
@@ -16,8 +16,9 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen: 573,
-  Name:   &ast.Path{
+  Rparen:           550,
+  PrimaryKeyRparen: 573,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/ddl/create_table_cluster.sql.txt
+++ b/testdata/result/ddl/create_table_cluster.sql.txt
@@ -7,8 +7,9 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen: 59,
-  Name:   &ast.Path{
+  Rparen:           44,
+  PrimaryKeyRparen: 59,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/ddl/create_table_cluster_and_row_deletion_policy.sql.txt
+++ b/testdata/result/ddl/create_table_cluster_and_row_deletion_policy.sql.txt
@@ -9,8 +9,9 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen: 77,
-  Name:   &ast.Path{
+  Rparen:           62,
+  PrimaryKeyRparen: 77,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/ddl/create_table_cluster_on_delete_no_action.sql.txt
+++ b/testdata/result/ddl/create_table_cluster_on_delete_no_action.sql.txt
@@ -6,8 +6,9 @@ create table foo (
              on delete no action
 --- AST
 &ast.CreateTable{
-  Rparen: 50,
-  Name:   &ast.Path{
+  Rparen:           32,
+  PrimaryKeyRparen: 50,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/ddl/create_table_cluster_set_on_delete.sql.txt
+++ b/testdata/result/ddl/create_table_cluster_set_on_delete.sql.txt
@@ -6,8 +6,9 @@ create table foo (
              on delete cascade
 --- AST
 &ast.CreateTable{
-  Rparen: 49,
-  Name:   &ast.Path{
+  Rparen:           31,
+  PrimaryKeyRparen: 49,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/ddl/create_table_for_format_test.sql.txt
+++ b/testdata/result/ddl/create_table_for_format_test.sql.txt
@@ -15,9 +15,10 @@ create table if not exists foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen:      461,
-  IfNotExists: true,
-  Name:        &ast.Path{
+  Rparen:           443,
+  PrimaryKeyRparen: 461,
+  IfNotExists:      true,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 27,

--- a/testdata/result/ddl/create_table_fulltext_albums.sql.txt
+++ b/testdata/result/ddl/create_table_fulltext_albums.sql.txt
@@ -11,9 +11,10 @@ CREATE TABLE Albums (
 ) PRIMARY KEY(AlbumId)
 --- AST
 &ast.CreateTable{
-  Create: 105,
-  Rparen: 575,
-  Name:   &ast.Path{
+  Create:           105,
+  Rparen:           554,
+  PrimaryKeyRparen: 575,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 118,

--- a/testdata/result/ddl/create_table_if_not_exists.sql.txt
+++ b/testdata/result/ddl/create_table_if_not_exists.sql.txt
@@ -6,9 +6,10 @@ create table if not exists foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen:      93,
-  IfNotExists: true,
-  Name:        &ast.Path{
+  Rparen:           70,
+  PrimaryKeyRparen: 93,
+  IfNotExists:      true,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 27,

--- a/testdata/result/ddl/create_table_row_deletion_policy.sql.txt
+++ b/testdata/result/ddl/create_table_row_deletion_policy.sql.txt
@@ -8,8 +8,9 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen: 77,
-  Name:   &ast.Path{
+  Rparen:           62,
+  PrimaryKeyRparen: 77,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/ddl/create_table_synonyms.sql.txt
+++ b/testdata/result/ddl/create_table_synonyms.sql.txt
@@ -6,8 +6,9 @@ CREATE TABLE Singers (
 ) PRIMARY KEY (SingerId)
 --- AST
 &ast.CreateTable{
-  Rparen: 126,
-  Name:   &ast.Path{
+  Rparen:           103,
+  PrimaryKeyRparen: 126,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/ddl/create_table_synonyms_abnormal.sql.txt
+++ b/testdata/result/ddl/create_table_synonyms_abnormal.sql.txt
@@ -8,9 +8,10 @@ CREATE TABLE Singers (
 ) PRIMARY KEY (SingerId)
 --- AST
 &ast.CreateTable{
-  Create: 45,
-  Rparen: 194,
-  Name:   &ast.Path{
+  Create:           45,
+  Rparen:           171,
+  PrimaryKeyRparen: 194,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 58,

--- a/testdata/result/ddl/create_table_trailing_comma.sql.txt
+++ b/testdata/result/ddl/create_table_trailing_comma.sql.txt
@@ -9,8 +9,9 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen: 83,
-  Name:   &ast.Path{
+  Rparen:           45,
+  PrimaryKeyRparen: 83,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/ddl/create_table_types.sql.txt
+++ b/testdata/result/ddl/create_table_types.sql.txt
@@ -31,9 +31,10 @@ create table types (
 
 --- AST
 &ast.CreateTable{
-  Create: 100,
-  Rparen: 796,
-  Name:   &ast.Path{
+  Create:           100,
+  Rparen:           780,
+  PrimaryKeyRparen: 796,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 113,

--- a/testdata/result/ddl/create_table_with_identity_columns.sql.txt
+++ b/testdata/result/ddl/create_table_with_identity_columns.sql.txt
@@ -12,8 +12,9 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen: -1,
-  Name:   &ast.Path{
+  Rparen:           460,
+  PrimaryKeyRparen: -1,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/ddl/create_table_with_sequence_function.sql.txt
+++ b/testdata/result/ddl/create_table_with_sequence_function.sql.txt
@@ -8,8 +8,9 @@ CREATE TABLE foo
 
 --- AST
 &ast.CreateTable{
-  Rparen: 143,
-  Name:   &ast.Path{
+  Rparen:           127,
+  PrimaryKeyRparen: 143,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/ddl/named_schema_create_table_backquoted.sql.txt
+++ b/testdata/result/ddl/named_schema_create_table_backquoted.sql.txt
@@ -2,8 +2,9 @@
 CREATE TABLE `ORDER`.`ORDER`(PK INT64) PRIMARY KEY(PK)
 --- AST
 &ast.CreateTable{
-  Rparen: 53,
-  Name:   &ast.Path{
+  Rparen:           37,
+  PrimaryKeyRparen: 53,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/ddl/named_schemas_create_table.sql.txt
+++ b/testdata/result/ddl/named_schemas_create_table.sql.txt
@@ -7,8 +7,9 @@ CREATE TABLE sch1.Singers (
 ) PRIMARY KEY(SingerId)
 --- AST
 &ast.CreateTable{
-  Rparen: 161,
-  Name:   &ast.Path{
+  Rparen:           139,
+  PrimaryKeyRparen: 161,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/ddl/named_schemas_create_table_foreign_key.sql.txt
+++ b/testdata/result/ddl/named_schemas_create_table_foreign_key.sql.txt
@@ -8,8 +8,9 @@ CREATE TABLE sch1.ShoppingCarts (
 ) PRIMARY KEY(CartId)
 --- AST
 &ast.CreateTable{
-  Rparen: 296,
-  Name:   &ast.Path{
+  Rparen:           276,
+  PrimaryKeyRparen: 296,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/ddl/named_schemas_create_table_interleave.sql.txt
+++ b/testdata/result/ddl/named_schemas_create_table_interleave.sql.txt
@@ -7,8 +7,9 @@ CREATE TABLE sch1.Albums (
   INTERLEAVE IN PARENT sch1.Singers ON DELETE CASCADE
 --- AST
 &ast.CreateTable{
-  Rparen: 137,
-  Name:   &ast.Path{
+  Rparen:           106,
+  PrimaryKeyRparen: 137,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/alter_table_add_check.sql.txt
+++ b/testdata/result/statement/alter_table_add_check.sql.txt
@@ -15,7 +15,8 @@ alter table foo add check (c1 > 0)
   TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
-      Constraint: &ast.Check{
+      ConstraintPos: -1,
+      Constraint:    &ast.Check{
         Check:  20,
         Rparen: 33,
         Expr:   &ast.BinaryExpr{

--- a/testdata/result/statement/alter_table_add_foreign_key.sql.txt
+++ b/testdata/result/statement/alter_table_add_foreign_key.sql.txt
@@ -15,7 +15,8 @@ alter table foo add foreign key (bar) references t2 (t2key1)
   TableAlteration: &ast.AddTableConstraint{
     Add:             16,
     TableConstraint: &ast.TableConstraint{
-      Constraint: &ast.ForeignKey{
+      ConstraintPos: -1,
+      Constraint:    &ast.ForeignKey{
         Foreign:     20,
         Rparen:      59,
         OnDeleteEnd: -1,

--- a/testdata/result/statement/create_change_stream_for_table.sql.txt
+++ b/testdata/result/statement/create_change_stream_for_table.sql.txt
@@ -12,6 +12,7 @@ CREATE CHANGE STREAM change_stream_name FOR table_name
     For:    40,
     Tables: []*ast.ChangeStreamForTable{
       &ast.ChangeStreamForTable{
+        Rparen:    -1,
         TableName: &ast.Ident{
           NamePos: 44,
           NameEnd: 54,

--- a/testdata/result/statement/create_change_stream_for_tables.sql.txt
+++ b/testdata/result/statement/create_change_stream_for_tables.sql.txt
@@ -12,6 +12,7 @@ CREATE CHANGE STREAM change_stream_name FOR table_name1, table_name2
     For:    40,
     Tables: []*ast.ChangeStreamForTable{
       &ast.ChangeStreamForTable{
+        Rparen:    -1,
         TableName: &ast.Ident{
           NamePos: 44,
           NameEnd: 55,
@@ -19,6 +20,7 @@ CREATE CHANGE STREAM change_stream_name FOR table_name1, table_name2
         },
       },
       &ast.ChangeStreamForTable{
+        Rparen:    -1,
         TableName: &ast.Ident{
           NamePos: 57,
           NameEnd: 68,

--- a/testdata/result/statement/create_table.sql.txt
+++ b/testdata/result/statement/create_table.sql.txt
@@ -16,8 +16,9 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen: 573,
-  Name:   &ast.Path{
+  Rparen:           550,
+  PrimaryKeyRparen: 573,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/create_table_cluster.sql.txt
+++ b/testdata/result/statement/create_table_cluster.sql.txt
@@ -7,8 +7,9 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen: 59,
-  Name:   &ast.Path{
+  Rparen:           44,
+  PrimaryKeyRparen: 59,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/create_table_cluster_and_row_deletion_policy.sql.txt
+++ b/testdata/result/statement/create_table_cluster_and_row_deletion_policy.sql.txt
@@ -9,8 +9,9 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen: 77,
-  Name:   &ast.Path{
+  Rparen:           62,
+  PrimaryKeyRparen: 77,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/create_table_cluster_on_delete_no_action.sql.txt
+++ b/testdata/result/statement/create_table_cluster_on_delete_no_action.sql.txt
@@ -6,8 +6,9 @@ create table foo (
              on delete no action
 --- AST
 &ast.CreateTable{
-  Rparen: 50,
-  Name:   &ast.Path{
+  Rparen:           32,
+  PrimaryKeyRparen: 50,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/create_table_cluster_set_on_delete.sql.txt
+++ b/testdata/result/statement/create_table_cluster_set_on_delete.sql.txt
@@ -6,8 +6,9 @@ create table foo (
              on delete cascade
 --- AST
 &ast.CreateTable{
-  Rparen: 49,
-  Name:   &ast.Path{
+  Rparen:           31,
+  PrimaryKeyRparen: 49,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/create_table_for_format_test.sql.txt
+++ b/testdata/result/statement/create_table_for_format_test.sql.txt
@@ -15,9 +15,10 @@ create table if not exists foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen:      461,
-  IfNotExists: true,
-  Name:        &ast.Path{
+  Rparen:           443,
+  PrimaryKeyRparen: 461,
+  IfNotExists:      true,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 27,

--- a/testdata/result/statement/create_table_fulltext_albums.sql.txt
+++ b/testdata/result/statement/create_table_fulltext_albums.sql.txt
@@ -11,9 +11,10 @@ CREATE TABLE Albums (
 ) PRIMARY KEY(AlbumId)
 --- AST
 &ast.CreateTable{
-  Create: 105,
-  Rparen: 575,
-  Name:   &ast.Path{
+  Create:           105,
+  Rparen:           554,
+  PrimaryKeyRparen: 575,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 118,

--- a/testdata/result/statement/create_table_if_not_exists.sql.txt
+++ b/testdata/result/statement/create_table_if_not_exists.sql.txt
@@ -6,9 +6,10 @@ create table if not exists foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen:      93,
-  IfNotExists: true,
-  Name:        &ast.Path{
+  Rparen:           70,
+  PrimaryKeyRparen: 93,
+  IfNotExists:      true,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 27,

--- a/testdata/result/statement/create_table_row_deletion_policy.sql.txt
+++ b/testdata/result/statement/create_table_row_deletion_policy.sql.txt
@@ -8,8 +8,9 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen: 77,
-  Name:   &ast.Path{
+  Rparen:           62,
+  PrimaryKeyRparen: 77,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/create_table_synonyms.sql.txt
+++ b/testdata/result/statement/create_table_synonyms.sql.txt
@@ -6,8 +6,9 @@ CREATE TABLE Singers (
 ) PRIMARY KEY (SingerId)
 --- AST
 &ast.CreateTable{
-  Rparen: 126,
-  Name:   &ast.Path{
+  Rparen:           103,
+  PrimaryKeyRparen: 126,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/create_table_synonyms_abnormal.sql.txt
+++ b/testdata/result/statement/create_table_synonyms_abnormal.sql.txt
@@ -8,9 +8,10 @@ CREATE TABLE Singers (
 ) PRIMARY KEY (SingerId)
 --- AST
 &ast.CreateTable{
-  Create: 45,
-  Rparen: 194,
-  Name:   &ast.Path{
+  Create:           45,
+  Rparen:           171,
+  PrimaryKeyRparen: 194,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 58,

--- a/testdata/result/statement/create_table_trailing_comma.sql.txt
+++ b/testdata/result/statement/create_table_trailing_comma.sql.txt
@@ -9,8 +9,9 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen: 83,
-  Name:   &ast.Path{
+  Rparen:           45,
+  PrimaryKeyRparen: 83,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/create_table_types.sql.txt
+++ b/testdata/result/statement/create_table_types.sql.txt
@@ -31,9 +31,10 @@ create table types (
 
 --- AST
 &ast.CreateTable{
-  Create: 100,
-  Rparen: 796,
-  Name:   &ast.Path{
+  Create:           100,
+  Rparen:           780,
+  PrimaryKeyRparen: 796,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 113,

--- a/testdata/result/statement/create_table_with_identity_columns.sql.txt
+++ b/testdata/result/statement/create_table_with_identity_columns.sql.txt
@@ -12,8 +12,9 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen: -1,
-  Name:   &ast.Path{
+  Rparen:           460,
+  PrimaryKeyRparen: -1,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/create_table_with_sequence_function.sql.txt
+++ b/testdata/result/statement/create_table_with_sequence_function.sql.txt
@@ -8,8 +8,9 @@ CREATE TABLE foo
 
 --- AST
 &ast.CreateTable{
-  Rparen: 143,
-  Name:   &ast.Path{
+  Rparen:           127,
+  PrimaryKeyRparen: 143,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/named_schema_create_table_backquoted.sql.txt
+++ b/testdata/result/statement/named_schema_create_table_backquoted.sql.txt
@@ -2,8 +2,9 @@
 CREATE TABLE `ORDER`.`ORDER`(PK INT64) PRIMARY KEY(PK)
 --- AST
 &ast.CreateTable{
-  Rparen: 53,
-  Name:   &ast.Path{
+  Rparen:           37,
+  PrimaryKeyRparen: 53,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/named_schemas_create_table.sql.txt
+++ b/testdata/result/statement/named_schemas_create_table.sql.txt
@@ -7,8 +7,9 @@ CREATE TABLE sch1.Singers (
 ) PRIMARY KEY(SingerId)
 --- AST
 &ast.CreateTable{
-  Rparen: 161,
-  Name:   &ast.Path{
+  Rparen:           139,
+  PrimaryKeyRparen: 161,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/named_schemas_create_table_foreign_key.sql.txt
+++ b/testdata/result/statement/named_schemas_create_table_foreign_key.sql.txt
@@ -8,8 +8,9 @@ CREATE TABLE sch1.ShoppingCarts (
 ) PRIMARY KEY(CartId)
 --- AST
 &ast.CreateTable{
-  Rparen: 296,
-  Name:   &ast.Path{
+  Rparen:           276,
+  PrimaryKeyRparen: 296,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,

--- a/testdata/result/statement/named_schemas_create_table_interleave.sql.txt
+++ b/testdata/result/statement/named_schemas_create_table_interleave.sql.txt
@@ -7,8 +7,9 @@ CREATE TABLE sch1.Albums (
   INTERLEAVE IN PARENT sch1.Singers ON DELETE CASCADE
 --- AST
 &ast.CreateTable{
-  Rparen: 137,
-  Name:   &ast.Path{
+  Rparen:           106,
+  PrimaryKeyRparen: 137,
+  Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
         NamePos: 13,


### PR DESCRIPTION
This PR adds walk based pos/end test and fixes many pos/end bugs.

- `BinaryExpr.end`
- `Join.end`
- `Selector.end`
- `AlterDatabase.end`
- `CreateTable.end`
- `ChangeStreamForAll.end`, `ChangeStreamForTable.end`
- `TableConstraint.pos`

Note

- `internal/walk.go` have some functionalities related to #218, but it is not yet exported.