### PR TITLE
feature: Allow trailing comma in PROTO BUNDLE

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -3046,8 +3046,25 @@ func (p *Parser) parseCreatePlacement(pos token.Pos) *ast.CreatePlacement {
 
 func (p *Parser) parseProtoBundleTypes() *ast.ProtoBundleTypes {
 	lparen := p.expect("(").Pos
-	types := parseCommaSeparatedList(p, p.parseNamedType)
+
+	var types []*ast.NamedType
+	if p.Token.Kind != ")" {
+		for {
+			types = append(types, p.parseNamedType())
+
+			if p.Token.Kind != "," {
+				break
+			}
+			p.nextToken()
+
+			// case of trailing comma
+			if p.Token.Kind == ")" {
+				break
+			}
+		}
+	}
 	rparen := p.expect(")").Pos
+
 	return &ast.ProtoBundleTypes{
 		Lparen: lparen,
 		Rparen: rparen,

--- a/testdata/input/ddl/alter_proto_bundle_delete_trailing_comma.sql
+++ b/testdata/input/ddl/alter_proto_bundle_delete_trailing_comma.sql
@@ -1,0 +1,3 @@
+ALTER PROTO BUNDLE DELETE (
+    examples.shipping.Order,
+)

--- a/testdata/input/ddl/alter_proto_bundle_insert_trailing_comma.sql
+++ b/testdata/input/ddl/alter_proto_bundle_insert_trailing_comma.sql
@@ -1,0 +1,3 @@
+ALTER PROTO BUNDLE INSERT (
+    examples.shipping.Order,
+)

--- a/testdata/input/ddl/alter_proto_bundle_update_trailing_comma.sql
+++ b/testdata/input/ddl/alter_proto_bundle_update_trailing_comma.sql
@@ -1,0 +1,3 @@
+ALTER PROTO BUNDLE UPDATE (
+    examples.shipping.OrderHistory,
+)

--- a/testdata/input/ddl/create_proto_bundle_trailing_comma.sql
+++ b/testdata/input/ddl/create_proto_bundle_trailing_comma.sql
@@ -1,0 +1,3 @@
+CREATE PROTO BUNDLE (
+    examples.shipping.OrderHistory,
+)

--- a/testdata/result/ddl/alter_proto_bundle_delete_trailing_comma.sql.txt
+++ b/testdata/result/ddl/alter_proto_bundle_delete_trailing_comma.sql.txt
@@ -1,0 +1,40 @@
+--- alter_proto_bundle_delete_trailing_comma.sql
+ALTER PROTO BUNDLE DELETE (
+    examples.shipping.Order,
+)
+
+--- AST
+&ast.AlterProtoBundle{
+  Bundle: 12,
+  Delete: &ast.AlterProtoBundleDelete{
+    Delete: 19,
+    Types:  &ast.ProtoBundleTypes{
+      Lparen: 26,
+      Rparen: 57,
+      Types:  []*ast.NamedType{
+        &ast.NamedType{
+          Path: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 32,
+              NameEnd: 40,
+              Name:    "examples",
+            },
+            &ast.Ident{
+              NamePos: 41,
+              NameEnd: 49,
+              Name:    "shipping",
+            },
+            &ast.Ident{
+              NamePos: 50,
+              NameEnd: 55,
+              Name:    "Order",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER PROTO BUNDLE DELETE (examples.shipping.`Order`)

--- a/testdata/result/ddl/alter_proto_bundle_insert_trailing_comma.sql.txt
+++ b/testdata/result/ddl/alter_proto_bundle_insert_trailing_comma.sql.txt
@@ -1,0 +1,40 @@
+--- alter_proto_bundle_insert_trailing_comma.sql
+ALTER PROTO BUNDLE INSERT (
+    examples.shipping.Order,
+)
+
+--- AST
+&ast.AlterProtoBundle{
+  Bundle: 12,
+  Insert: &ast.AlterProtoBundleInsert{
+    Insert: 19,
+    Types:  &ast.ProtoBundleTypes{
+      Lparen: 26,
+      Rparen: 57,
+      Types:  []*ast.NamedType{
+        &ast.NamedType{
+          Path: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 32,
+              NameEnd: 40,
+              Name:    "examples",
+            },
+            &ast.Ident{
+              NamePos: 41,
+              NameEnd: 49,
+              Name:    "shipping",
+            },
+            &ast.Ident{
+              NamePos: 50,
+              NameEnd: 55,
+              Name:    "Order",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER PROTO BUNDLE INSERT (examples.shipping.`Order`)

--- a/testdata/result/ddl/alter_proto_bundle_update_trailing_comma.sql.txt
+++ b/testdata/result/ddl/alter_proto_bundle_update_trailing_comma.sql.txt
@@ -1,0 +1,40 @@
+--- alter_proto_bundle_update_trailing_comma.sql
+ALTER PROTO BUNDLE UPDATE (
+    examples.shipping.OrderHistory,
+)
+
+--- AST
+&ast.AlterProtoBundle{
+  Bundle: 12,
+  Update: &ast.AlterProtoBundleUpdate{
+    Update: 19,
+    Types:  &ast.ProtoBundleTypes{
+      Lparen: 26,
+      Rparen: 64,
+      Types:  []*ast.NamedType{
+        &ast.NamedType{
+          Path: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 32,
+              NameEnd: 40,
+              Name:    "examples",
+            },
+            &ast.Ident{
+              NamePos: 41,
+              NameEnd: 49,
+              Name:    "shipping",
+            },
+            &ast.Ident{
+              NamePos: 50,
+              NameEnd: 62,
+              Name:    "OrderHistory",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER PROTO BUNDLE UPDATE (examples.shipping.OrderHistory)

--- a/testdata/result/ddl/create_proto_bundle_trailing_comma.sql.txt
+++ b/testdata/result/ddl/create_proto_bundle_trailing_comma.sql.txt
@@ -1,0 +1,36 @@
+--- create_proto_bundle_trailing_comma.sql
+CREATE PROTO BUNDLE (
+    examples.shipping.OrderHistory,
+)
+
+--- AST
+&ast.CreateProtoBundle{
+  Types: &ast.ProtoBundleTypes{
+    Lparen: 20,
+    Rparen: 58,
+    Types:  []*ast.NamedType{
+      &ast.NamedType{
+        Path: []*ast.Ident{
+          &ast.Ident{
+            NamePos: 26,
+            NameEnd: 34,
+            Name:    "examples",
+          },
+          &ast.Ident{
+            NamePos: 35,
+            NameEnd: 43,
+            Name:    "shipping",
+          },
+          &ast.Ident{
+            NamePos: 44,
+            NameEnd: 56,
+            Name:    "OrderHistory",
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE PROTO BUNDLE (examples.shipping.OrderHistory)

--- a/testdata/result/statement/alter_proto_bundle_delete_trailing_comma.sql.txt
+++ b/testdata/result/statement/alter_proto_bundle_delete_trailing_comma.sql.txt
@@ -1,0 +1,40 @@
+--- alter_proto_bundle_delete_trailing_comma.sql
+ALTER PROTO BUNDLE DELETE (
+    examples.shipping.Order,
+)
+
+--- AST
+&ast.AlterProtoBundle{
+  Bundle: 12,
+  Delete: &ast.AlterProtoBundleDelete{
+    Delete: 19,
+    Types:  &ast.ProtoBundleTypes{
+      Lparen: 26,
+      Rparen: 57,
+      Types:  []*ast.NamedType{
+        &ast.NamedType{
+          Path: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 32,
+              NameEnd: 40,
+              Name:    "examples",
+            },
+            &ast.Ident{
+              NamePos: 41,
+              NameEnd: 49,
+              Name:    "shipping",
+            },
+            &ast.Ident{
+              NamePos: 50,
+              NameEnd: 55,
+              Name:    "Order",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER PROTO BUNDLE DELETE (examples.shipping.`Order`)

--- a/testdata/result/statement/alter_proto_bundle_insert_trailing_comma.sql.txt
+++ b/testdata/result/statement/alter_proto_bundle_insert_trailing_comma.sql.txt
@@ -1,0 +1,40 @@
+--- alter_proto_bundle_insert_trailing_comma.sql
+ALTER PROTO BUNDLE INSERT (
+    examples.shipping.Order,
+)
+
+--- AST
+&ast.AlterProtoBundle{
+  Bundle: 12,
+  Insert: &ast.AlterProtoBundleInsert{
+    Insert: 19,
+    Types:  &ast.ProtoBundleTypes{
+      Lparen: 26,
+      Rparen: 57,
+      Types:  []*ast.NamedType{
+        &ast.NamedType{
+          Path: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 32,
+              NameEnd: 40,
+              Name:    "examples",
+            },
+            &ast.Ident{
+              NamePos: 41,
+              NameEnd: 49,
+              Name:    "shipping",
+            },
+            &ast.Ident{
+              NamePos: 50,
+              NameEnd: 55,
+              Name:    "Order",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER PROTO BUNDLE INSERT (examples.shipping.`Order`)

--- a/testdata/result/statement/alter_proto_bundle_update_trailing_comma.sql.txt
+++ b/testdata/result/statement/alter_proto_bundle_update_trailing_comma.sql.txt
@@ -1,0 +1,40 @@
+--- alter_proto_bundle_update_trailing_comma.sql
+ALTER PROTO BUNDLE UPDATE (
+    examples.shipping.OrderHistory,
+)
+
+--- AST
+&ast.AlterProtoBundle{
+  Bundle: 12,
+  Update: &ast.AlterProtoBundleUpdate{
+    Update: 19,
+    Types:  &ast.ProtoBundleTypes{
+      Lparen: 26,
+      Rparen: 64,
+      Types:  []*ast.NamedType{
+        &ast.NamedType{
+          Path: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 32,
+              NameEnd: 40,
+              Name:    "examples",
+            },
+            &ast.Ident{
+              NamePos: 41,
+              NameEnd: 49,
+              Name:    "shipping",
+            },
+            &ast.Ident{
+              NamePos: 50,
+              NameEnd: 62,
+              Name:    "OrderHistory",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER PROTO BUNDLE UPDATE (examples.shipping.OrderHistory)

--- a/testdata/result/statement/create_proto_bundle_trailing_comma.sql.txt
+++ b/testdata/result/statement/create_proto_bundle_trailing_comma.sql.txt
@@ -1,0 +1,36 @@
+--- create_proto_bundle_trailing_comma.sql
+CREATE PROTO BUNDLE (
+    examples.shipping.OrderHistory,
+)
+
+--- AST
+&ast.CreateProtoBundle{
+  Types: &ast.ProtoBundleTypes{
+    Lparen: 20,
+    Rparen: 58,
+    Types:  []*ast.NamedType{
+      &ast.NamedType{
+        Path: []*ast.Ident{
+          &ast.Ident{
+            NamePos: 26,
+            NameEnd: 34,
+            Name:    "examples",
+          },
+          &ast.Ident{
+            NamePos: 35,
+            NameEnd: 43,
+            Name:    "shipping",
+          },
+          &ast.Ident{
+            NamePos: 44,
+            NameEnd: 56,
+            Name:    "OrderHistory",
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE PROTO BUNDLE (examples.shipping.OrderHistory)


### PR DESCRIPTION
This PR fixes `parseProtoBundleTypes()` to allow trailing comma in `PROTO BUNDLE`.

## Related Issue

- close #254 

## Note

This PR is vibe coded by Cline with the task:
````
Document don't says about trailing commas, but it is actually allowed.

```
CREATE PROTO BUNDLE (
examples.shipping.OrderHistory,
);
```

```
ALTER PROTO BUNDLE DELETE (
examples.shipping.OrderHistory,
);
```
etc.

Implement this trailing commas.
````