### PR TITLE
Implement statement hints in DMLs

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -3957,16 +3957,18 @@ type ThenReturn struct {
 
 // Insert is INSERT statement node.
 //
+//	{{.Hint | sqlOpt}}
 //	INSERT {{if .InsertOrType}}OR .InsertOrType{{end}}INTO {{.TableName | sql}} ({{.Columns | sqlJoin ","}}) {{.Input | sql}}
 //	{{.ThenReturn | sqlOpt}}
 type Insert struct {
-	// pos = Insert
+	// pos = Hint.pos || Insert
 	// end = (ThenReturn ?? Input).end
 
 	Insert token.Pos // position of "INSERT" keyword
 
 	InsertOrType InsertOrType
 
+	Hint       *Hint // optional
 	TableName  *Path
 	Columns    []*Ident
 	Input      InsertInput
@@ -4022,14 +4024,16 @@ type SubQueryInput struct {
 
 // Delete is DELETE statement.
 //
+//	{{.Hint | sqlOpt}}
 //	DELETE FROM {{.TableName | sql}} {{.As | sqlOpt}} {{.Where | sql}}
 //	{{.ThenReturn | sqlOpt}}
 type Delete struct {
-	// pos = Delete
+	// pos = Hint.pos || Delete
 	// end = (ThenReturn ?? Where).end
 
 	Delete token.Pos // position of "DELETE" keyword
 
+	Hint       *Hint // optional
 	TableName  *Path
 	As         *AsAlias // optional
 	Where      *Where
@@ -4038,15 +4042,17 @@ type Delete struct {
 
 // Update is UPDATE statement.
 //
+//	{{.Hint | sqlOpt}}
 //	UPDATE {{.TableName | sql}} {{.As | sqlOpt}}
 //	SET {{.Updates | sqlJoin ","}} {{.Where | sql}}
 //	{{.ThenReturn | sqlOpt}}
 type Update struct {
-	// pos = Update
+	// pos = Hint.pos || Update
 	// end = (ThenReturn ?? Where).end
 
 	Update token.Pos // position of "UPDATE" keyword
 
+	Hint       *Hint // optional
 	TableName  *Path
 	As         *AsAlias      // optional
 	Updates    []*UpdateItem // len(Updates) > 0

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -577,11 +577,12 @@ type BadNode struct {
 
 // BadStatement is a BadNode for Statement.
 //
-//	{{.BadNode | sql}}
+//	{{.Hint | sqlOpt}} {{.BadNode | sql}}
 type BadStatement struct {
-	// pos = BadNode.pos
+	// pos = (Hint ?? BadNode).pos
 	// end = BadNode.end
 
+	Hint    *Hint
 	BadNode *BadNode
 }
 
@@ -592,6 +593,7 @@ type BadQueryExpr struct {
 	// pos = BadNode.pos
 	// end = BadNode.end
 
+	Hint    *Hint
 	BadNode *BadNode
 }
 
@@ -627,11 +629,12 @@ type BadDDL struct {
 
 // BadDML is a BadNode for DML.
 //
-//	{{.BadNode | sql}}
+//	{{.Hint | sqlOpt}} {{.BadNode | sql}}
 type BadDML struct {
-	// pos = BadNode.pos
+	// pos = (Hint ?? BadNode).pos
 	// end = BadNode.end
 
+	Hint    *Hint // optional
 	BadNode *BadNode
 }
 

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -2007,7 +2007,7 @@ func (t *ThenReturn) End() token.Pos {
 }
 
 func (i *Insert) Pos() token.Pos {
-	return i.Insert
+	return posChoice(nodePos(wrapNode(i.Hint)), i.Insert)
 }
 
 func (i *Insert) End() token.Pos {
@@ -2047,7 +2047,7 @@ func (s *SubQueryInput) End() token.Pos {
 }
 
 func (d *Delete) Pos() token.Pos {
-	return d.Delete
+	return posChoice(nodePos(wrapNode(d.Hint)), d.Delete)
 }
 
 func (d *Delete) End() token.Pos {
@@ -2055,7 +2055,7 @@ func (d *Delete) End() token.Pos {
 }
 
 func (u *Update) Pos() token.Pos {
-	return u.Update
+	return posChoice(nodePos(wrapNode(u.Hint)), u.Update)
 }
 
 func (u *Update) End() token.Pos {

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -15,7 +15,7 @@ func (b *BadNode) End() token.Pos {
 }
 
 func (b *BadStatement) Pos() token.Pos {
-	return nodePos(wrapNode(b.BadNode))
+	return nodePos(nodeChoice(wrapNode(b.Hint), wrapNode(b.BadNode)))
 }
 
 func (b *BadStatement) End() token.Pos {
@@ -55,7 +55,7 @@ func (b *BadDDL) End() token.Pos {
 }
 
 func (b *BadDML) Pos() token.Pos {
-	return nodePos(wrapNode(b.BadNode))
+	return nodePos(nodeChoice(wrapNode(b.Hint), wrapNode(b.BadNode)))
 }
 
 func (b *BadDML) End() token.Pos {

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -1306,7 +1306,8 @@ func (t *ThenReturn) SQL() string {
 }
 
 func (i *Insert) SQL() string {
-	return "INSERT " +
+	return sqlOpt("", i.Hint, " ") +
+		"INSERT " +
 		strOpt(i.InsertOrType != "", "OR "+string(i.InsertOrType)+" ") +
 		"INTO " + i.TableName.SQL() + " (" +
 		sqlJoin(i.Columns, ", ") +
@@ -1335,7 +1336,8 @@ func (s *SubQueryInput) SQL() string {
 }
 
 func (d *Delete) SQL() string {
-	return "DELETE FROM " +
+	return sqlOpt("", d.Hint, " ") +
+		"DELETE FROM " +
 		d.TableName.SQL() + " " +
 		sqlOpt("", d.As, " ") +
 		d.Where.SQL() +
@@ -1343,7 +1345,8 @@ func (d *Delete) SQL() string {
 }
 
 func (u *Update) SQL() string {
-	return "UPDATE " + u.TableName.SQL() + " " +
+	return sqlOpt("", u.Hint, " ") +
+		"UPDATE " + u.TableName.SQL() + " " +
 		sqlOpt("", u.As, " ") +
 		"SET " +
 		sqlJoin(u.Updates, ", ") +

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -172,12 +172,12 @@ func (b *BadNode) SQL() string {
 	return sql
 }
 
-func (b *BadStatement) SQL() string { return b.BadNode.SQL() }
+func (b *BadStatement) SQL() string { return sqlOpt("", b.Hint, " ") + b.BadNode.SQL() }
 func (b *BadQueryExpr) SQL() string { return b.BadNode.SQL() }
 func (b *BadExpr) SQL() string      { return b.BadNode.SQL() }
 func (b *BadType) SQL() string      { return b.BadNode.SQL() }
 func (b *BadDDL) SQL() string       { return b.BadNode.SQL() }
-func (b *BadDML) SQL() string       { return b.BadNode.SQL() }
+func (b *BadDML) SQL() string       { return sqlOpt("", b.Hint, " ") + b.BadNode.SQL() }
 
 // ================================================================================
 //

--- a/parser.go
+++ b/parser.go
@@ -180,7 +180,7 @@ func (p *Parser) parseStatementInternal(hint *ast.Hint) (stmt ast.Statement) {
 	case p.Token.IsKeywordLike("INSERT") || p.Token.IsKeywordLike("DELETE") || p.Token.IsKeywordLike("UPDATE"):
 		return p.parseDMLInternal(hint)
 	case hint != nil:
-		panic(p.errorfAtToken(&p.Token, "statement hint is only permitted before query or DML, but got: %s", p.Token.Raw))
+		panic(p.errorfAtPosition(hint.Pos(), p.Token.End, "statement hint is only permitted before query or DML, but got: %s", p.Token.Raw))
 	case p.Token.Kind == "CREATE" || p.Token.IsKeywordLike("ALTER") || p.Token.IsKeywordLike("DROP") ||
 		p.Token.IsKeywordLike("RENAME") || p.Token.IsKeywordLike("GRANT") || p.Token.IsKeywordLike("REVOKE") ||
 		p.Token.IsKeywordLike("ANALYZE"):

--- a/parser.go
+++ b/parser.go
@@ -150,16 +150,6 @@ func (p *Parser) ParseDMLs() ([]ast.DML, error) {
 	return dmls, nil
 }
 
-func (p *Parser) lookaheadTokenAfterOptionalHint() token.Token {
-	lexer := p.Lexer.Clone()
-	defer func() {
-		p.Lexer = lexer
-	}()
-
-	p.tryParseHint()
-	return p.Token
-}
-
 func (p *Parser) parseStatement() (stmt ast.Statement) {
 	l := p.Lexer.Clone()
 	defer func() {

--- a/parser.go
+++ b/parser.go
@@ -189,7 +189,7 @@ func (p *Parser) parseStatementInternal(hint *ast.Hint) (stmt ast.Statement) {
 		return p.parseOtherStatement()
 	}
 
-	panic(p.errorfAtToken(&p.Token, "unexpected p.Token: %s", p.Token.Kind))
+	panic(p.errorfAtToken(&p.Token, "unexpected token: %s", p.Token.Kind))
 }
 
 func (p *Parser) parseOtherStatement() ast.Statement {

--- a/parser.go
+++ b/parser.go
@@ -261,17 +261,7 @@ func (p *Parser) parseQueryStatement() (stmt *ast.QueryStatement) {
 }
 
 func (p *Parser) parseQueryStatementInternal(hint *ast.Hint) (stmt *ast.QueryStatement) {
-	l := p.Lexer.Clone()
-	defer func() {
-		if r := recover(); r != nil {
-			// When parsing is failed on tryParseWith, the result of these methods are discarded
-			// because they are concrete structs and we cannot fill them with *ast.BadNode.
-			stmt = &ast.QueryStatement{
-				Query: &ast.BadQueryExpr{BadNode: p.handleParseStatementError(r, l)},
-			}
-		}
-	}()
-
+	// Can be BadQueryExpr and won't panic
 	query := p.parseQueryExpr()
 
 	return &ast.QueryStatement{

--- a/parser.go
+++ b/parser.go
@@ -261,7 +261,7 @@ func (p *Parser) parseQueryStatement() (stmt *ast.QueryStatement) {
 }
 
 func (p *Parser) parseQueryStatementInternal(hint *ast.Hint) (stmt *ast.QueryStatement) {
-	// Can be BadQueryExpr and won't panic
+	// Can be a *ast.BadQueryExpr and won't panic
 	query := p.parseQueryExpr()
 
 	return &ast.QueryStatement{

--- a/testdata/input/ddl/!bad_create_table_with_hint.sql
+++ b/testdata/input/ddl/!bad_create_table_with_hint.sql
@@ -1,0 +1,2 @@
+@{unknown_hint=1}
+create table tbl(pk int64 primary key)

--- a/testdata/input/dml/!bad_delete.sql
+++ b/testdata/input/dml/!bad_delete.sql
@@ -1,0 +1,1 @@
+delete foo filter foo = 1 and bar = 2

--- a/testdata/input/dml/!bad_delete_with_bad_hint.sql
+++ b/testdata/input/dml/!bad_delete_with_bad_hint.sql
@@ -1,0 +1,2 @@
+@{invalid}
+delete foo where foo = 1 and bar = 2

--- a/testdata/input/dml/!bad_delete_with_hint.sql
+++ b/testdata/input/dml/!bad_delete_with_hint.sql
@@ -1,0 +1,2 @@
+@{pdml_max_parallelism=1}
+delete foo filter foo = 1 and bar = 2

--- a/testdata/input/dml/!bad_insert_with_bad_hint.sql
+++ b/testdata/input/dml/!bad_insert_with_bad_hint.sql
@@ -1,0 +1,4 @@
+@{invalid}
+insert foo (foo, bar, baz)
+vales (1, 2, 3),
+      (4, 5, 6)

--- a/testdata/input/dml/!bad_insert_with_hint.sql
+++ b/testdata/input/dml/!bad_insert_with_hint.sql
@@ -1,0 +1,4 @@
+@{pdml_max_parallelism=1}
+insert foo (foo, bar, baz)
+vales (1, 2, 3),
+      (4, 5, 6)

--- a/testdata/input/dml/!bad_update.sql
+++ b/testdata/input/dml/!bad_update.sql
@@ -1,0 +1,1 @@
+update foo set invalid where foo = 1

--- a/testdata/input/dml/!bad_update_with_bad_hint.sql
+++ b/testdata/input/dml/!bad_update_with_bad_hint.sql
@@ -1,0 +1,2 @@
+@{invalid}
+update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1

--- a/testdata/input/dml/!bad_update_with_hint.sql
+++ b/testdata/input/dml/!bad_update_with_hint.sql
@@ -1,0 +1,2 @@
+@{pdml_max_parallelism=1}
+update foo set invalid where foo = 1

--- a/testdata/input/dml/delete_with_hint.sql
+++ b/testdata/input/dml/delete_with_hint.sql
@@ -1,0 +1,1 @@
+@{pdml_max_parallelism=1} delete foo where foo = 1 and bar = 2

--- a/testdata/input/dml/insert_with_hint.sql
+++ b/testdata/input/dml/insert_with_hint.sql
@@ -1,0 +1,4 @@
+@{pdml_max_parallelism=1}
+insert into foo (foo, bar, baz)
+values (1, 2, 3),
+       (4, 5, 6)

--- a/testdata/input/dml/update_with_hint.sql
+++ b/testdata/input/dml/update_with_hint.sql
@@ -1,0 +1,2 @@
+@{pdml_max_parallelism=1}
+update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1

--- a/testdata/input/query/!bad_with_select_with_hint.sql
+++ b/testdata/input/query/!bad_with_select_with_hint.sql
@@ -1,0 +1,1 @@
+@{hint = 1} WITH SELECT 1

--- a/testdata/input/statement/!bad_call_cancel_query_with_hint.sql
+++ b/testdata/input/statement/!bad_call_cancel_query_with_hint.sql
@@ -1,0 +1,2 @@
+@{unknown_hint=1}
+CALL cancel_query("12345")

--- a/testdata/input/statement/!bad_call_cancel_query_with_hint_oneline.sql
+++ b/testdata/input/statement/!bad_call_cancel_query_with_hint_oneline.sql
@@ -1,0 +1,1 @@
+@{unknown_hint=1} CALL cancel_query("12345")

--- a/testdata/result/ddl/!bad_create_table_with_hint.sql.txt
+++ b/testdata/result/ddl/!bad_create_table_with_hint.sql.txt
@@ -1,0 +1,123 @@
+--- !bad_create_table_with_hint.sql
+@{unknown_hint=1}
+create table tbl(pk int64 primary key)
+--- Error
+syntax error: testdata/input/ddl/!bad_create_table_with_hint.sql:1:1: expected token: CREATE, <ident>, but: @
+  1|  @{unknown_hint=1}
+   |  ^
+
+
+--- AST
+&ast.BadDDL{
+  BadNode: &ast.BadNode{
+    NodeEnd: 56,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind: "@",
+        Raw:  "@",
+        End:  1,
+      },
+      &token.Token{
+        Kind: "{",
+        Raw:  "{",
+        Pos:  1,
+        End:  2,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "unknown_hint",
+        AsString: "unknown_hint",
+        Pos:      2,
+        End:      14,
+      },
+      &token.Token{
+        Kind: "=",
+        Raw:  "=",
+        Pos:  14,
+        End:  15,
+      },
+      &token.Token{
+        Kind: "<int>",
+        Raw:  "1",
+        Base: 10,
+        Pos:  15,
+        End:  16,
+      },
+      &token.Token{
+        Kind: "}",
+        Raw:  "}",
+        Pos:  16,
+        End:  17,
+      },
+      &token.Token{
+        Kind:  "CREATE",
+        Space: "\n",
+        Raw:   "create",
+        Pos:   18,
+        End:   24,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "table",
+        AsString: "table",
+        Pos:      25,
+        End:      30,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "tbl",
+        AsString: "tbl",
+        Pos:      31,
+        End:      34,
+      },
+      &token.Token{
+        Kind: "(",
+        Raw:  "(",
+        Pos:  34,
+        End:  35,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "pk",
+        AsString: "pk",
+        Pos:      35,
+        End:      37,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "int64",
+        AsString: "int64",
+        Pos:      38,
+        End:      43,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "primary",
+        AsString: "primary",
+        Pos:      44,
+        End:      51,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "key",
+        AsString: "key",
+        Pos:      52,
+        End:      55,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  55,
+        End:  56,
+      },
+    },
+  },
+}
+
+--- SQL
+@{unknown_hint=1} create table tbl(pk int64 primary key)

--- a/testdata/result/dml/!bad_delete.sql.txt
+++ b/testdata/result/dml/!bad_delete.sql.txt
@@ -1,0 +1,94 @@
+--- !bad_delete.sql
+delete foo filter foo = 1 and bar = 2
+--- Error
+syntax error: testdata/input/dml/!bad_delete.sql:1:19: expected token: WHERE, but: <ident>
+  1|  delete foo filter foo = 1 and bar = 2
+   |                    ^~~
+
+
+--- AST
+&ast.BadDML{
+  BadNode: &ast.BadNode{
+    NodeEnd: 37,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "delete",
+        AsString: "delete",
+        End:      6,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      7,
+        End:      10,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "filter",
+        AsString: "filter",
+        Pos:      11,
+        End:      17,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      18,
+        End:      21,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   22,
+        End:   23,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "1",
+        Base:  10,
+        Pos:   24,
+        End:   25,
+      },
+      &token.Token{
+        Kind:  "AND",
+        Space: " ",
+        Raw:   "and",
+        Pos:   26,
+        End:   29,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "bar",
+        AsString: "bar",
+        Pos:      30,
+        End:      33,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   34,
+        End:   35,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "2",
+        Base:  10,
+        Pos:   36,
+        End:   37,
+      },
+    },
+  },
+}
+
+--- SQL
+delete foo filter foo = 1 and bar = 2

--- a/testdata/result/dml/!bad_delete_with_bad_hint.sql.txt
+++ b/testdata/result/dml/!bad_delete_with_bad_hint.sql.txt
@@ -1,0 +1,120 @@
+--- !bad_delete_with_bad_hint.sql
+@{invalid}
+delete foo where foo = 1 and bar = 2
+--- Error
+syntax error: testdata/input/dml/!bad_delete_with_bad_hint.sql:1:10: expected token: =, but: }
+  1|  @{invalid}
+   |           ^
+
+
+--- AST
+&ast.BadDML{
+  BadNode: &ast.BadNode{
+    NodeEnd: 47,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind: "@",
+        Raw:  "@",
+        End:  1,
+      },
+      &token.Token{
+        Kind: "{",
+        Raw:  "{",
+        Pos:  1,
+        End:  2,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "invalid",
+        AsString: "invalid",
+        Pos:      2,
+        End:      9,
+      },
+      &token.Token{
+        Kind: "}",
+        Raw:  "}",
+        Pos:  9,
+        End:  10,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n",
+        Raw:      "delete",
+        AsString: "delete",
+        Pos:      11,
+        End:      17,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      18,
+        End:      21,
+      },
+      &token.Token{
+        Kind:  "WHERE",
+        Space: " ",
+        Raw:   "where",
+        Pos:   22,
+        End:   27,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      28,
+        End:      31,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   32,
+        End:   33,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "1",
+        Base:  10,
+        Pos:   34,
+        End:   35,
+      },
+      &token.Token{
+        Kind:  "AND",
+        Space: " ",
+        Raw:   "and",
+        Pos:   36,
+        End:   39,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "bar",
+        AsString: "bar",
+        Pos:      40,
+        End:      43,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   44,
+        End:   45,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "2",
+        Base:  10,
+        Pos:   46,
+        End:   47,
+      },
+    },
+  },
+}
+
+--- SQL
+@{invalid} delete foo where foo = 1 and bar = 2

--- a/testdata/result/dml/!bad_delete_with_hint.sql.txt
+++ b/testdata/result/dml/!bad_delete_with_hint.sql.txt
@@ -1,0 +1,120 @@
+--- !bad_delete_with_hint.sql
+@{pdml_max_parallelism=1}
+delete foo filter foo = 1 and bar = 2
+--- Error
+syntax error: testdata/input/dml/!bad_delete_with_hint.sql:2:19: expected token: WHERE, but: <ident>
+  2|  delete foo filter foo = 1 and bar = 2
+   |                    ^~~
+
+
+--- AST
+&ast.BadDML{
+  Hint: &ast.Hint{
+    Rbrace:  24,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 22,
+              Name:    "pdml_max_parallelism",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 23,
+          ValueEnd: 24,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  BadNode: &ast.BadNode{
+    NodePos: 26,
+    NodeEnd: 63,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n",
+        Raw:      "delete",
+        AsString: "delete",
+        Pos:      26,
+        End:      32,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      33,
+        End:      36,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "filter",
+        AsString: "filter",
+        Pos:      37,
+        End:      43,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      44,
+        End:      47,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   48,
+        End:   49,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "1",
+        Base:  10,
+        Pos:   50,
+        End:   51,
+      },
+      &token.Token{
+        Kind:  "AND",
+        Space: " ",
+        Raw:   "and",
+        Pos:   52,
+        End:   55,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "bar",
+        AsString: "bar",
+        Pos:      56,
+        End:      59,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   60,
+        End:   61,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "2",
+        Base:  10,
+        Pos:   62,
+        End:   63,
+      },
+    },
+  },
+}
+
+--- SQL
+@{pdml_max_parallelism=1} delete foo filter foo = 1 and bar = 2

--- a/testdata/result/dml/!bad_insert_with_bad_hint.sql.txt
+++ b/testdata/result/dml/!bad_insert_with_bad_hint.sql.txt
@@ -1,0 +1,220 @@
+--- !bad_insert_with_bad_hint.sql
+@{invalid}
+insert foo (foo, bar, baz)
+vales (1, 2, 3),
+      (4, 5, 6)
+--- Error
+syntax error: testdata/input/dml/!bad_insert_with_bad_hint.sql:1:10: expected token: =, but: }
+  1|  @{invalid}
+   |           ^
+
+
+--- AST
+&ast.BadDML{
+  BadNode: &ast.BadNode{
+    NodeEnd: 70,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind: "@",
+        Raw:  "@",
+        End:  1,
+      },
+      &token.Token{
+        Kind: "{",
+        Raw:  "{",
+        Pos:  1,
+        End:  2,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "invalid",
+        AsString: "invalid",
+        Pos:      2,
+        End:      9,
+      },
+      &token.Token{
+        Kind: "}",
+        Raw:  "}",
+        Pos:  9,
+        End:  10,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n",
+        Raw:      "insert",
+        AsString: "insert",
+        Pos:      11,
+        End:      17,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      18,
+        End:      21,
+      },
+      &token.Token{
+        Kind:  "(",
+        Space: " ",
+        Raw:   "(",
+        Pos:   22,
+        End:   23,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      23,
+        End:      26,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  26,
+        End:  27,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "bar",
+        AsString: "bar",
+        Pos:      28,
+        End:      31,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  31,
+        End:  32,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "baz",
+        AsString: "baz",
+        Pos:      33,
+        End:      36,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  36,
+        End:  37,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n",
+        Raw:      "vales",
+        AsString: "vales",
+        Pos:      38,
+        End:      43,
+      },
+      &token.Token{
+        Kind:  "(",
+        Space: " ",
+        Raw:   "(",
+        Pos:   44,
+        End:   45,
+      },
+      &token.Token{
+        Kind: "<int>",
+        Raw:  "1",
+        Base: 10,
+        Pos:  45,
+        End:  46,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  46,
+        End:  47,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "2",
+        Base:  10,
+        Pos:   48,
+        End:   49,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  49,
+        End:  50,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "3",
+        Base:  10,
+        Pos:   51,
+        End:   52,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  52,
+        End:  53,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  53,
+        End:  54,
+      },
+      &token.Token{
+        Kind:  "(",
+        Space: "\n      ",
+        Raw:   "(",
+        Pos:   61,
+        End:   62,
+      },
+      &token.Token{
+        Kind: "<int>",
+        Raw:  "4",
+        Base: 10,
+        Pos:  62,
+        End:  63,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  63,
+        End:  64,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "5",
+        Base:  10,
+        Pos:   65,
+        End:   66,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  66,
+        End:  67,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "6",
+        Base:  10,
+        Pos:   68,
+        End:   69,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  69,
+        End:  70,
+      },
+    },
+  },
+}
+
+--- SQL
+@{invalid} insert foo (foo, bar, baz) vales (1, 2, 3), (4, 5, 6)

--- a/testdata/result/dml/!bad_insert_with_hint.sql.txt
+++ b/testdata/result/dml/!bad_insert_with_hint.sql.txt
@@ -1,0 +1,186 @@
+--- !bad_insert_with_hint.sql
+@{pdml_max_parallelism=1}
+insert foo (foo, bar, baz)
+vales (1, 2, 3),
+      (4, 5, 6)
+--- Error
+syntax error: testdata/input/dml/!bad_insert_with_hint.sql:3:1: expected beginning of simple query "(", SELECT, FROM, but: "vales"
+  3|  vales (1, 2, 3),
+   |  ^~~~~
+
+
+--- AST
+&ast.Insert{
+  Insert: 26,
+  Hint:   &ast.Hint{
+    Rbrace:  24,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 22,
+              Name:    "pdml_max_parallelism",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 23,
+          ValueEnd: 24,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 33,
+        NameEnd: 36,
+        Name:    "foo",
+      },
+    },
+  },
+  Columns: []*ast.Ident{
+    &ast.Ident{
+      NamePos: 38,
+      NameEnd: 41,
+      Name:    "foo",
+    },
+    &ast.Ident{
+      NamePos: 43,
+      NameEnd: 46,
+      Name:    "bar",
+    },
+    &ast.Ident{
+      NamePos: 48,
+      NameEnd: 51,
+      Name:    "baz",
+    },
+  },
+  Input: &ast.SubQueryInput{
+    Query: &ast.BadQueryExpr{
+      BadNode: &ast.BadNode{
+        NodePos: 53,
+        NodeEnd: 85,
+        Tokens:  []*token.Token{
+          &token.Token{
+            Kind:     "<ident>",
+            Space:    "\n",
+            Raw:      "vales",
+            AsString: "vales",
+            Pos:      53,
+            End:      58,
+          },
+          &token.Token{
+            Kind:  "(",
+            Space: " ",
+            Raw:   "(",
+            Pos:   59,
+            End:   60,
+          },
+          &token.Token{
+            Kind: "<int>",
+            Raw:  "1",
+            Base: 10,
+            Pos:  60,
+            End:  61,
+          },
+          &token.Token{
+            Kind: ",",
+            Raw:  ",",
+            Pos:  61,
+            End:  62,
+          },
+          &token.Token{
+            Kind:  "<int>",
+            Space: " ",
+            Raw:   "2",
+            Base:  10,
+            Pos:   63,
+            End:   64,
+          },
+          &token.Token{
+            Kind: ",",
+            Raw:  ",",
+            Pos:  64,
+            End:  65,
+          },
+          &token.Token{
+            Kind:  "<int>",
+            Space: " ",
+            Raw:   "3",
+            Base:  10,
+            Pos:   66,
+            End:   67,
+          },
+          &token.Token{
+            Kind: ")",
+            Raw:  ")",
+            Pos:  67,
+            End:  68,
+          },
+          &token.Token{
+            Kind: ",",
+            Raw:  ",",
+            Pos:  68,
+            End:  69,
+          },
+          &token.Token{
+            Kind:  "(",
+            Space: "\n      ",
+            Raw:   "(",
+            Pos:   76,
+            End:   77,
+          },
+          &token.Token{
+            Kind: "<int>",
+            Raw:  "4",
+            Base: 10,
+            Pos:  77,
+            End:  78,
+          },
+          &token.Token{
+            Kind: ",",
+            Raw:  ",",
+            Pos:  78,
+            End:  79,
+          },
+          &token.Token{
+            Kind:  "<int>",
+            Space: " ",
+            Raw:   "5",
+            Base:  10,
+            Pos:   80,
+            End:   81,
+          },
+          &token.Token{
+            Kind: ",",
+            Raw:  ",",
+            Pos:  81,
+            End:  82,
+          },
+          &token.Token{
+            Kind:  "<int>",
+            Space: " ",
+            Raw:   "6",
+            Base:  10,
+            Pos:   83,
+            End:   84,
+          },
+          &token.Token{
+            Kind: ")",
+            Raw:  ")",
+            Pos:  84,
+            End:  85,
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+@{pdml_max_parallelism=1} INSERT INTO foo (foo, bar, baz) vales (1, 2, 3), (4, 5, 6)

--- a/testdata/result/dml/!bad_update.sql.txt
+++ b/testdata/result/dml/!bad_update.sql.txt
@@ -1,0 +1,78 @@
+--- !bad_update.sql
+update foo set invalid where foo = 1
+--- Error
+syntax error: testdata/input/dml/!bad_update.sql:1:24: expected token: =, but: WHERE
+  1|  update foo set invalid where foo = 1
+   |                         ^~~~~
+
+
+--- AST
+&ast.BadDML{
+  BadNode: &ast.BadNode{
+    NodeEnd: 36,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "update",
+        AsString: "update",
+        End:      6,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      7,
+        End:      10,
+      },
+      &token.Token{
+        Kind:  "SET",
+        Space: " ",
+        Raw:   "set",
+        Pos:   11,
+        End:   14,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "invalid",
+        AsString: "invalid",
+        Pos:      15,
+        End:      22,
+      },
+      &token.Token{
+        Kind:  "WHERE",
+        Space: " ",
+        Raw:   "where",
+        Pos:   23,
+        End:   28,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      29,
+        End:      32,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   33,
+        End:   34,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "1",
+        Base:  10,
+        Pos:   35,
+        End:   36,
+      },
+    },
+  },
+}
+
+--- SQL
+update foo set invalid where foo = 1

--- a/testdata/result/dml/!bad_update_with_bad_hint.sql.txt
+++ b/testdata/result/dml/!bad_update_with_bad_hint.sql.txt
@@ -1,0 +1,178 @@
+--- !bad_update_with_bad_hint.sql
+@{invalid}
+update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
+
+--- Error
+syntax error: testdata/input/dml/!bad_update_with_bad_hint.sql:1:10: expected token: =, but: }
+  1|  @{invalid}
+   |           ^
+
+
+--- AST
+&ast.BadDML{
+  BadNode: &ast.BadNode{
+    NodeEnd: 75,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind: "@",
+        Raw:  "@",
+        End:  1,
+      },
+      &token.Token{
+        Kind: "{",
+        Raw:  "{",
+        Pos:  1,
+        End:  2,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "invalid",
+        AsString: "invalid",
+        Pos:      2,
+        End:      9,
+      },
+      &token.Token{
+        Kind: "}",
+        Raw:  "}",
+        Pos:  9,
+        End:  10,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n",
+        Raw:      "update",
+        AsString: "update",
+        Pos:      11,
+        End:      17,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      18,
+        End:      21,
+      },
+      &token.Token{
+        Kind:  "SET",
+        Space: " ",
+        Raw:   "set",
+        Pos:   22,
+        End:   25,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      26,
+        End:      29,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   30,
+        End:   31,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "bar",
+        AsString: "bar",
+        Pos:      32,
+        End:      35,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  35,
+        End:  36,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "bar",
+        AsString: "bar",
+        Pos:      37,
+        End:      40,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   41,
+        End:   42,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      43,
+        End:      46,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  46,
+        End:  47,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "baz",
+        AsString: "baz",
+        Pos:      48,
+        End:      51,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   52,
+        End:   53,
+      },
+      &token.Token{
+        Kind:  "DEFAULT",
+        Space: " ",
+        Raw:   "DEFAULT",
+        Pos:   54,
+        End:   61,
+      },
+      &token.Token{
+        Kind:  "WHERE",
+        Space: " ",
+        Raw:   "where",
+        Pos:   62,
+        End:   67,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      68,
+        End:      71,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   72,
+        End:   73,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "1",
+        Base:  10,
+        Pos:   74,
+        End:   75,
+      },
+    },
+  },
+}
+
+--- SQL
+@{invalid} update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1

--- a/testdata/result/dml/!bad_update_with_hint.sql.txt
+++ b/testdata/result/dml/!bad_update_with_hint.sql.txt
@@ -1,0 +1,104 @@
+--- !bad_update_with_hint.sql
+@{pdml_max_parallelism=1}
+update foo set invalid where foo = 1
+--- Error
+syntax error: testdata/input/dml/!bad_update_with_hint.sql:2:24: expected token: =, but: WHERE
+  2|  update foo set invalid where foo = 1
+   |                         ^~~~~
+
+
+--- AST
+&ast.BadDML{
+  Hint: &ast.Hint{
+    Rbrace:  24,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 22,
+              Name:    "pdml_max_parallelism",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 23,
+          ValueEnd: 24,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  BadNode: &ast.BadNode{
+    NodePos: 26,
+    NodeEnd: 62,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n",
+        Raw:      "update",
+        AsString: "update",
+        Pos:      26,
+        End:      32,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      33,
+        End:      36,
+      },
+      &token.Token{
+        Kind:  "SET",
+        Space: " ",
+        Raw:   "set",
+        Pos:   37,
+        End:   40,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "invalid",
+        AsString: "invalid",
+        Pos:      41,
+        End:      48,
+      },
+      &token.Token{
+        Kind:  "WHERE",
+        Space: " ",
+        Raw:   "where",
+        Pos:   49,
+        End:   54,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      55,
+        End:      58,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   59,
+        End:   60,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "1",
+        Base:  10,
+        Pos:   61,
+        End:   62,
+      },
+    },
+  },
+}
+
+--- SQL
+@{pdml_max_parallelism=1} update foo set invalid where foo = 1

--- a/testdata/result/dml/delete_with_hint.sql.txt
+++ b/testdata/result/dml/delete_with_hint.sql.txt
@@ -1,0 +1,74 @@
+--- delete_with_hint.sql
+@{pdml_max_parallelism=1} delete foo where foo = 1 and bar = 2
+--- AST
+&ast.Delete{
+  Delete: 26,
+  Hint:   &ast.Hint{
+    Rbrace:  24,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 22,
+              Name:    "pdml_max_parallelism",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 23,
+          ValueEnd: 24,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 33,
+        NameEnd: 36,
+        Name:    "foo",
+      },
+    },
+  },
+  Where: &ast.Where{
+    Where: 37,
+    Expr:  &ast.BinaryExpr{
+      Op:   "AND",
+      Left: &ast.BinaryExpr{
+        Op:   "=",
+        Left: &ast.Ident{
+          NamePos: 43,
+          NameEnd: 46,
+          Name:    "foo",
+        },
+        Right: &ast.IntLiteral{
+          ValuePos: 49,
+          ValueEnd: 50,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+      Right: &ast.BinaryExpr{
+        Op:   "=",
+        Left: &ast.Ident{
+          NamePos: 55,
+          NameEnd: 58,
+          Name:    "bar",
+        },
+        Right: &ast.IntLiteral{
+          ValuePos: 61,
+          ValueEnd: 62,
+          Base:     10,
+          Value:    "2",
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+@{pdml_max_parallelism=1} DELETE FROM foo WHERE foo = 1 AND bar = 2

--- a/testdata/result/dml/insert_with_hint.sql.txt
+++ b/testdata/result/dml/insert_with_hint.sql.txt
@@ -1,0 +1,131 @@
+--- insert_with_hint.sql
+@{pdml_max_parallelism=1}
+insert into foo (foo, bar, baz)
+values (1, 2, 3),
+       (4, 5, 6)
+--- AST
+&ast.Insert{
+  Insert: 26,
+  Hint:   &ast.Hint{
+    Rbrace:  24,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 22,
+              Name:    "pdml_max_parallelism",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 23,
+          ValueEnd: 24,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 38,
+        NameEnd: 41,
+        Name:    "foo",
+      },
+    },
+  },
+  Columns: []*ast.Ident{
+    &ast.Ident{
+      NamePos: 43,
+      NameEnd: 46,
+      Name:    "foo",
+    },
+    &ast.Ident{
+      NamePos: 48,
+      NameEnd: 51,
+      Name:    "bar",
+    },
+    &ast.Ident{
+      NamePos: 53,
+      NameEnd: 56,
+      Name:    "baz",
+    },
+  },
+  Input: &ast.ValuesInput{
+    Values: 58,
+    Rows:   []*ast.ValuesRow{
+      &ast.ValuesRow{
+        Lparen: 65,
+        Rparen: 73,
+        Exprs:  []*ast.DefaultExpr{
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 66,
+              ValueEnd: 67,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 69,
+              ValueEnd: 70,
+              Base:     10,
+              Value:    "2",
+            },
+          },
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 72,
+              ValueEnd: 73,
+              Base:     10,
+              Value:    "3",
+            },
+          },
+        },
+      },
+      &ast.ValuesRow{
+        Lparen: 83,
+        Rparen: 91,
+        Exprs:  []*ast.DefaultExpr{
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 84,
+              ValueEnd: 85,
+              Base:     10,
+              Value:    "4",
+            },
+          },
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 87,
+              ValueEnd: 88,
+              Base:     10,
+              Value:    "5",
+            },
+          },
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 90,
+              ValueEnd: 91,
+              Base:     10,
+              Value:    "6",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+@{pdml_max_parallelism=1} INSERT INTO foo (foo, bar, baz) VALUES (1, 2, 3), (4, 5, 6)

--- a/testdata/result/dml/update_with_hint.sql.txt
+++ b/testdata/result/dml/update_with_hint.sql.txt
@@ -1,0 +1,107 @@
+--- update_with_hint.sql
+@{pdml_max_parallelism=1}
+update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
+--- AST
+&ast.Update{
+  Update: 26,
+  Hint:   &ast.Hint{
+    Rbrace:  24,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 22,
+              Name:    "pdml_max_parallelism",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 23,
+          ValueEnd: 24,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 33,
+        NameEnd: 36,
+        Name:    "foo",
+      },
+    },
+  },
+  Updates: []*ast.UpdateItem{
+    &ast.UpdateItem{
+      Path: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 41,
+          NameEnd: 44,
+          Name:    "foo",
+        },
+      },
+      DefaultExpr: &ast.DefaultExpr{
+        DefaultPos: -1,
+        Expr:       &ast.Ident{
+          NamePos: 47,
+          NameEnd: 50,
+          Name:    "bar",
+        },
+      },
+    },
+    &ast.UpdateItem{
+      Path: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 52,
+          NameEnd: 55,
+          Name:    "bar",
+        },
+      },
+      DefaultExpr: &ast.DefaultExpr{
+        DefaultPos: -1,
+        Expr:       &ast.Ident{
+          NamePos: 58,
+          NameEnd: 61,
+          Name:    "foo",
+        },
+      },
+    },
+    &ast.UpdateItem{
+      Path: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 63,
+          NameEnd: 66,
+          Name:    "baz",
+        },
+      },
+      DefaultExpr: &ast.DefaultExpr{
+        DefaultPos: 69,
+        Default:    true,
+      },
+    },
+  },
+  Where: &ast.Where{
+    Where: 77,
+    Expr:  &ast.BinaryExpr{
+      Op:   "=",
+      Left: &ast.Ident{
+        NamePos: 83,
+        NameEnd: 86,
+        Name:    "foo",
+      },
+      Right: &ast.IntLiteral{
+        ValuePos: 89,
+        ValueEnd: 90,
+        Base:     10,
+        Value:    "1",
+      },
+    },
+  },
+}
+
+--- SQL
+@{pdml_max_parallelism=1} UPDATE foo SET foo = bar, bar = foo, baz = DEFAULT WHERE foo = 1

--- a/testdata/result/query/!bad_with_select_with_hint.sql.txt
+++ b/testdata/result/query/!bad_with_select_with_hint.sql.txt
@@ -1,0 +1,66 @@
+--- !bad_with_select_with_hint.sql
+@{hint = 1} WITH SELECT 1
+--- Error
+syntax error: testdata/input/query/!bad_with_select_with_hint.sql:1:18: expected token: <ident>, but: SELECT
+  1|  @{hint = 1} WITH SELECT 1
+   |                   ^~~~~~
+
+
+--- AST
+&ast.QueryStatement{
+  Hint: &ast.Hint{
+    Rbrace:  10,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 6,
+              Name:    "hint",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 9,
+          ValueEnd: 10,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  Query: &ast.BadQueryExpr{
+    BadNode: &ast.BadNode{
+      NodePos: 12,
+      NodeEnd: 25,
+      Tokens:  []*token.Token{
+        &token.Token{
+          Kind:  "WITH",
+          Space: " ",
+          Raw:   "WITH",
+          Pos:   12,
+          End:   16,
+        },
+        &token.Token{
+          Kind:  "SELECT",
+          Space: " ",
+          Raw:   "SELECT",
+          Pos:   17,
+          End:   23,
+        },
+        &token.Token{
+          Kind:  "<int>",
+          Space: " ",
+          Raw:   "1",
+          Base:  10,
+          Pos:   24,
+          End:   25,
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+@{hint=1} WITH SELECT 1

--- a/testdata/result/statement/!bad_call_cancel_query_with_hint.sql.txt
+++ b/testdata/result/statement/!bad_call_cancel_query_with_hint.sql.txt
@@ -1,0 +1,78 @@
+--- !bad_call_cancel_query_with_hint.sql
+@{unknown_hint=1}
+CALL cancel_query("12345")
+--- Error
+syntax error: testdata/input/statement/!bad_call_cancel_query_with_hint.sql:2:1: statement hint is only permitted before query or DML, but got: CALL
+  2|  CALL cancel_query("12345")
+   |  ^~~~
+
+
+--- AST
+&ast.BadStatement{
+  Hint: &ast.Hint{
+    Rbrace:  16,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 14,
+              Name:    "unknown_hint",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 15,
+          ValueEnd: 16,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  BadNode: &ast.BadNode{
+    NodePos: 18,
+    NodeEnd: 44,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n",
+        Raw:      "CALL",
+        AsString: "CALL",
+        Pos:      18,
+        End:      22,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "cancel_query",
+        AsString: "cancel_query",
+        Pos:      23,
+        End:      35,
+      },
+      &token.Token{
+        Kind: "(",
+        Raw:  "(",
+        Pos:  35,
+        End:  36,
+      },
+      &token.Token{
+        Kind:     "<string>",
+        Raw:      "\"12345\"",
+        AsString: "12345",
+        Pos:      36,
+        End:      43,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  43,
+        End:  44,
+      },
+    },
+  },
+}
+
+--- SQL
+@{unknown_hint=1} CALL cancel_query("12345")

--- a/testdata/result/statement/!bad_call_cancel_query_with_hint_oneline.sql.txt
+++ b/testdata/result/statement/!bad_call_cancel_query_with_hint_oneline.sql.txt
@@ -1,10 +1,9 @@
---- !bad_call_cancel_query_with_hint.sql
-@{unknown_hint=1}
-CALL cancel_query("12345")
+--- !bad_call_cancel_query_with_hint_oneline.sql
+@{unknown_hint=1} CALL cancel_query("12345")
 --- Error
-syntax error: testdata/input/statement/!bad_call_cancel_query_with_hint.sql:1:1: statement hint is only permitted before query or DML, but got: CALL
-  1|  @{unknown_hint=1}
-  2|  CALL cancel_query("12345")
+syntax error: testdata/input/statement/!bad_call_cancel_query_with_hint_oneline.sql:1:1: statement hint is only permitted before query or DML, but got: CALL
+  1|  @{unknown_hint=1} CALL cancel_query("12345")
+   |  ^~~~~~~~~~~~~~~~~~~~~~
 
 
 --- AST
@@ -37,7 +36,7 @@ syntax error: testdata/input/statement/!bad_call_cancel_query_with_hint.sql:1:1:
     Tokens:  []*token.Token{
       &token.Token{
         Kind:     "<ident>",
-        Space:    "\n",
+        Space:    " ",
         Raw:      "CALL",
         AsString: "CALL",
         Pos:      18,

--- a/testdata/result/statement/!bad_create_table_with_hint.sql.txt
+++ b/testdata/result/statement/!bad_create_table_with_hint.sql.txt
@@ -2,9 +2,9 @@
 @{unknown_hint=1}
 create table tbl(pk int64 primary key)
 --- Error
-syntax error: testdata/input/ddl/!bad_create_table_with_hint.sql:2:1: statement hint is only permitted before query or DML, but got: create
+syntax error: testdata/input/ddl/!bad_create_table_with_hint.sql:1:1: statement hint is only permitted before query or DML, but got: create
+  1|  @{unknown_hint=1}
   2|  create table tbl(pk int64 primary key)
-   |  ^~~~~~
 
 
 --- AST

--- a/testdata/result/statement/!bad_create_table_with_hint.sql.txt
+++ b/testdata/result/statement/!bad_create_table_with_hint.sql.txt
@@ -1,0 +1,109 @@
+--- !bad_create_table_with_hint.sql
+@{unknown_hint=1}
+create table tbl(pk int64 primary key)
+--- Error
+syntax error: testdata/input/ddl/!bad_create_table_with_hint.sql:2:1: statement hint is only permitted before query or DML, but got: create
+  2|  create table tbl(pk int64 primary key)
+   |  ^~~~~~
+
+
+--- AST
+&ast.BadStatement{
+  Hint: &ast.Hint{
+    Rbrace:  16,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 14,
+              Name:    "unknown_hint",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 15,
+          ValueEnd: 16,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  BadNode: &ast.BadNode{
+    NodePos: 18,
+    NodeEnd: 56,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind:  "CREATE",
+        Space: "\n",
+        Raw:   "create",
+        Pos:   18,
+        End:   24,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "table",
+        AsString: "table",
+        Pos:      25,
+        End:      30,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "tbl",
+        AsString: "tbl",
+        Pos:      31,
+        End:      34,
+      },
+      &token.Token{
+        Kind: "(",
+        Raw:  "(",
+        Pos:  34,
+        End:  35,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "pk",
+        AsString: "pk",
+        Pos:      35,
+        End:      37,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "int64",
+        AsString: "int64",
+        Pos:      38,
+        End:      43,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "primary",
+        AsString: "primary",
+        Pos:      44,
+        End:      51,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "key",
+        AsString: "key",
+        Pos:      52,
+        End:      55,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  55,
+        End:  56,
+      },
+    },
+  },
+}
+
+--- SQL
+@{unknown_hint=1} create table tbl(pk int64 primary key)

--- a/testdata/result/statement/!bad_delete.sql.txt
+++ b/testdata/result/statement/!bad_delete.sql.txt
@@ -1,0 +1,94 @@
+--- !bad_delete.sql
+delete foo filter foo = 1 and bar = 2
+--- Error
+syntax error: testdata/input/dml/!bad_delete.sql:1:19: expected token: WHERE, but: <ident>
+  1|  delete foo filter foo = 1 and bar = 2
+   |                    ^~~
+
+
+--- AST
+&ast.BadDML{
+  BadNode: &ast.BadNode{
+    NodeEnd: 37,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "delete",
+        AsString: "delete",
+        End:      6,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      7,
+        End:      10,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "filter",
+        AsString: "filter",
+        Pos:      11,
+        End:      17,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      18,
+        End:      21,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   22,
+        End:   23,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "1",
+        Base:  10,
+        Pos:   24,
+        End:   25,
+      },
+      &token.Token{
+        Kind:  "AND",
+        Space: " ",
+        Raw:   "and",
+        Pos:   26,
+        End:   29,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "bar",
+        AsString: "bar",
+        Pos:      30,
+        End:      33,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   34,
+        End:   35,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "2",
+        Base:  10,
+        Pos:   36,
+        End:   37,
+      },
+    },
+  },
+}
+
+--- SQL
+delete foo filter foo = 1 and bar = 2

--- a/testdata/result/statement/!bad_delete_with_bad_hint.sql.txt
+++ b/testdata/result/statement/!bad_delete_with_bad_hint.sql.txt
@@ -1,0 +1,120 @@
+--- !bad_delete_with_bad_hint.sql
+@{invalid}
+delete foo where foo = 1 and bar = 2
+--- Error
+syntax error: testdata/input/dml/!bad_delete_with_bad_hint.sql:1:10: expected token: =, but: }
+  1|  @{invalid}
+   |           ^
+
+
+--- AST
+&ast.BadStatement{
+  BadNode: &ast.BadNode{
+    NodeEnd: 47,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind: "@",
+        Raw:  "@",
+        End:  1,
+      },
+      &token.Token{
+        Kind: "{",
+        Raw:  "{",
+        Pos:  1,
+        End:  2,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "invalid",
+        AsString: "invalid",
+        Pos:      2,
+        End:      9,
+      },
+      &token.Token{
+        Kind: "}",
+        Raw:  "}",
+        Pos:  9,
+        End:  10,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n",
+        Raw:      "delete",
+        AsString: "delete",
+        Pos:      11,
+        End:      17,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      18,
+        End:      21,
+      },
+      &token.Token{
+        Kind:  "WHERE",
+        Space: " ",
+        Raw:   "where",
+        Pos:   22,
+        End:   27,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      28,
+        End:      31,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   32,
+        End:   33,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "1",
+        Base:  10,
+        Pos:   34,
+        End:   35,
+      },
+      &token.Token{
+        Kind:  "AND",
+        Space: " ",
+        Raw:   "and",
+        Pos:   36,
+        End:   39,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "bar",
+        AsString: "bar",
+        Pos:      40,
+        End:      43,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   44,
+        End:   45,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "2",
+        Base:  10,
+        Pos:   46,
+        End:   47,
+      },
+    },
+  },
+}
+
+--- SQL
+@{invalid} delete foo where foo = 1 and bar = 2

--- a/testdata/result/statement/!bad_delete_with_hint.sql.txt
+++ b/testdata/result/statement/!bad_delete_with_hint.sql.txt
@@ -1,0 +1,120 @@
+--- !bad_delete_with_hint.sql
+@{pdml_max_parallelism=1}
+delete foo filter foo = 1 and bar = 2
+--- Error
+syntax error: testdata/input/dml/!bad_delete_with_hint.sql:2:19: expected token: WHERE, but: <ident>
+  2|  delete foo filter foo = 1 and bar = 2
+   |                    ^~~
+
+
+--- AST
+&ast.BadDML{
+  Hint: &ast.Hint{
+    Rbrace:  24,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 22,
+              Name:    "pdml_max_parallelism",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 23,
+          ValueEnd: 24,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  BadNode: &ast.BadNode{
+    NodePos: 26,
+    NodeEnd: 63,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n",
+        Raw:      "delete",
+        AsString: "delete",
+        Pos:      26,
+        End:      32,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      33,
+        End:      36,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "filter",
+        AsString: "filter",
+        Pos:      37,
+        End:      43,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      44,
+        End:      47,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   48,
+        End:   49,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "1",
+        Base:  10,
+        Pos:   50,
+        End:   51,
+      },
+      &token.Token{
+        Kind:  "AND",
+        Space: " ",
+        Raw:   "and",
+        Pos:   52,
+        End:   55,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "bar",
+        AsString: "bar",
+        Pos:      56,
+        End:      59,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   60,
+        End:   61,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "2",
+        Base:  10,
+        Pos:   62,
+        End:   63,
+      },
+    },
+  },
+}
+
+--- SQL
+@{pdml_max_parallelism=1} delete foo filter foo = 1 and bar = 2

--- a/testdata/result/statement/!bad_hint_select.sql.txt
+++ b/testdata/result/statement/!bad_hint_select.sql.txt
@@ -8,31 +8,29 @@ syntax error: testdata/input/query/!bad_hint_select.sql:1:3: expected token: {, 
 
 
 --- AST
-&ast.QueryStatement{
-  Query: &ast.BadQueryExpr{
-    BadNode: &ast.BadNode{
-      NodeEnd: 10,
-      Tokens:  []*token.Token{
-        &token.Token{
-          Kind: "@",
-          Raw:  "@",
-          End:  1,
-        },
-        &token.Token{
-          Kind:  "SELECT",
-          Space: " ",
-          Raw:   "select",
-          Pos:   2,
-          End:   8,
-        },
-        &token.Token{
-          Kind:  "<int>",
-          Space: " ",
-          Raw:   "1",
-          Base:  10,
-          Pos:   9,
-          End:   10,
-        },
+&ast.BadStatement{
+  BadNode: &ast.BadNode{
+    NodeEnd: 10,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind: "@",
+        Raw:  "@",
+        End:  1,
+      },
+      &token.Token{
+        Kind:  "SELECT",
+        Space: " ",
+        Raw:   "select",
+        Pos:   2,
+        End:   8,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "1",
+        Base:  10,
+        Pos:   9,
+        End:   10,
       },
     },
   },

--- a/testdata/result/statement/!bad_insert_with_bad_hint.sql.txt
+++ b/testdata/result/statement/!bad_insert_with_bad_hint.sql.txt
@@ -1,0 +1,220 @@
+--- !bad_insert_with_bad_hint.sql
+@{invalid}
+insert foo (foo, bar, baz)
+vales (1, 2, 3),
+      (4, 5, 6)
+--- Error
+syntax error: testdata/input/dml/!bad_insert_with_bad_hint.sql:1:10: expected token: =, but: }
+  1|  @{invalid}
+   |           ^
+
+
+--- AST
+&ast.BadStatement{
+  BadNode: &ast.BadNode{
+    NodeEnd: 70,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind: "@",
+        Raw:  "@",
+        End:  1,
+      },
+      &token.Token{
+        Kind: "{",
+        Raw:  "{",
+        Pos:  1,
+        End:  2,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "invalid",
+        AsString: "invalid",
+        Pos:      2,
+        End:      9,
+      },
+      &token.Token{
+        Kind: "}",
+        Raw:  "}",
+        Pos:  9,
+        End:  10,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n",
+        Raw:      "insert",
+        AsString: "insert",
+        Pos:      11,
+        End:      17,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      18,
+        End:      21,
+      },
+      &token.Token{
+        Kind:  "(",
+        Space: " ",
+        Raw:   "(",
+        Pos:   22,
+        End:   23,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      23,
+        End:      26,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  26,
+        End:  27,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "bar",
+        AsString: "bar",
+        Pos:      28,
+        End:      31,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  31,
+        End:  32,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "baz",
+        AsString: "baz",
+        Pos:      33,
+        End:      36,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  36,
+        End:  37,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n",
+        Raw:      "vales",
+        AsString: "vales",
+        Pos:      38,
+        End:      43,
+      },
+      &token.Token{
+        Kind:  "(",
+        Space: " ",
+        Raw:   "(",
+        Pos:   44,
+        End:   45,
+      },
+      &token.Token{
+        Kind: "<int>",
+        Raw:  "1",
+        Base: 10,
+        Pos:  45,
+        End:  46,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  46,
+        End:  47,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "2",
+        Base:  10,
+        Pos:   48,
+        End:   49,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  49,
+        End:  50,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "3",
+        Base:  10,
+        Pos:   51,
+        End:   52,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  52,
+        End:  53,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  53,
+        End:  54,
+      },
+      &token.Token{
+        Kind:  "(",
+        Space: "\n      ",
+        Raw:   "(",
+        Pos:   61,
+        End:   62,
+      },
+      &token.Token{
+        Kind: "<int>",
+        Raw:  "4",
+        Base: 10,
+        Pos:  62,
+        End:  63,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  63,
+        End:  64,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "5",
+        Base:  10,
+        Pos:   65,
+        End:   66,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  66,
+        End:  67,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "6",
+        Base:  10,
+        Pos:   68,
+        End:   69,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  69,
+        End:  70,
+      },
+    },
+  },
+}
+
+--- SQL
+@{invalid} insert foo (foo, bar, baz) vales (1, 2, 3), (4, 5, 6)

--- a/testdata/result/statement/!bad_insert_with_hint.sql.txt
+++ b/testdata/result/statement/!bad_insert_with_hint.sql.txt
@@ -1,0 +1,186 @@
+--- !bad_insert_with_hint.sql
+@{pdml_max_parallelism=1}
+insert foo (foo, bar, baz)
+vales (1, 2, 3),
+      (4, 5, 6)
+--- Error
+syntax error: testdata/input/dml/!bad_insert_with_hint.sql:3:1: expected beginning of simple query "(", SELECT, FROM, but: "vales"
+  3|  vales (1, 2, 3),
+   |  ^~~~~
+
+
+--- AST
+&ast.Insert{
+  Insert: 26,
+  Hint:   &ast.Hint{
+    Rbrace:  24,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 22,
+              Name:    "pdml_max_parallelism",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 23,
+          ValueEnd: 24,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 33,
+        NameEnd: 36,
+        Name:    "foo",
+      },
+    },
+  },
+  Columns: []*ast.Ident{
+    &ast.Ident{
+      NamePos: 38,
+      NameEnd: 41,
+      Name:    "foo",
+    },
+    &ast.Ident{
+      NamePos: 43,
+      NameEnd: 46,
+      Name:    "bar",
+    },
+    &ast.Ident{
+      NamePos: 48,
+      NameEnd: 51,
+      Name:    "baz",
+    },
+  },
+  Input: &ast.SubQueryInput{
+    Query: &ast.BadQueryExpr{
+      BadNode: &ast.BadNode{
+        NodePos: 53,
+        NodeEnd: 85,
+        Tokens:  []*token.Token{
+          &token.Token{
+            Kind:     "<ident>",
+            Space:    "\n",
+            Raw:      "vales",
+            AsString: "vales",
+            Pos:      53,
+            End:      58,
+          },
+          &token.Token{
+            Kind:  "(",
+            Space: " ",
+            Raw:   "(",
+            Pos:   59,
+            End:   60,
+          },
+          &token.Token{
+            Kind: "<int>",
+            Raw:  "1",
+            Base: 10,
+            Pos:  60,
+            End:  61,
+          },
+          &token.Token{
+            Kind: ",",
+            Raw:  ",",
+            Pos:  61,
+            End:  62,
+          },
+          &token.Token{
+            Kind:  "<int>",
+            Space: " ",
+            Raw:   "2",
+            Base:  10,
+            Pos:   63,
+            End:   64,
+          },
+          &token.Token{
+            Kind: ",",
+            Raw:  ",",
+            Pos:  64,
+            End:  65,
+          },
+          &token.Token{
+            Kind:  "<int>",
+            Space: " ",
+            Raw:   "3",
+            Base:  10,
+            Pos:   66,
+            End:   67,
+          },
+          &token.Token{
+            Kind: ")",
+            Raw:  ")",
+            Pos:  67,
+            End:  68,
+          },
+          &token.Token{
+            Kind: ",",
+            Raw:  ",",
+            Pos:  68,
+            End:  69,
+          },
+          &token.Token{
+            Kind:  "(",
+            Space: "\n      ",
+            Raw:   "(",
+            Pos:   76,
+            End:   77,
+          },
+          &token.Token{
+            Kind: "<int>",
+            Raw:  "4",
+            Base: 10,
+            Pos:  77,
+            End:  78,
+          },
+          &token.Token{
+            Kind: ",",
+            Raw:  ",",
+            Pos:  78,
+            End:  79,
+          },
+          &token.Token{
+            Kind:  "<int>",
+            Space: " ",
+            Raw:   "5",
+            Base:  10,
+            Pos:   80,
+            End:   81,
+          },
+          &token.Token{
+            Kind: ",",
+            Raw:  ",",
+            Pos:  81,
+            End:  82,
+          },
+          &token.Token{
+            Kind:  "<int>",
+            Space: " ",
+            Raw:   "6",
+            Base:  10,
+            Pos:   83,
+            End:   84,
+          },
+          &token.Token{
+            Kind: ")",
+            Raw:  ")",
+            Pos:  84,
+            End:  85,
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+@{pdml_max_parallelism=1} INSERT INTO foo (foo, bar, baz) vales (1, 2, 3), (4, 5, 6)

--- a/testdata/result/statement/!bad_update.sql.txt
+++ b/testdata/result/statement/!bad_update.sql.txt
@@ -1,0 +1,78 @@
+--- !bad_update.sql
+update foo set invalid where foo = 1
+--- Error
+syntax error: testdata/input/dml/!bad_update.sql:1:24: expected token: =, but: WHERE
+  1|  update foo set invalid where foo = 1
+   |                         ^~~~~
+
+
+--- AST
+&ast.BadDML{
+  BadNode: &ast.BadNode{
+    NodeEnd: 36,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "update",
+        AsString: "update",
+        End:      6,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      7,
+        End:      10,
+      },
+      &token.Token{
+        Kind:  "SET",
+        Space: " ",
+        Raw:   "set",
+        Pos:   11,
+        End:   14,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "invalid",
+        AsString: "invalid",
+        Pos:      15,
+        End:      22,
+      },
+      &token.Token{
+        Kind:  "WHERE",
+        Space: " ",
+        Raw:   "where",
+        Pos:   23,
+        End:   28,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      29,
+        End:      32,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   33,
+        End:   34,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "1",
+        Base:  10,
+        Pos:   35,
+        End:   36,
+      },
+    },
+  },
+}
+
+--- SQL
+update foo set invalid where foo = 1

--- a/testdata/result/statement/!bad_update_with_bad_hint.sql.txt
+++ b/testdata/result/statement/!bad_update_with_bad_hint.sql.txt
@@ -1,0 +1,178 @@
+--- !bad_update_with_bad_hint.sql
+@{invalid}
+update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
+
+--- Error
+syntax error: testdata/input/dml/!bad_update_with_bad_hint.sql:1:10: expected token: =, but: }
+  1|  @{invalid}
+   |           ^
+
+
+--- AST
+&ast.BadStatement{
+  BadNode: &ast.BadNode{
+    NodeEnd: 75,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind: "@",
+        Raw:  "@",
+        End:  1,
+      },
+      &token.Token{
+        Kind: "{",
+        Raw:  "{",
+        Pos:  1,
+        End:  2,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "invalid",
+        AsString: "invalid",
+        Pos:      2,
+        End:      9,
+      },
+      &token.Token{
+        Kind: "}",
+        Raw:  "}",
+        Pos:  9,
+        End:  10,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n",
+        Raw:      "update",
+        AsString: "update",
+        Pos:      11,
+        End:      17,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      18,
+        End:      21,
+      },
+      &token.Token{
+        Kind:  "SET",
+        Space: " ",
+        Raw:   "set",
+        Pos:   22,
+        End:   25,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      26,
+        End:      29,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   30,
+        End:   31,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "bar",
+        AsString: "bar",
+        Pos:      32,
+        End:      35,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  35,
+        End:  36,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "bar",
+        AsString: "bar",
+        Pos:      37,
+        End:      40,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   41,
+        End:   42,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      43,
+        End:      46,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  46,
+        End:  47,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "baz",
+        AsString: "baz",
+        Pos:      48,
+        End:      51,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   52,
+        End:   53,
+      },
+      &token.Token{
+        Kind:  "DEFAULT",
+        Space: " ",
+        Raw:   "DEFAULT",
+        Pos:   54,
+        End:   61,
+      },
+      &token.Token{
+        Kind:  "WHERE",
+        Space: " ",
+        Raw:   "where",
+        Pos:   62,
+        End:   67,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      68,
+        End:      71,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   72,
+        End:   73,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "1",
+        Base:  10,
+        Pos:   74,
+        End:   75,
+      },
+    },
+  },
+}
+
+--- SQL
+@{invalid} update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1

--- a/testdata/result/statement/!bad_update_with_hint.sql.txt
+++ b/testdata/result/statement/!bad_update_with_hint.sql.txt
@@ -1,0 +1,104 @@
+--- !bad_update_with_hint.sql
+@{pdml_max_parallelism=1}
+update foo set invalid where foo = 1
+--- Error
+syntax error: testdata/input/dml/!bad_update_with_hint.sql:2:24: expected token: =, but: WHERE
+  2|  update foo set invalid where foo = 1
+   |                         ^~~~~
+
+
+--- AST
+&ast.BadDML{
+  Hint: &ast.Hint{
+    Rbrace:  24,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 22,
+              Name:    "pdml_max_parallelism",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 23,
+          ValueEnd: 24,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  BadNode: &ast.BadNode{
+    NodePos: 26,
+    NodeEnd: 62,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n",
+        Raw:      "update",
+        AsString: "update",
+        Pos:      26,
+        End:      32,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      33,
+        End:      36,
+      },
+      &token.Token{
+        Kind:  "SET",
+        Space: " ",
+        Raw:   "set",
+        Pos:   37,
+        End:   40,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "invalid",
+        AsString: "invalid",
+        Pos:      41,
+        End:      48,
+      },
+      &token.Token{
+        Kind:  "WHERE",
+        Space: " ",
+        Raw:   "where",
+        Pos:   49,
+        End:   54,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      55,
+        End:      58,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   59,
+        End:   60,
+      },
+      &token.Token{
+        Kind:  "<int>",
+        Space: " ",
+        Raw:   "1",
+        Base:  10,
+        Pos:   61,
+        End:   62,
+      },
+    },
+  },
+}
+
+--- SQL
+@{pdml_max_parallelism=1} update foo set invalid where foo = 1

--- a/testdata/result/statement/!bad_with_select_with_hint.sql.txt
+++ b/testdata/result/statement/!bad_with_select_with_hint.sql.txt
@@ -1,0 +1,66 @@
+--- !bad_with_select_with_hint.sql
+@{hint = 1} WITH SELECT 1
+--- Error
+syntax error: testdata/input/query/!bad_with_select_with_hint.sql:1:18: expected token: <ident>, but: SELECT
+  1|  @{hint = 1} WITH SELECT 1
+   |                   ^~~~~~
+
+
+--- AST
+&ast.QueryStatement{
+  Hint: &ast.Hint{
+    Rbrace:  10,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 6,
+              Name:    "hint",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 9,
+          ValueEnd: 10,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  Query: &ast.BadQueryExpr{
+    BadNode: &ast.BadNode{
+      NodePos: 12,
+      NodeEnd: 25,
+      Tokens:  []*token.Token{
+        &token.Token{
+          Kind:  "WITH",
+          Space: " ",
+          Raw:   "WITH",
+          Pos:   12,
+          End:   16,
+        },
+        &token.Token{
+          Kind:  "SELECT",
+          Space: " ",
+          Raw:   "SELECT",
+          Pos:   17,
+          End:   23,
+        },
+        &token.Token{
+          Kind:  "<int>",
+          Space: " ",
+          Raw:   "1",
+          Base:  10,
+          Pos:   24,
+          End:   25,
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+@{hint=1} WITH SELECT 1

--- a/testdata/result/statement/delete_with_hint.sql.txt
+++ b/testdata/result/statement/delete_with_hint.sql.txt
@@ -1,0 +1,74 @@
+--- delete_with_hint.sql
+@{pdml_max_parallelism=1} delete foo where foo = 1 and bar = 2
+--- AST
+&ast.Delete{
+  Delete: 26,
+  Hint:   &ast.Hint{
+    Rbrace:  24,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 22,
+              Name:    "pdml_max_parallelism",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 23,
+          ValueEnd: 24,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 33,
+        NameEnd: 36,
+        Name:    "foo",
+      },
+    },
+  },
+  Where: &ast.Where{
+    Where: 37,
+    Expr:  &ast.BinaryExpr{
+      Op:   "AND",
+      Left: &ast.BinaryExpr{
+        Op:   "=",
+        Left: &ast.Ident{
+          NamePos: 43,
+          NameEnd: 46,
+          Name:    "foo",
+        },
+        Right: &ast.IntLiteral{
+          ValuePos: 49,
+          ValueEnd: 50,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+      Right: &ast.BinaryExpr{
+        Op:   "=",
+        Left: &ast.Ident{
+          NamePos: 55,
+          NameEnd: 58,
+          Name:    "bar",
+        },
+        Right: &ast.IntLiteral{
+          ValuePos: 61,
+          ValueEnd: 62,
+          Base:     10,
+          Value:    "2",
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+@{pdml_max_parallelism=1} DELETE FROM foo WHERE foo = 1 AND bar = 2

--- a/testdata/result/statement/insert_with_hint.sql.txt
+++ b/testdata/result/statement/insert_with_hint.sql.txt
@@ -1,0 +1,131 @@
+--- insert_with_hint.sql
+@{pdml_max_parallelism=1}
+insert into foo (foo, bar, baz)
+values (1, 2, 3),
+       (4, 5, 6)
+--- AST
+&ast.Insert{
+  Insert: 26,
+  Hint:   &ast.Hint{
+    Rbrace:  24,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 22,
+              Name:    "pdml_max_parallelism",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 23,
+          ValueEnd: 24,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 38,
+        NameEnd: 41,
+        Name:    "foo",
+      },
+    },
+  },
+  Columns: []*ast.Ident{
+    &ast.Ident{
+      NamePos: 43,
+      NameEnd: 46,
+      Name:    "foo",
+    },
+    &ast.Ident{
+      NamePos: 48,
+      NameEnd: 51,
+      Name:    "bar",
+    },
+    &ast.Ident{
+      NamePos: 53,
+      NameEnd: 56,
+      Name:    "baz",
+    },
+  },
+  Input: &ast.ValuesInput{
+    Values: 58,
+    Rows:   []*ast.ValuesRow{
+      &ast.ValuesRow{
+        Lparen: 65,
+        Rparen: 73,
+        Exprs:  []*ast.DefaultExpr{
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 66,
+              ValueEnd: 67,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 69,
+              ValueEnd: 70,
+              Base:     10,
+              Value:    "2",
+            },
+          },
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 72,
+              ValueEnd: 73,
+              Base:     10,
+              Value:    "3",
+            },
+          },
+        },
+      },
+      &ast.ValuesRow{
+        Lparen: 83,
+        Rparen: 91,
+        Exprs:  []*ast.DefaultExpr{
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 84,
+              ValueEnd: 85,
+              Base:     10,
+              Value:    "4",
+            },
+          },
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 87,
+              ValueEnd: 88,
+              Base:     10,
+              Value:    "5",
+            },
+          },
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 90,
+              ValueEnd: 91,
+              Base:     10,
+              Value:    "6",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+@{pdml_max_parallelism=1} INSERT INTO foo (foo, bar, baz) VALUES (1, 2, 3), (4, 5, 6)

--- a/testdata/result/statement/update_with_hint.sql.txt
+++ b/testdata/result/statement/update_with_hint.sql.txt
@@ -1,0 +1,107 @@
+--- update_with_hint.sql
+@{pdml_max_parallelism=1}
+update foo set foo = bar, bar = foo, baz = DEFAULT where foo = 1
+--- AST
+&ast.Update{
+  Update: 26,
+  Hint:   &ast.Hint{
+    Rbrace:  24,
+    Records: []*ast.HintRecord{
+      &ast.HintRecord{
+        Key: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 2,
+              NameEnd: 22,
+              Name:    "pdml_max_parallelism",
+            },
+          },
+        },
+        Value: &ast.IntLiteral{
+          ValuePos: 23,
+          ValueEnd: 24,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 33,
+        NameEnd: 36,
+        Name:    "foo",
+      },
+    },
+  },
+  Updates: []*ast.UpdateItem{
+    &ast.UpdateItem{
+      Path: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 41,
+          NameEnd: 44,
+          Name:    "foo",
+        },
+      },
+      DefaultExpr: &ast.DefaultExpr{
+        DefaultPos: -1,
+        Expr:       &ast.Ident{
+          NamePos: 47,
+          NameEnd: 50,
+          Name:    "bar",
+        },
+      },
+    },
+    &ast.UpdateItem{
+      Path: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 52,
+          NameEnd: 55,
+          Name:    "bar",
+        },
+      },
+      DefaultExpr: &ast.DefaultExpr{
+        DefaultPos: -1,
+        Expr:       &ast.Ident{
+          NamePos: 58,
+          NameEnd: 61,
+          Name:    "foo",
+        },
+      },
+    },
+    &ast.UpdateItem{
+      Path: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 63,
+          NameEnd: 66,
+          Name:    "baz",
+        },
+      },
+      DefaultExpr: &ast.DefaultExpr{
+        DefaultPos: 69,
+        Default:    true,
+      },
+    },
+  },
+  Where: &ast.Where{
+    Where: 77,
+    Expr:  &ast.BinaryExpr{
+      Op:   "=",
+      Left: &ast.Ident{
+        NamePos: 83,
+        NameEnd: 86,
+        Name:    "foo",
+      },
+      Right: &ast.IntLiteral{
+        ValuePos: 89,
+        ValueEnd: 90,
+        Base:     10,
+        Value:    "1",
+      },
+    },
+  },
+}
+
+--- SQL
+@{pdml_max_parallelism=1} UPDATE foo SET foo = bar, bar = foo, baz = DEFAULT WHERE foo = 1


### PR DESCRIPTION
This PR implements statement hints in DMLs.

## Note

- There is no breaking changes, but this PR introduces some important changes
  - ~~Introduces `(*Parser).lookaheadTokenAfterOptionalHint()` in `parseStatement()`~~
  - Now `BadDML` and `BadStatement` have `Hint`.
  - some parse methods have their `*Internal` methods. They parses after valid hints.
  - `parseUpdate()`, `parseInsert()`, `parseDelete()` have `hint *ast.Hint` argument.

## Related issues
- close #133 