### PR TITLE
Fix comment about AsString in TokenParam

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -9,7 +9,7 @@ type Token struct {
 	Comments []TokenComment
 	Space    string
 	Raw      string
-	AsString string // available for TokenIdent, TokenString and TokenBytes
+	AsString string // available for TokenIdent, TokenParam, TokenString and TokenBytes
 	Base     int    // 10 or 16 on TokenInt
 	Pos, End Pos
 }


### PR DESCRIPTION
This PR includes a minor update to the `Token` struct in `token/token.go`. The change updates the comment for the `AsString` field to indicate that it is now also applicable to `TokenParam`.

* [`token/token.go`](diffhunk://#diff-33bf6304dd970a085d3e7819ae65390a9c7fd1fe65eee30f0dc82021ff6975e0L12-R12): Updated the comment for the `AsString` field in the `Token` struct to include `TokenParam` as one of the applicable token types.