### PR TITLE
Support ENFORCED/NOT ENFORCED in ForeignKey

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -443,7 +443,7 @@ type ColumnDefaultSemantics interface {
 func (ColumnDefaultExpr) isColumnDefaultSemantics()   {}
 func (GeneratedColumnExpr) isColumnDefaultSemantics() {}
 func (IdentityColumn) isColumnDefaultSemantics()      {}
-func (AutoIncrement) isColumnDefaultSemantics()      {}
+func (AutoIncrement) isColumnDefaultSemantics()       {}
 
 type SequenceParam interface {
 	Node
@@ -2569,19 +2569,22 @@ type TableConstraint struct {
 
 // ForeignKey is foreign key specifier in CREATE TABLE and ALTER TABLE.
 //
-//	FOREIGN KEY ({{.ColumnNames | sqlJoin ","}}) REFERENCES {{.ReferenceTable}} ({{.ReferenceColumns | sqlJoin ","}}) {{.OnDelete}}
+//	FOREIGN KEY ({{.ColumnNames | sqlJoin ","}}) REFERENCES {{.ReferenceTable}} ({{.ReferenceColumns | sqlJoin ","}})
+//	{{.OnDelete}} {{.Enforcement}}
 type ForeignKey struct {
 	// pos = Foreign
-	// end = OnDeleteEnd || Rparen + 1
+	// end = Enforced + 8 || OnDeleteEnd || Rparen + 1
 
 	Foreign     token.Pos // position of "FOREIGN" keyword
 	Rparen      token.Pos // position of ")" after reference columns
 	OnDeleteEnd token.Pos // end position of ON DELETE clause
+	Enforced    token.Pos // position of "ENFORCED", optional
 
 	Columns          []*Ident
 	ReferenceTable   *Path
 	ReferenceColumns []*Ident       // len(ReferenceColumns) > 0
 	OnDelete         OnDeleteAction // optional
+	Enforcement      Enforcement    // optional
 }
 
 // Check is check constraint in CREATE TABLE and ALTER TABLE.

--- a/ast/ast_const.go
+++ b/ast/ast_const.go
@@ -130,6 +130,13 @@ const (
 	OnDeleteNoAction OnDeleteAction = "ON DELETE NO ACTION"
 )
 
+type Enforcement string
+
+const (
+	Enforced    Enforcement = "ENFORCED"
+	NotEnforced Enforcement = "NOT ENFORCED"
+)
+
 type SecurityType string
 
 const (

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -1187,7 +1187,7 @@ func (f *ForeignKey) Pos() token.Pos {
 }
 
 func (f *ForeignKey) End() token.Pos {
-	return posChoice(f.OnDeleteEnd, posAdd(f.Rparen, 1))
+	return posChoice(posAdd(f.Enforced, 8), f.OnDeleteEnd, posAdd(f.Rparen, 1))
 }
 
 func (c *Check) Pos() token.Pos {

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -852,7 +852,8 @@ func (f *ForeignKey) SQL() string {
 	return "FOREIGN KEY (" + sqlJoin(f.Columns, ", ") + ") " +
 		"REFERENCES " + f.ReferenceTable.SQL() + " (" +
 		sqlJoin(f.ReferenceColumns, ", ") + ")" +
-		strOpt(f.OnDelete != "", " "+string(f.OnDelete))
+		strOpt(f.OnDelete != "", " "+string(f.OnDelete)) +
+		strOpt(f.Enforcement != "", " "+string(f.Enforcement))
 }
 
 func (c *Check) SQL() string {

--- a/parser.go
+++ b/parser.go
@@ -3344,14 +3344,30 @@ func (p *Parser) parseForeignKey() *ast.ForeignKey {
 
 	onDelete, onDeleteEnd := p.tryParseOnDeleteAction()
 
+	enforced := token.InvalidPos
+	var enforcement ast.Enforcement
+	switch {
+	case p.Token.Kind == "NOT":
+		p.nextToken()
+		enforced = p.expectKeywordLike("ENFORCED").Pos
+
+		enforcement = ast.NotEnforced
+	case p.Token.IsKeywordLike("ENFORCED"):
+		enforced = p.expectKeywordLike("ENFORCED").Pos
+
+		enforcement = ast.Enforced
+	}
+
 	return &ast.ForeignKey{
 		Foreign:          pos,
 		Rparen:           rparen,
 		OnDeleteEnd:      onDeleteEnd,
+		Enforced:         enforced,
 		Columns:          columns,
 		ReferenceTable:   refTable,
 		ReferenceColumns: refColumns,
 		OnDelete:         onDelete,
+		Enforcement:      enforcement,
 	}
 }
 

--- a/testdata/input/ddl/alter_table_add_foreign_key_enforced.sql
+++ b/testdata/input/ddl/alter_table_add_foreign_key_enforced.sql
@@ -1,0 +1,1 @@
+alter table foo add foreign key (bar) references t2 (t2key1) enforced

--- a/testdata/input/ddl/alter_table_add_foreign_key_not_enforced.sql
+++ b/testdata/input/ddl/alter_table_add_foreign_key_not_enforced.sql
@@ -1,0 +1,1 @@
+alter table foo add foreign key (bar) references t2 (t2key1) not enforced

--- a/testdata/input/ddl/create_table.sql
+++ b/testdata/input/ddl/create_table.sql
@@ -7,6 +7,8 @@ create table foo (
   foreign key (bar) references t2 (t2key2) on delete cascade,
   foreign key (baz) references t2 (t2key3) on delete no action,
   constraint fkname foreign key (foo, bar) references t2 (t2key1, t2key2),
+  constraint fkname2 foreign key (foo, bar) references t2 (t2key1, t2key2) on delete cascade enforced,
+  constraint fkname3 foreign key (foo, bar) references t2 (t2key1, t2key2) not enforced,
   check (foo > 0),
   constraint cname check (bar > 0),
   quux json,

--- a/testdata/result/ddl/alter_table_add_constraint_foreign_key.sql.txt
+++ b/testdata/result/ddl/alter_table_add_constraint_foreign_key.sql.txt
@@ -25,6 +25,7 @@ alter table foo add constraint fkname foreign key (foo, bar) references t2 (t2ke
         Foreign:     38,
         Rparen:      90,
         OnDeleteEnd: -1,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 51,

--- a/testdata/result/ddl/alter_table_add_constraint_foreign_key_on_delete_cascade.sql.txt
+++ b/testdata/result/ddl/alter_table_add_constraint_foreign_key_on_delete_cascade.sql.txt
@@ -25,6 +25,7 @@ alter table foo add constraint fkname foreign key (foo, bar) references t2 (t2ke
         Foreign:     38,
         Rparen:      90,
         OnDeleteEnd: 109,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 51,

--- a/testdata/result/ddl/alter_table_add_constraint_foreign_key_on_delete_no_action.sql.txt
+++ b/testdata/result/ddl/alter_table_add_constraint_foreign_key_on_delete_no_action.sql.txt
@@ -25,6 +25,7 @@ alter table foo add constraint fkname foreign key (foo, bar) references t2 (t2ke
         Foreign:     38,
         Rparen:      90,
         OnDeleteEnd: 111,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 51,

--- a/testdata/result/ddl/alter_table_add_foreign_key_enforced.sql.txt
+++ b/testdata/result/ddl/alter_table_add_foreign_key_enforced.sql.txt
@@ -1,5 +1,5 @@
---- alter_table_add_foreign_key.sql
-alter table foo add foreign key (bar) references t2 (t2key1)
+--- alter_table_add_foreign_key_enforced.sql
+alter table foo add foreign key (bar) references t2 (t2key1) enforced
 
 --- AST
 &ast.AlterTable{
@@ -20,7 +20,7 @@ alter table foo add foreign key (bar) references t2 (t2key1)
         Foreign:     20,
         Rparen:      59,
         OnDeleteEnd: -1,
-        Enforced:    -1,
+        Enforced:    61,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 33,
@@ -44,10 +44,11 @@ alter table foo add foreign key (bar) references t2 (t2key1)
             Name:    "t2key1",
           },
         },
+        Enforcement: "ENFORCED",
       },
     },
   },
 }
 
 --- SQL
-ALTER TABLE foo ADD FOREIGN KEY (bar) REFERENCES t2 (t2key1)
+ALTER TABLE foo ADD FOREIGN KEY (bar) REFERENCES t2 (t2key1) ENFORCED

--- a/testdata/result/ddl/alter_table_add_foreign_key_not_enforced.sql.txt
+++ b/testdata/result/ddl/alter_table_add_foreign_key_not_enforced.sql.txt
@@ -1,5 +1,5 @@
---- alter_table_add_foreign_key.sql
-alter table foo add foreign key (bar) references t2 (t2key1)
+--- alter_table_add_foreign_key_not_enforced.sql
+alter table foo add foreign key (bar) references t2 (t2key1) not enforced
 
 --- AST
 &ast.AlterTable{
@@ -20,7 +20,7 @@ alter table foo add foreign key (bar) references t2 (t2key1)
         Foreign:     20,
         Rparen:      59,
         OnDeleteEnd: -1,
-        Enforced:    -1,
+        Enforced:    65,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 33,
@@ -44,10 +44,11 @@ alter table foo add foreign key (bar) references t2 (t2key1)
             Name:    "t2key1",
           },
         },
+        Enforcement: "NOT ENFORCED",
       },
     },
   },
 }
 
 --- SQL
