### PR TITLE
Remove unused constants

### DIFF
--- a/ast/ast_const.go
+++ b/ast/ast_const.go
@@ -17,21 +17,6 @@ const (
 	AllOrDistinctDistinct AllOrDistinct = "DISTINCT"
 )
 
-type TableHintKey string
-
-const (
-	ForceIndexTableHint     TableHintKey = "FORCE_INDEX"
-	GroupScanByOptimization TableHintKey = "GROUPBY_SCAN_OPTIMIZATION"
-)
-
-type JoinHintKey string
-
-const (
-	ForceJoinOrderJoinHint JoinHintKey = "FORCE_JOIN_ORDER"
-	JoinTypeJoinHint       JoinHintKey = "JOIN_TYPE"
-)
-
-// JoinMethod is used for prefix of JOIN, not for hint.
 type JoinMethod string
 
 const (


### PR DESCRIPTION
This PR removes unused constants related to `TableHintKey` and `JoinHintKey`.
Strictly speaking, it is a kind of breaking change because it removes export symbols, but I believe that there is no valid reason that any user code depends on them.