### PR TITLE
fix: Make TO mandatory in IntervalLiteralRange

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -2538,12 +2538,8 @@ func (p *Parser) parseIntervalLiteral() ast.Expr {
 	case *ast.StringLiteral:
 		starting, _, _ := p.parseDateTimePart()
 
-		var ending ast.DateTimePart
-		var endingEnd token.Pos
-		if p.Token.Kind == "TO" {
-			p.nextToken()
-			ending, _, endingEnd = p.parseDateTimePart()
-		}
+		p.expect("TO")
+		ending, _, endingEnd := p.parseDateTimePart()
 
 		return &ast.IntervalLiteralRange{
 			Interval:              interval,


### PR DESCRIPTION
This PR fixes a bug that memefish wrongly accepts `INTERVAL string_literal date_time_part`.

before
```
$ go run github.com/cloudspannerecosystem/memefish/tools/parse@latest -output=unparse -mode expr 'INTERVAL "1" DAY'
--- SQL
INTERVAL "1" DAY TO 
```

after

```
$ go run ./tools/parse -output=unparse -mode expr 'INTERVAL "1" DAY'                                              
--- Error
syntax error: :1:17: expected token: TO, but: <eof>
  1|  INTERVAL "1" DAY
   |                  ^

--- SQL
INTERVAL "1" DAY
```