### PR TITLE
Implement TABLE OPTIONS

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -432,6 +432,7 @@ func (DropRowDeletionPolicy) isTableAlteration()    {}
 func (ReplaceRowDeletionPolicy) isTableAlteration() {}
 func (SetOnDelete) isTableAlteration()              {}
 func (AlterColumn) isTableAlteration()              {}
+func (AlterTableSetOptions) isTableAlteration()     {}
 
 // ColumnDefaultSemantics is interface of DefaultExpr, GeneratedColumnExpr, IdentityColumn, AutoIncrement.
 // They are change default value of column and mutually exclusive.
@@ -2874,6 +2875,17 @@ type SetOnDelete struct {
 	OnDeleteEnd token.Pos // end position of ON DELETE clause
 
 	OnDelete OnDeleteAction
+}
+
+// AlterTableSetOptions is SET OPTIONS node in ALTER TABLE.
+//
+//	SET {{.Options | sql}}
+type AlterTableSetOptions struct {
+	// pos = Set
+	// end = Options.end
+
+	Set     token.Pos
+	Options *Options
 }
 
 // AlterColumn is ALTER COLUMN clause in ALTER TABLE.

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2391,7 +2391,7 @@ type DropProtoBundle struct {
 //	{{if .PrimaryKeys}}PRIMARY KEY ({{.PrimaryKeys | sqlJoin ","}}){{end}}
 //	{{.Cluster | sqlOpt}}
 //	{{.CreateRowDeletionPolicy | sqlOpt}}
-//	{{.Options | sqlOpt}}
+//	{{if .Options}}, {{.Options | sqlOpt}}{{end}}
 //
 // Spanner SQL allows to mix `Columns` and `TableConstraints` and `Synonyms`,
 // however they are separated in AST definition for historical reasons. If you want to get

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2390,13 +2390,14 @@ type DropProtoBundle struct {
 //	{{if .PrimaryKeys}}PRIMARY KEY ({{.PrimaryKeys | sqlJoin ","}}){{end}}
 //	{{.Cluster | sqlOpt}}
 //	{{.CreateRowDeletionPolicy | sqlOpt}}
+//	{{.Options | sqlOpt}}
 //
 // Spanner SQL allows to mix `Columns` and `TableConstraints` and `Synonyms`,
 // however they are separated in AST definition for historical reasons. If you want to get
 // the original order of them, please sort them by their `Pos()`.
 type CreateTable struct {
 	// pos = Create
-	// end = RowDeletionPolicy.end || Cluster.end || PrimaryKeyRparen + 1 || Rparen + 1
+	// end = Options.end || RowDeletionPolicy.end || Cluster.end || PrimaryKeyRparen + 1 || Rparen + 1
 
 	Create           token.Pos // position of "CREATE" keyword
 	Rparen           token.Pos // position of ")" of end of column definitions
@@ -2410,6 +2411,7 @@ type CreateTable struct {
 	Synonyms          []*Synonym
 	Cluster           *Cluster                 // optional
 	RowDeletionPolicy *CreateRowDeletionPolicy // optional
+	Options           *Options                 // optional
 }
 
 // Synonym is SYNONYM node in CREATE TABLE

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -1091,7 +1091,7 @@ func (c *CreateTable) Pos() token.Pos {
 }
 
 func (c *CreateTable) End() token.Pos {
-	return posChoice(nodeEnd(wrapNode(c.RowDeletionPolicy)), nodeEnd(wrapNode(c.Cluster)), posAdd(c.PrimaryKeyRparen, 1), posAdd(c.Rparen, 1))
+	return posChoice(nodeEnd(wrapNode(c.Options)), nodeEnd(wrapNode(c.RowDeletionPolicy)), nodeEnd(wrapNode(c.Cluster)), posAdd(c.PrimaryKeyRparen, 1), posAdd(c.Rparen, 1))
 }
 
 func (s *Synonym) Pos() token.Pos {

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -1366,6 +1366,14 @@ func (s *SetOnDelete) End() token.Pos {
 	return s.OnDeleteEnd
 }
 
+func (a *AlterTableSetOptions) Pos() token.Pos {
+	return a.Set
+}
+
+func (a *AlterTableSetOptions) End() token.Pos {
+	return nodeEnd(wrapNode(a.Options))
+}
+
 func (a *AlterColumn) Pos() token.Pos {
 	return a.Alter
 }

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -795,7 +795,8 @@ func (c *CreateTable) SQL() string {
 		"\n)" +
 		strOpt(len(c.PrimaryKeys) > 0, " PRIMARY KEY ("+sqlJoin(c.PrimaryKeys, ", ")+")") +
 		sqlOpt("", c.Cluster, "") +
-		sqlOpt("", c.RowDeletionPolicy, "")
+		sqlOpt("", c.RowDeletionPolicy, "") +
+		sqlOpt(", ", c.Options, "")
 }
 
 func (s *Synonym) SQL() string { return "SYNONYM (" + s.Name.SQL() + ")" }

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -936,6 +936,8 @@ func (s *SetOnDelete) SQL() string {
 	return "SET " + string(s.OnDelete)
 }
 
+func (a *AlterTableSetOptions) SQL() string { return "SET " + a.Options.SQL() }
+
 func (a *AlterColumn) SQL() string {
 	return "ALTER COLUMN " + a.Name.SQL() + " " + a.Alteration.SQL()
 }

--- a/ast/walk_internal.go
+++ b/ast/walk_internal.go
@@ -623,6 +623,9 @@ func walkInternal(node Node, v Visitor, stack []*stackItem) []*stackItem {
 	case *SetOnDelete:
 		// nothing to do
 
+	case *AlterTableSetOptions:
+		stack = append(stack, &stackItem{node: wrapNode(n.Options), visitor: v.Field("Options")})
+
 	case *AlterColumn:
 		stack = append(stack, &stackItem{node: wrapNode(n.Alteration), visitor: v.Field("Alteration")})
 		stack = append(stack, &stackItem{node: wrapNode(n.Name), visitor: v.Field("Name")})

--- a/ast/walk_internal.go
+++ b/ast/walk_internal.go
@@ -493,6 +493,7 @@ func walkInternal(node Node, v Visitor, stack []*stackItem) []*stackItem {
 		// nothing to do
 
 	case *CreateTable:
+		stack = append(stack, &stackItem{node: wrapNode(n.Options), visitor: v.Field("Options")})
 		stack = append(stack, &stackItem{node: wrapNode(n.RowDeletionPolicy), visitor: v.Field("RowDeletionPolicy")})
 		stack = append(stack, &stackItem{node: wrapNode(n.Cluster), visitor: v.Field("Cluster")})
 		stack = append(stack, &stackItem{nodes: wrapNodes(n.Synonyms), visitor: v.Field("Synonyms")})

--- a/testdata/input/ddl/alter_table_set_options.sql
+++ b/testdata/input/ddl/alter_table_set_options.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Singers SET OPTIONS (locality_group = 'spill_to_hdd')

--- a/testdata/input/ddl/create_table_options.sql
+++ b/testdata/input/ddl/create_table_options.sql
@@ -1,0 +1,6 @@
+CREATE TABLE Singers (
+  SingerId   INT64 NOT NULL,
+  FirstName  STRING(1024),
+  LastName   STRING(1024),
+  Awards     ARRAY<STRING(MAX)> OPTIONS (locality_group = 'spill_to_hdd')
+) PRIMARY KEY (SingerId), OPTIONS (locality_group = 'ssd_only')

--- a/testdata/result/ddl/alter_table_set_options.sql.txt
+++ b/testdata/result/ddl/alter_table_set_options.sql.txt
@@ -1,0 +1,38 @@
+--- alter_table_set_options.sql
+ALTER TABLE Singers SET OPTIONS (locality_group = 'spill_to_hdd')
+--- AST
+&ast.AlterTable{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 19,
+        Name:    "Singers",
+      },
+    },
+  },
+  TableAlteration: &ast.AlterTableSetOptions{
+    Set:     20,
+    Options: &ast.Options{
+      Options: 24,
+      Rparen:  64,
+      Records: []*ast.OptionsDef{
+        &ast.OptionsDef{
+          Name: &ast.Ident{
+            NamePos: 33,
+            NameEnd: 47,
+            Name:    "locality_group",
+          },
+          Value: &ast.StringLiteral{
+            ValuePos: 50,
+            ValueEnd: 64,
+            Value:    "spill_to_hdd",
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE Singers SET OPTIONS (locality_group = "spill_to_hdd")

--- a/testdata/result/ddl/create_table_options.sql.txt
+++ b/testdata/result/ddl/create_table_options.sql.txt
@@ -1,0 +1,155 @@
+--- create_table_options.sql
+CREATE TABLE Singers (
+  SingerId   INT64 NOT NULL,
+  FirstName  STRING(1024),
+  LastName   STRING(1024),
+  Awards     ARRAY<STRING(MAX)> OPTIONS (locality_group = 'spill_to_hdd')
+) PRIMARY KEY (SingerId), OPTIONS (locality_group = 'ssd_only')
+--- AST
+&ast.CreateTable{
+  Rparen:           180,
+  PrimaryKeyRparen: 203,
+  Name:             &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 20,
+        Name:    "Singers",
+      },
+    },
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: 46,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 25,
+        NameEnd: 33,
+        Name:    "SingerId",
+      },
+      Type: &ast.ScalarSchemaType{
+        NamePos: 36,
+        Name:    "INT64",
+      },
+      NotNull: true,
+      Hidden:  -1,
+    },
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 54,
+        NameEnd: 63,
+        Name:    "FirstName",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 65,
+        Rparen:  76,
+        Name:    "STRING",
+        Size:    &ast.IntLiteral{
+          ValuePos: 72,
+          ValueEnd: 76,
+          Base:     10,
+          Value:    "1024",
+        },
+      },
+      Hidden: -1,
+    },
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 81,
+        NameEnd: 89,
+        Name:    "LastName",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 92,
+        Rparen:  103,
+        Name:    "STRING",
+        Size:    &ast.IntLiteral{
+          ValuePos: 99,
+          ValueEnd: 103,
+          Base:     10,
+          Value:    "1024",
+        },
+      },
+      Hidden: -1,
+    },
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 108,
+        NameEnd: 114,
+        Name:    "Awards",
+      },
+      Type: &ast.ArraySchemaType{
+        Array:  119,
+        Gt:     136,
+        Rparen: -1,
+        Item:   &ast.SizedSchemaType{
+          NamePos: 125,
+          Rparen:  135,
+          Name:    "STRING",
+          Max:     true,
+        },
+      },
+      Hidden:  -1,
+      Options: &ast.Options{
+        Options: 138,
+        Rparen:  178,
+        Records: []*ast.OptionsDef{
+          &ast.OptionsDef{
+            Name: &ast.Ident{
+              NamePos: 147,
+              NameEnd: 161,
+              Name:    "locality_group",
+            },
+            Value: &ast.StringLiteral{
+              ValuePos: 164,
+              ValueEnd: 178,
+              Value:    "spill_to_hdd",
+            },
+          },
+        },
+      },
+    },
+  },
+  PrimaryKeys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 195,
+        NameEnd: 203,
+        Name:    "SingerId",
+      },
+    },
+  },
+  Options: &ast.Options{
+    Options: 206,
+    Rparen:  242,
+    Records: []*ast.OptionsDef{
+      &ast.OptionsDef{
+        Name: &ast.Ident{
+          NamePos: 215,
+          NameEnd: 229,
+          Name:    "locality_group",
+        },
+        Value: &ast.StringLiteral{
+          ValuePos: 232,
+          ValueEnd: 242,
+          Value:    "ssd_only",
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE TABLE Singers (
+  SingerId INT64 NOT NULL,
+  FirstName STRING(1024),
+  LastName STRING(1024),
+  Awards ARRAY<STRING(MAX)> OPTIONS (locality_group = "spill_to_hdd")
+) PRIMARY KEY (SingerId), OPTIONS (locality_group = "ssd_only")

--- a/testdata/result/statement/alter_table_set_options.sql.txt
+++ b/testdata/result/statement/alter_table_set_options.sql.txt
@@ -1,0 +1,38 @@
+--- alter_table_set_options.sql
+ALTER TABLE Singers SET OPTIONS (locality_group = 'spill_to_hdd')
+--- AST
+&ast.AlterTable{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 19,
+        Name:    "Singers",
+      },
+    },
+  },
+  TableAlteration: &ast.AlterTableSetOptions{
+    Set:     20,
+    Options: &ast.Options{
+      Options: 24,
+      Rparen:  64,
+      Records: []*ast.OptionsDef{
+        &ast.OptionsDef{
+          Name: &ast.Ident{
+            NamePos: 33,
+            NameEnd: 47,
+            Name:    "locality_group",
+          },
+          Value: &ast.StringLiteral{
+            ValuePos: 50,
+            ValueEnd: 64,
+            Value:    "spill_to_hdd",
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE Singers SET OPTIONS (locality_group = "spill_to_hdd")

--- a/testdata/result/statement/create_table_options.sql.txt
+++ b/testdata/result/statement/create_table_options.sql.txt
@@ -1,0 +1,155 @@
+--- create_table_options.sql
+CREATE TABLE Singers (
+  SingerId   INT64 NOT NULL,
+  FirstName  STRING(1024),
+  LastName   STRING(1024),
+  Awards     ARRAY<STRING(MAX)> OPTIONS (locality_group = 'spill_to_hdd')
+) PRIMARY KEY (SingerId), OPTIONS (locality_group = 'ssd_only')
+--- AST
+&ast.CreateTable{
+  Rparen:           180,
+  PrimaryKeyRparen: 203,
+  Name:             &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 20,
+        Name:    "Singers",
+      },
+    },
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: 46,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 25,
+        NameEnd: 33,
+        Name:    "SingerId",
+      },
+      Type: &ast.ScalarSchemaType{
+        NamePos: 36,
+        Name:    "INT64",
+      },
+      NotNull: true,
+      Hidden:  -1,
+    },
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 54,
+        NameEnd: 63,
+        Name:    "FirstName",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 65,
+        Rparen:  76,
+        Name:    "STRING",
+        Size:    &ast.IntLiteral{
+          ValuePos: 72,
+          ValueEnd: 76,
+          Base:     10,
+          Value:    "1024",
+        },
+      },
+      Hidden: -1,
+    },
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 81,
+        NameEnd: 89,
+        Name:    "LastName",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 92,
+        Rparen:  103,
+        Name:    "STRING",
+        Size:    &ast.IntLiteral{
+          ValuePos: 99,
+          ValueEnd: 103,
+          Base:     10,
+          Value:    "1024",
+        },
+      },
+      Hidden: -1,
+    },
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 108,
+        NameEnd: 114,
+        Name:    "Awards",
+      },
+      Type: &ast.ArraySchemaType{
+        Array:  119,
+        Gt:     136,
+        Rparen: -1,
+        Item:   &ast.SizedSchemaType{
+          NamePos: 125,
+          Rparen:  135,
+          Name:    "STRING",
+          Max:     true,
+        },
+      },
+      Hidden:  -1,
+      Options: &ast.Options{
+        Options: 138,
+        Rparen:  178,
+        Records: []*ast.OptionsDef{
+          &ast.OptionsDef{
+            Name: &ast.Ident{
+              NamePos: 147,
+              NameEnd: 161,
+              Name:    "locality_group",
+            },
+            Value: &ast.StringLiteral{
+              ValuePos: 164,
+              ValueEnd: 178,
+              Value:    "spill_to_hdd",
+            },
+          },
+        },
+      },
+    },
+  },
+  PrimaryKeys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 195,
+        NameEnd: 203,
+        Name:    "SingerId",
+      },
+    },
+  },
+  Options: &ast.Options{
+    Options: 206,
+    Rparen:  242,
+    Records: []*ast.OptionsDef{
+      &ast.OptionsDef{
+        Name: &ast.Ident{
+          NamePos: 215,
+          NameEnd: 229,
+          Name:    "locality_group",
+        },
+        Value: &ast.StringLiteral{
+          ValuePos: 232,
+          ValueEnd: 242,
+          Value:    "ssd_only",
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE TABLE Singers (
+  SingerId INT64 NOT NULL,
+  FirstName STRING(1024),
+  LastName STRING(1024),
+  Awards ARRAY<STRING(MAX)> OPTIONS (locality_group = "spill_to_hdd")
+) PRIMARY KEY (SingerId), OPTIONS (locality_group = "ssd_only")


### PR DESCRIPTION
This PR implements `OPTIONS` in `CREATE TABLE` and `ALTER TABLE`.

## Note

If breaking changes are permitted, we can generalize `SET OPTIONS` in `ALTER` statements.

- `AlterColumnSetOptions`
- `ChangeStreamSetOptions`


## Related Issues

- close #287 
- part of #288 