-ALTER TABLE foo ADD FOREIGN KEY (bar) REFERENCES t2 (t2key1)
+ALTER TABLE foo ADD FOREIGN KEY (bar) REFERENCES t2 (t2key1) NOT ENFORCED

--- a/testdata/result/ddl/create_table.sql.txt
+++ b/testdata/result/ddl/create_table.sql.txt
@@ -8,6 +8,8 @@ create table foo (
   foreign key (bar) references t2 (t2key2) on delete cascade,
   foreign key (baz) references t2 (t2key3) on delete no action,
   constraint fkname foreign key (foo, bar) references t2 (t2key1, t2key2),
+  constraint fkname2 foreign key (foo, bar) references t2 (t2key1, t2key2) on delete cascade enforced,
+  constraint fkname3 foreign key (foo, bar) references t2 (t2key1, t2key2) not enforced,
   check (foo > 0),
   constraint cname check (bar > 0),
   quux json,
@@ -16,8 +18,8 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen:           550,
-  PrimaryKeyRparen: 573,
+  Rparen:           742,
+  PrimaryKeyRparen: 765,
   Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
@@ -154,39 +156,39 @@ create table foo (
       Null: -1,
       Key:  -1,
       Name: &ast.Ident{
-        NamePos: 482,
-        NameEnd: 486,
+        NamePos: 674,
+        NameEnd: 678,
         Name:    "quux",
       },
       Type: &ast.ScalarSchemaType{
-        NamePos: 487,
+        NamePos: 679,
         Name:    "JSON",
       },
       Hidden: -1,
     },
     &ast.ColumnDef{
-      Null: 515,
+      Null: 707,
       Key:  -1,
       Name: &ast.Ident{
-        NamePos: 495,
-        NameEnd: 500,
+        NamePos: 687,
+        NameEnd: 692,
         Name:    "corge",
       },
       Type: &ast.ScalarSchemaType{
-        NamePos: 501,
+        NamePos: 693,
         Name:    "TIMESTAMP",
       },
       NotNull:          true,
       DefaultSemantics: &ast.ColumnDefaultExpr{
-        Default: 520,
-        Rparen:  548,
+        Default: 712,
+        Rparen:  740,
         Expr:    &ast.CallExpr{
-          Rparen: 547,
+          Rparen: 739,
           Func:   &ast.Path{
             Idents: []*ast.Ident{
               &ast.Ident{
-                NamePos: 529,
-                NameEnd: 546,
+                NamePos: 721,
+                NameEnd: 738,
                 Name:    "current_timestamp",
               },
             },
@@ -203,6 +205,7 @@ create table foo (
         Foreign:     182,
         Rparen:      221,
         OnDeleteEnd: -1,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 195,
@@ -234,6 +237,7 @@ create table foo (
         Foreign:     226,
         Rparen:      265,
         OnDeleteEnd: 284,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 239,
@@ -266,6 +270,7 @@ create table foo (
         Foreign:     288,
         Rparen:      327,
         OnDeleteEnd: 348,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 301,
@@ -303,6 +308,7 @@ create table foo (
         Foreign:     370,
         Rparen:      422,
         OnDeleteEnd: -1,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 383,
@@ -339,20 +345,117 @@ create table foo (
       },
     },
     &ast.TableConstraint{
+      ConstraintPos: 427,
+      Name:          &ast.Ident{
+        NamePos: 438,
+        NameEnd: 445,
+        Name:    "fkname2",
+      },
+      Constraint: &ast.ForeignKey{
+        Foreign:     446,
+        Rparen:      498,
+        OnDeleteEnd: 517,
+        Enforced:    518,
+        Columns:     []*ast.Ident{
+          &ast.Ident{
+            NamePos: 459,
+            NameEnd: 462,
+            Name:    "foo",
+          },
+          &ast.Ident{
+            NamePos: 464,
+            NameEnd: 467,
+            Name:    "bar",
+          },
+        },
+        ReferenceTable: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 480,
+              NameEnd: 482,
+              Name:    "t2",
+            },
+          },
+        },
+        ReferenceColumns: []*ast.Ident{
+          &ast.Ident{
+            NamePos: 484,
+            NameEnd: 490,
+            Name:    "t2key1",
+          },
+          &ast.Ident{
+            NamePos: 492,
+            NameEnd: 498,
+            Name:    "t2key2",
+          },
+        },
+        OnDelete:    "ON DELETE CASCADE",
+        Enforcement: "ENFORCED",
+      },
+    },
+    &ast.TableConstraint{
+      ConstraintPos: 530,
+      Name:          &ast.Ident{
+        NamePos: 541,
+        NameEnd: 548,
+        Name:    "fkname3",
+      },
+      Constraint: &ast.ForeignKey{
+        Foreign:     549,
+        Rparen:      601,
+        OnDeleteEnd: -1,
+        Enforced:    607,
+        Columns:     []*ast.Ident{
+          &ast.Ident{
+            NamePos: 562,
+            NameEnd: 565,
+            Name:    "foo",
+          },
+          &ast.Ident{
+            NamePos: 567,
+            NameEnd: 570,
+            Name:    "bar",
+          },
+        },
+        ReferenceTable: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 583,
+              NameEnd: 585,
+              Name:    "t2",
+            },
+          },
+        },
+        ReferenceColumns: []*ast.Ident{
+          &ast.Ident{
+            NamePos: 587,
+            NameEnd: 593,
+            Name:    "t2key1",
+          },
+          &ast.Ident{
+            NamePos: 595,
+            NameEnd: 601,
+            Name:    "t2key2",
+          },
+        },
+        Enforcement: "NOT ENFORCED",
+      },
+    },
+    &ast.TableConstraint{
       ConstraintPos: -1,
       Constraint:    &ast.Check{
-        Check:  427,
-        Rparen: 441,
+        Check:  619,
+        Rparen: 633,
         Expr:   &ast.BinaryExpr{
           Op:   ">",
           Left: &ast.Ident{
-            NamePos: 434,
-            NameEnd: 437,
+            NamePos: 626,
+            NameEnd: 629,
             Name:    "foo",
           },
           Right: &ast.IntLiteral{
-            ValuePos: 440,
-            ValueEnd: 441,
+            ValuePos: 632,
+            ValueEnd: 633,
             Base:     10,
             Value:    "0",
           },
@@ -360,25 +463,25 @@ create table foo (
       },
     },
     &ast.TableConstraint{
-      ConstraintPos: 446,
+      ConstraintPos: 638,
       Name:          &ast.Ident{
-        NamePos: 457,
-        NameEnd: 462,
+        NamePos: 649,
+        NameEnd: 654,
         Name:    "cname",
       },
       Constraint: &ast.Check{
-        Check:  463,
-        Rparen: 477,
+        Check:  655,
+        Rparen: 669,
         Expr:   &ast.BinaryExpr{
           Op:   ">",
           Left: &ast.Ident{
-            NamePos: 470,
-            NameEnd: 473,
+            NamePos: 662,
+            NameEnd: 665,
             Name:    "bar",
           },
           Right: &ast.IntLiteral{
-            ValuePos: 476,
-            ValueEnd: 477,
+            ValuePos: 668,
+            ValueEnd: 669,
             Base:     10,
             Value:    "0",
           },
@@ -390,16 +493,16 @@ create table foo (
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
-        NamePos: 565,
-        NameEnd: 568,
+        NamePos: 757,
+        NameEnd: 760,
         Name:    "foo",
       },
     },
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
-        NamePos: 570,
-        NameEnd: 573,
+        NamePos: 762,
+        NameEnd: 765,
         Name:    "bar",
       },
     },
@@ -418,6 +521,8 @@ CREATE TABLE foo (
   FOREIGN KEY (bar) REFERENCES t2 (t2key2) ON DELETE CASCADE,
   FOREIGN KEY (baz) REFERENCES t2 (t2key3) ON DELETE NO ACTION,
   CONSTRAINT fkname FOREIGN KEY (foo, bar) REFERENCES t2 (t2key1, t2key2),
+  CONSTRAINT fkname2 FOREIGN KEY (foo, bar) REFERENCES t2 (t2key1, t2key2) ON DELETE CASCADE ENFORCED,
+  CONSTRAINT fkname3 FOREIGN KEY (foo, bar) REFERENCES t2 (t2key1, t2key2) NOT ENFORCED,
   CHECK (foo > 0),
   CONSTRAINT cname CHECK (bar > 0)
 ) PRIMARY KEY (foo, bar)

--- a/testdata/result/ddl/create_table_for_format_test.sql.txt
+++ b/testdata/result/ddl/create_table_for_format_test.sql.txt
@@ -189,6 +189,7 @@ create table if not exists foo (
         Foreign:     206,
         Rparen:      245,
         OnDeleteEnd: -1,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 219,
@@ -225,6 +226,7 @@ create table if not exists foo (
         Foreign:     270,
         Rparen:      322,
         OnDeleteEnd: -1,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 283,

--- a/testdata/result/ddl/named_schemas_alter_table_add_constraint.sql.txt
+++ b/testdata/result/ddl/named_schemas_alter_table_add_constraint.sql.txt
@@ -30,6 +30,7 @@ ALTER TABLE sch1.ShoppingCarts ADD CONSTRAINT FKShoppingCartsCustomers FOREIGN K
         Foreign:     71,
         Rparen:      163,
         OnDeleteEnd: 182,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 83,

--- a/testdata/result/ddl/named_schemas_create_table_foreign_key.sql.txt
+++ b/testdata/result/ddl/named_schemas_create_table_foreign_key.sql.txt
@@ -85,6 +85,7 @@ CREATE TABLE sch1.ShoppingCarts (
         Foreign:     163,
         Rparen:      255,
         OnDeleteEnd: 274,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 175,

--- a/testdata/result/statement/alter_table_add_constraint_foreign_key.sql.txt
+++ b/testdata/result/statement/alter_table_add_constraint_foreign_key.sql.txt
@@ -25,6 +25,7 @@ alter table foo add constraint fkname foreign key (foo, bar) references t2 (t2ke
         Foreign:     38,
         Rparen:      90,
         OnDeleteEnd: -1,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 51,

--- a/testdata/result/statement/alter_table_add_constraint_foreign_key_on_delete_cascade.sql.txt
+++ b/testdata/result/statement/alter_table_add_constraint_foreign_key_on_delete_cascade.sql.txt
@@ -25,6 +25,7 @@ alter table foo add constraint fkname foreign key (foo, bar) references t2 (t2ke
         Foreign:     38,
         Rparen:      90,
         OnDeleteEnd: 109,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 51,

--- a/testdata/result/statement/alter_table_add_constraint_foreign_key_on_delete_no_action.sql.txt
+++ b/testdata/result/statement/alter_table_add_constraint_foreign_key_on_delete_no_action.sql.txt
@@ -25,6 +25,7 @@ alter table foo add constraint fkname foreign key (foo, bar) references t2 (t2ke
         Foreign:     38,
         Rparen:      90,
         OnDeleteEnd: 111,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 51,

--- a/testdata/result/statement/alter_table_add_foreign_key.sql.txt
+++ b/testdata/result/statement/alter_table_add_foreign_key.sql.txt
@@ -20,6 +20,7 @@ alter table foo add foreign key (bar) references t2 (t2key1)
         Foreign:     20,
         Rparen:      59,
         OnDeleteEnd: -1,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 33,

--- a/testdata/result/statement/alter_table_add_foreign_key_enforced.sql.txt
+++ b/testdata/result/statement/alter_table_add_foreign_key_enforced.sql.txt
@@ -1,5 +1,5 @@
---- alter_table_add_foreign_key.sql
-alter table foo add foreign key (bar) references t2 (t2key1)
+--- alter_table_add_foreign_key_enforced.sql
+alter table foo add foreign key (bar) references t2 (t2key1) enforced
 
 --- AST
 &ast.AlterTable{
@@ -20,7 +20,7 @@ alter table foo add foreign key (bar) references t2 (t2key1)
         Foreign:     20,
         Rparen:      59,
         OnDeleteEnd: -1,
-        Enforced:    -1,
+        Enforced:    61,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 33,
@@ -44,10 +44,11 @@ alter table foo add foreign key (bar) references t2 (t2key1)
             Name:    "t2key1",
           },
         },
+        Enforcement: "ENFORCED",
       },
     },
   },
 }
 
 --- SQL
-ALTER TABLE foo ADD FOREIGN KEY (bar) REFERENCES t2 (t2key1)
+ALTER TABLE foo ADD FOREIGN KEY (bar) REFERENCES t2 (t2key1) ENFORCED

--- a/testdata/result/statement/alter_table_add_foreign_key_not_enforced.sql.txt
+++ b/testdata/result/statement/alter_table_add_foreign_key_not_enforced.sql.txt
@@ -1,5 +1,5 @@
---- alter_table_add_foreign_key.sql
-alter table foo add foreign key (bar) references t2 (t2key1)
+--- alter_table_add_foreign_key_not_enforced.sql
+alter table foo add foreign key (bar) references t2 (t2key1) not enforced
 
 --- AST
 &ast.AlterTable{
@@ -20,7 +20,7 @@ alter table foo add foreign key (bar) references t2 (t2key1)
         Foreign:     20,
         Rparen:      59,
         OnDeleteEnd: -1,
-        Enforced:    -1,
+        Enforced:    65,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 33,
@@ -44,10 +44,11 @@ alter table foo add foreign key (bar) references t2 (t2key1)
             Name:    "t2key1",
           },
         },
+        Enforcement: "NOT ENFORCED",
       },
     },
   },
 }
 
 --- SQL
