### PR TITLE
feature: Support ALTER VECTOR INDEX

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -115,6 +115,7 @@ func (AlterModel) isStatement()          {}
 func (DropModel) isStatement()           {}
 func (Analyze) isStatement()             {}
 func (CreateVectorIndex) isStatement()   {}
+func (AlterVectorIndex) isStatement()    {}
 func (DropVectorIndex) isStatement()     {}
 func (CreatePropertyGraph) isStatement() {}
 func (DropPropertyGraph) isStatement()   {}
@@ -407,6 +408,7 @@ func (AlterModel) isDDL()          {}
 func (DropModel) isDDL()           {}
 func (Analyze) isDDL()             {}
 func (CreateVectorIndex) isDDL()   {}
+func (AlterVectorIndex) isDDL()    {}
 func (DropVectorIndex) isDDL()     {}
 func (CreatePropertyGraph) isDDL() {}
 func (DropPropertyGraph) isDDL()   {}
@@ -525,6 +527,17 @@ type IndexAlteration interface {
 
 func (AddStoredColumn) isIndexAlteration()  {}
 func (DropStoredColumn) isIndexAlteration() {}
+
+// VectorIndexAlteration represents ALTER VECTOR INDEX action.
+// Note: Currently, it is same as IndexAlteration,
+// but cloud-spanner-emulator/backend/schema/parser/ddl_parser.jjt implies their difference.
+type VectorIndexAlteration interface {
+	Node
+	isVectorIndexAlteration()
+}
+
+func (AddStoredColumn) isVectorIndexAlteration()  {}
+func (DropStoredColumn) isVectorIndexAlteration() {}
 
 // DML represents data manipulation language in SQL.
 //
@@ -3151,6 +3164,18 @@ type CreateVectorIndex struct {
 	// Reference: https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#vector_index_statements
 	Where   *Where // optional
 	Options *Options
+}
+
+// AlterVectorIndex is ALTER VECTOR INDEX statement node.
+//
+//	ALTER VECTOR INDEX {{.Name | sql}} {{.Alteration | sql}}
+type AlterVectorIndex struct {
+	// pos = Alter
+	// end = Alteration.end
+
+	Alter      token.Pos
+	Name       *Path
+	Alteration VectorIndexAlteration
 }
 
 // CreateChangeStream is CREATE CHANGE STREAM statement node.

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -1526,6 +1526,14 @@ func (c *CreateVectorIndex) End() token.Pos {
 	return nodeEnd(wrapNode(c.Options))
 }
 
+func (a *AlterVectorIndex) Pos() token.Pos {
+	return a.Alter
+}
+
+func (a *AlterVectorIndex) End() token.Pos {
+	return nodeEnd(wrapNode(a.Alteration))
+}
+
 func (c *CreateChangeStream) Pos() token.Pos {
 	return c.Create
 }

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -1011,6 +1011,10 @@ func (c *CreateVectorIndex) SQL() string {
 		c.Options.SQL()
 }
 
+func (a *AlterVectorIndex) SQL() string {
+	return "ALTER VECTOR INDEX " + a.Name.SQL() + " " + a.Alteration.SQL()
+}
+
 func (c *CreateChangeStream) SQL() string {
 	return "CREATE CHANGE STREAM " + c.Name.SQL() +
 		sqlOpt(" ", c.For, "") +

--- a/ast/walk_internal.go
+++ b/ast/walk_internal.go
@@ -697,6 +697,10 @@ func walkInternal(node Node, v Visitor, stack []*stackItem) []*stackItem {
 		stack = append(stack, &stackItem{node: wrapNode(n.TableName), visitor: v.Field("TableName")})
 		stack = append(stack, &stackItem{node: wrapNode(n.Name), visitor: v.Field("Name")})
 
+	case *AlterVectorIndex:
+		stack = append(stack, &stackItem{node: wrapNode(n.Alteration), visitor: v.Field("Alteration")})
+		stack = append(stack, &stackItem{node: wrapNode(n.Name), visitor: v.Field("Name")})
+
 	case *CreateChangeStream:
 		stack = append(stack, &stackItem{node: wrapNode(n.Options), visitor: v.Field("Options")})
 		stack = append(stack, &stackItem{node: wrapNode(n.For), visitor: v.Field("For")})

--- a/parser.go
+++ b/parser.go
@@ -2898,6 +2898,8 @@ func (p *Parser) parseDDL() (ddl ast.DDL) {
 			return p.parseAlterStatistics(pos)
 		case p.Token.IsKeywordLike("MODEL"):
 			return p.parseAlterModel(pos)
+		case p.Token.IsKeywordLike("VECTOR"):
+			return p.parseAlterVectorIndex(pos)
 		}
 		p.panicfAtToken(&p.Token, "expected pseudo keyword: TABLE, CHANGE, but: %s", p.Token.AsString)
 	case p.Token.IsKeywordLike("DROP"):
@@ -3747,6 +3749,17 @@ func (p *Parser) parseIndexAlteration() ast.IndexAlteration {
 	}
 }
 
+func (p *Parser) parseVectorIndexAlteration() ast.VectorIndexAlteration {
+	switch {
+	case p.Token.IsKeywordLike("ADD"):
+		return p.parseAddStoredColumn()
+	case p.Token.IsKeywordLike("DROP"):
+		return p.parseDropStoredColumn()
+	default:
+		panic(p.errorfAtToken(&p.Token, "expected pseudo keyword: ADD, DROP, but: %s", p.Token.AsString))
+	}
+}
+
 func (p *Parser) parseCreateIndex(pos token.Pos) *ast.CreateIndex {
 	unique := false
 	if p.Token.IsKeywordLike("UNIQUE") {
@@ -4367,7 +4380,7 @@ func (p *Parser) parseAlterSequence(pos token.Pos) *ast.AlterSequence {
 	}
 }
 
-func (p *Parser) parseAddStoredColumn() ast.IndexAlteration {
+func (p *Parser) parseAddStoredColumn() *ast.AddStoredColumn {
 	pos := p.expectKeywordLike("ADD").Pos
 	p.expectKeywordLike("STORED")
 	p.expectKeywordLike("COLUMN")
@@ -4380,7 +4393,7 @@ func (p *Parser) parseAddStoredColumn() ast.IndexAlteration {
 	}
 }
 
-func (p *Parser) parseDropStoredColumn() ast.IndexAlteration {
+func (p *Parser) parseDropStoredColumn() *ast.DropStoredColumn {
 	pos := p.expectKeywordLike("DROP").Pos
 	p.expectKeywordLike("STORED")
 	p.expectKeywordLike("COLUMN")
@@ -4411,6 +4424,18 @@ func (p *Parser) parseDropIndex(pos token.Pos) *ast.DropIndex {
 		Drop:     pos,
 		IfExists: ifExists,
 		Name:     name,
+	}
+}
+
+func (p *Parser) parseAlterVectorIndex(pos token.Pos) *ast.AlterVectorIndex {
+	p.expectKeywordLike("VECTOR")
+	p.expectKeywordLike("INDEX")
+	name := p.parsePath()
+	alteration := p.parseVectorIndexAlteration()
+	return &ast.AlterVectorIndex{
+		Alter:      pos,
+		Name:       name,
+		Alteration: alteration,
 	}
 }
 

--- a/testdata/input/ddl/alter_vector_index_add_stored_column.sql
+++ b/testdata/input/ddl/alter_vector_index_add_stored_column.sql
@@ -1,0 +1,2 @@
+alter vector index Singer_vector_index
+add stored column genre

--- a/testdata/input/ddl/alter_vector_index_drop_stored_column.sql
+++ b/testdata/input/ddl/alter_vector_index_drop_stored_column.sql
@@ -1,0 +1,2 @@
+alter vector index Singer_vector_index
+drop stored column genre

--- a/testdata/result/ddl/alter_vector_index_add_stored_column.sql.txt
+++ b/testdata/result/ddl/alter_vector_index_add_stored_column.sql.txt
@@ -1,0 +1,26 @@
+--- alter_vector_index_add_stored_column.sql
+alter vector index Singer_vector_index
+add stored column genre
+--- AST
+&ast.AlterVectorIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 38,
+        Name:    "Singer_vector_index",
+      },
+    },
+  },
+  Alteration: &ast.AddStoredColumn{
+    Add:  39,
+    Name: &ast.Ident{
+      NamePos: 57,
+      NameEnd: 62,
+      Name:    "genre",
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX Singer_vector_index ADD STORED COLUMN genre

--- a/testdata/result/ddl/alter_vector_index_drop_stored_column.sql.txt
+++ b/testdata/result/ddl/alter_vector_index_drop_stored_column.sql.txt
@@ -1,0 +1,26 @@
+--- alter_vector_index_drop_stored_column.sql
+alter vector index Singer_vector_index
+drop stored column genre
+--- AST
+&ast.AlterVectorIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 38,
+        Name:    "Singer_vector_index",
+      },
+    },
+  },
+  Alteration: &ast.DropStoredColumn{
+    Drop: 39,
+    Name: &ast.Ident{
+      NamePos: 58,
+      NameEnd: 63,
+      Name:    "genre",
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX Singer_vector_index DROP STORED COLUMN genre

--- a/testdata/result/statement/alter_vector_index_add_stored_column.sql.txt
+++ b/testdata/result/statement/alter_vector_index_add_stored_column.sql.txt
@@ -1,0 +1,26 @@
+--- alter_vector_index_add_stored_column.sql
+alter vector index Singer_vector_index
+add stored column genre
+--- AST
+&ast.AlterVectorIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 38,
+        Name:    "Singer_vector_index",
+      },
+    },
+  },
+  Alteration: &ast.AddStoredColumn{
+    Add:  39,
+    Name: &ast.Ident{
+      NamePos: 57,
+      NameEnd: 62,
+      Name:    "genre",
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX Singer_vector_index ADD STORED COLUMN genre

--- a/testdata/result/statement/alter_vector_index_drop_stored_column.sql.txt
+++ b/testdata/result/statement/alter_vector_index_drop_stored_column.sql.txt
@@ -1,0 +1,26 @@
+--- alter_vector_index_drop_stored_column.sql
+alter vector index Singer_vector_index
+drop stored column genre
+--- AST
+&ast.AlterVectorIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 38,
+        Name:    "Singer_vector_index",
+      },
+    },
+  },
+  Alteration: &ast.DropStoredColumn{
+    Drop: 39,
+    Name: &ast.Ident{
+      NamePos: 58,
+      NameEnd: 63,
+      Name:    "genre",
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX Singer_vector_index DROP STORED COLUMN genre


### PR DESCRIPTION
This PR implements `ALTER VECTOR INDEX` statement.

Note: `VECTOR INDEX` doesn't yet have supported named schema, but it is parseable as qualified identifier so `AlterVectorIndex.Name` is implemented as `*ast.Path`.

- #298

## Related Issue

- close #296 