### PR TITLE
Reset errors and allow processing to continue in Parse*

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -24,7 +24,11 @@ func (p *Parser) ParseStatement() (ast.Statement, error) {
 	}
 
 	if len(p.errors) > 0 {
-		return stmt, MultiError(p.errors)
+		// Reset the errors and allow processing to continue
+		err := MultiError(p.errors)
+		p.errors = nil
+
+		return stmt, err
 	}
 
 	return stmt, nil
@@ -39,7 +43,11 @@ func (p *Parser) ParseStatements() ([]ast.Statement, error) {
 	}
 
 	if len(p.errors) > 0 {
-		return stmts, MultiError(p.errors)
+		// Reset the errors and allow processing to continue
+		err := MultiError(p.errors)
+		p.errors = nil
+
+		return stmts, err
 	}
 
 	return stmts, nil
@@ -54,7 +62,11 @@ func (p *Parser) ParseQuery() (*ast.QueryStatement, error) {
 	}
 
 	if len(p.errors) > 0 {
-		return stmt, MultiError(p.errors)
+		// Reset the errors and allow processing to continue
+		err := MultiError(p.errors)
+		p.errors = nil
+
+		return stmt, err
 	}
 
 	return stmt, nil
@@ -69,7 +81,11 @@ func (p *Parser) ParseExpr() (ast.Expr, error) {
 	}
 
 	if len(p.errors) > 0 {
-		return expr, MultiError(p.errors)
+		// Reset the errors and allow processing to continue
+		err := MultiError(p.errors)
+		p.errors = nil
+
+		return expr, err
 	}
 
 	return expr, nil
@@ -84,7 +100,11 @@ func (p *Parser) ParseType() (ast.Type, error) {
 	}
 
 	if len(p.errors) > 0 {
-		return t, MultiError(p.errors)
+		// Reset the errors and allow processing to continue
+		err := MultiError(p.errors)
+		p.errors = nil
+
+		return t, err
 	}
 
 	return t, nil
@@ -99,7 +119,11 @@ func (p *Parser) ParseDDL() (ast.DDL, error) {
 	}
 
 	if len(p.errors) > 0 {
-		return ddl, MultiError(p.errors)
+		// Reset the errors and allow processing to continue
+		err := MultiError(p.errors)
+		p.errors = nil
+
+		return ddl, err
 	}
 
 	return ddl, nil
@@ -114,7 +138,11 @@ func (p *Parser) ParseDDLs() ([]ast.DDL, error) {
 	}
 
 	if len(p.errors) > 0 {
-		return ddls, MultiError(p.errors)
+		// Reset the errors and allow processing to continue
+		err := MultiError(p.errors)
+		p.errors = nil
+
+		return ddls, err
 	}
 
 	return ddls, nil
@@ -129,7 +157,11 @@ func (p *Parser) ParseDML() (ast.DML, error) {
 	}
 
 	if len(p.errors) > 0 {
-		return dml, MultiError(p.errors)
+		// Reset the errors and allow processing to continue
+		err := MultiError(p.errors)
+		p.errors = nil
+
+		return dml, err
 	}
 
 	return dml, nil
@@ -144,7 +176,11 @@ func (p *Parser) ParseDMLs() ([]ast.DML, error) {
 	}
 
 	if len(p.errors) > 0 {
-		return dmls, MultiError(p.errors)
+		// Reset the errors and allow processing to continue
+		err := MultiError(p.errors)
+		p.errors = nil
+
+		return dmls, err
 	}
 
 	return dmls, nil


### PR DESCRIPTION
This PR fixes to reset internal errors in `(*memefish.Parser).Parse*()`

Currently, Parse* functions do not reset their internal error state `errors`.
These functions return an error if, after successfully parsing a complete unit/statement (i.e., reaching a final state), the next token encountered is not `token.TokenEOF`.
In other words, if you attempt to parse an `Expr` from the middle of a string (meaning the `Expr` is successfully parsed but is followed by more tokens instead of the expected `token.TokenEOF`), an error is returned. Because this error state is not reset, any subsequent attempts to parse further from the remaining string will also result in an error.
This means these functions cannot be reused to parse multiple fragments from a single string unless their accumulated errors are explicitly ignored.

Current usecase:
https://github.com/apstndb/spanner-mycli/blob/df6f18c1803d8a6570ad78c3bc7cbcd2c2df6371/statements_split_points.go#L243-L263