-ALTER TABLE foo ADD FOREIGN KEY (bar) REFERENCES t2 (t2key1)
+ALTER TABLE foo ADD FOREIGN KEY (bar) REFERENCES t2 (t2key1) NOT ENFORCED

--- a/testdata/result/statement/create_table.sql.txt
+++ b/testdata/result/statement/create_table.sql.txt
@@ -8,6 +8,8 @@ create table foo (
   foreign key (bar) references t2 (t2key2) on delete cascade,
   foreign key (baz) references t2 (t2key3) on delete no action,
   constraint fkname foreign key (foo, bar) references t2 (t2key1, t2key2),
+  constraint fkname2 foreign key (foo, bar) references t2 (t2key1, t2key2) on delete cascade enforced,
+  constraint fkname3 foreign key (foo, bar) references t2 (t2key1, t2key2) not enforced,
   check (foo > 0),
   constraint cname check (bar > 0),
   quux json,
@@ -16,8 +18,8 @@ create table foo (
 
 --- AST
 &ast.CreateTable{
-  Rparen:           550,
-  PrimaryKeyRparen: 573,
+  Rparen:           742,
+  PrimaryKeyRparen: 765,
   Name:             &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
@@ -154,39 +156,39 @@ create table foo (
       Null: -1,
       Key:  -1,
       Name: &ast.Ident{
-        NamePos: 482,
-        NameEnd: 486,
+        NamePos: 674,
+        NameEnd: 678,
         Name:    "quux",
       },
       Type: &ast.ScalarSchemaType{
-        NamePos: 487,
+        NamePos: 679,
         Name:    "JSON",
       },
       Hidden: -1,
     },
     &ast.ColumnDef{
-      Null: 515,
+      Null: 707,
       Key:  -1,
       Name: &ast.Ident{
-        NamePos: 495,
-        NameEnd: 500,
+        NamePos: 687,
+        NameEnd: 692,
         Name:    "corge",
       },
       Type: &ast.ScalarSchemaType{
-        NamePos: 501,
+        NamePos: 693,
         Name:    "TIMESTAMP",
       },
       NotNull:          true,
       DefaultSemantics: &ast.ColumnDefaultExpr{
-        Default: 520,
-        Rparen:  548,
+        Default: 712,
+        Rparen:  740,
         Expr:    &ast.CallExpr{
-          Rparen: 547,
+          Rparen: 739,
           Func:   &ast.Path{
             Idents: []*ast.Ident{
               &ast.Ident{
-                NamePos: 529,
-                NameEnd: 546,
+                NamePos: 721,
+                NameEnd: 738,
                 Name:    "current_timestamp",
               },
             },
@@ -203,6 +205,7 @@ create table foo (
         Foreign:     182,
         Rparen:      221,
         OnDeleteEnd: -1,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 195,
@@ -234,6 +237,7 @@ create table foo (
         Foreign:     226,
         Rparen:      265,
         OnDeleteEnd: 284,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 239,
@@ -266,6 +270,7 @@ create table foo (
         Foreign:     288,
         Rparen:      327,
         OnDeleteEnd: 348,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 301,
@@ -303,6 +308,7 @@ create table foo (
         Foreign:     370,
         Rparen:      422,
         OnDeleteEnd: -1,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 383,
@@ -339,20 +345,117 @@ create table foo (
       },
     },
     &ast.TableConstraint{
+      ConstraintPos: 427,
+      Name:          &ast.Ident{
+        NamePos: 438,
+        NameEnd: 445,
+        Name:    "fkname2",
+      },
+      Constraint: &ast.ForeignKey{
+        Foreign:     446,
+        Rparen:      498,
+        OnDeleteEnd: 517,
+        Enforced:    518,
+        Columns:     []*ast.Ident{
+          &ast.Ident{
+            NamePos: 459,
+            NameEnd: 462,
+            Name:    "foo",
+          },
+          &ast.Ident{
+            NamePos: 464,
+            NameEnd: 467,
+            Name:    "bar",
+          },
+        },
+        ReferenceTable: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 480,
+              NameEnd: 482,
+              Name:    "t2",
+            },
+          },
+        },
+        ReferenceColumns: []*ast.Ident{
+          &ast.Ident{
+            NamePos: 484,
+            NameEnd: 490,
+            Name:    "t2key1",
+          },
+          &ast.Ident{
+            NamePos: 492,
+            NameEnd: 498,
+            Name:    "t2key2",
+          },
+        },
+        OnDelete:    "ON DELETE CASCADE",
+        Enforcement: "ENFORCED",
+      },
+    },
+    &ast.TableConstraint{
+      ConstraintPos: 530,
+      Name:          &ast.Ident{
+        NamePos: 541,
+        NameEnd: 548,
+        Name:    "fkname3",
+      },
+      Constraint: &ast.ForeignKey{
+        Foreign:     549,
+        Rparen:      601,
+        OnDeleteEnd: -1,
+        Enforced:    607,
+        Columns:     []*ast.Ident{
+          &ast.Ident{
+            NamePos: 562,
+            NameEnd: 565,
+            Name:    "foo",
+          },
+          &ast.Ident{
+            NamePos: 567,
+            NameEnd: 570,
+            Name:    "bar",
+          },
+        },
+        ReferenceTable: &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 583,
+              NameEnd: 585,
+              Name:    "t2",
+            },
+          },
+        },
+        ReferenceColumns: []*ast.Ident{
+          &ast.Ident{
+            NamePos: 587,
+            NameEnd: 593,
+            Name:    "t2key1",
+          },
+          &ast.Ident{
+            NamePos: 595,
+            NameEnd: 601,
+            Name:    "t2key2",
+          },
+        },
+        Enforcement: "NOT ENFORCED",
+      },
+    },
+    &ast.TableConstraint{
       ConstraintPos: -1,
       Constraint:    &ast.Check{
-        Check:  427,
-        Rparen: 441,
+        Check:  619,
+        Rparen: 633,
         Expr:   &ast.BinaryExpr{
           Op:   ">",
           Left: &ast.Ident{
-            NamePos: 434,
-            NameEnd: 437,
+            NamePos: 626,
+            NameEnd: 629,
             Name:    "foo",
           },
           Right: &ast.IntLiteral{
-            ValuePos: 440,
-            ValueEnd: 441,
+            ValuePos: 632,
+            ValueEnd: 633,
             Base:     10,
             Value:    "0",
           },
@@ -360,25 +463,25 @@ create table foo (
       },
     },
     &ast.TableConstraint{
-      ConstraintPos: 446,
+      ConstraintPos: 638,
       Name:          &ast.Ident{
-        NamePos: 457,
-        NameEnd: 462,
+        NamePos: 649,
+        NameEnd: 654,
         Name:    "cname",
       },
       Constraint: &ast.Check{
-        Check:  463,
-        Rparen: 477,
+        Check:  655,
+        Rparen: 669,
         Expr:   &ast.BinaryExpr{
           Op:   ">",
           Left: &ast.Ident{
-            NamePos: 470,
-            NameEnd: 473,
+            NamePos: 662,
+            NameEnd: 665,
             Name:    "bar",
           },
           Right: &ast.IntLiteral{
-            ValuePos: 476,
-            ValueEnd: 477,
+            ValuePos: 668,
+            ValueEnd: 669,
             Base:     10,
             Value:    "0",
           },
@@ -390,16 +493,16 @@ create table foo (
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
-        NamePos: 565,
-        NameEnd: 568,
+        NamePos: 757,
+        NameEnd: 760,
         Name:    "foo",
       },
     },
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
-        NamePos: 570,
-        NameEnd: 573,
+        NamePos: 762,
+        NameEnd: 765,
         Name:    "bar",
       },
     },
@@ -418,6 +521,8 @@ CREATE TABLE foo (
   FOREIGN KEY (bar) REFERENCES t2 (t2key2) ON DELETE CASCADE,
   FOREIGN KEY (baz) REFERENCES t2 (t2key3) ON DELETE NO ACTION,
   CONSTRAINT fkname FOREIGN KEY (foo, bar) REFERENCES t2 (t2key1, t2key2),
+  CONSTRAINT fkname2 FOREIGN KEY (foo, bar) REFERENCES t2 (t2key1, t2key2) ON DELETE CASCADE ENFORCED,
+  CONSTRAINT fkname3 FOREIGN KEY (foo, bar) REFERENCES t2 (t2key1, t2key2) NOT ENFORCED,
   CHECK (foo > 0),
   CONSTRAINT cname CHECK (bar > 0)
 ) PRIMARY KEY (foo, bar)

--- a/testdata/result/statement/create_table_for_format_test.sql.txt
+++ b/testdata/result/statement/create_table_for_format_test.sql.txt
@@ -189,6 +189,7 @@ create table if not exists foo (
         Foreign:     206,
         Rparen:      245,
         OnDeleteEnd: -1,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 219,
@@ -225,6 +226,7 @@ create table if not exists foo (
         Foreign:     270,
         Rparen:      322,
         OnDeleteEnd: -1,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 283,

--- a/testdata/result/statement/named_schemas_alter_table_add_constraint.sql.txt
+++ b/testdata/result/statement/named_schemas_alter_table_add_constraint.sql.txt
@@ -30,6 +30,7 @@ ALTER TABLE sch1.ShoppingCarts ADD CONSTRAINT FKShoppingCartsCustomers FOREIGN K
         Foreign:     71,
         Rparen:      163,
         OnDeleteEnd: 182,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 83,

--- a/testdata/result/statement/named_schemas_create_table_foreign_key.sql.txt
+++ b/testdata/result/statement/named_schemas_create_table_foreign_key.sql.txt
@@ -85,6 +85,7 @@ CREATE TABLE sch1.ShoppingCarts (
         Foreign:     163,
         Rparen:      255,
         OnDeleteEnd: 274,
+        Enforced:    -1,
         Columns:     []*ast.Ident{
           &ast.Ident{
             NamePos: 175,


### PR DESCRIPTION
This PR implements `ENFORCED` or `NOT ENFORCED` in `ast.ForeignKey` to support informational foreign keys.

## Related Issue

- close #282