### PR TITLE
fix: Reject non-GoogleSQL line comment //

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -641,7 +641,7 @@ func (l *Lexer) skipSpaces() {
 func (l *Lexer) skipComment(noPanic bool) bool {
 	r, _ := utf8.DecodeRuneInString(l.Buffer[l.pos:])
 	switch {
-	case r == '#' || r == '/' && l.peekIs(1, '/') || r == '-' && l.peekIs(1, '-'):
+	case r == '#' || r == '-' && l.peekIs(1, '-'):
 		return l.skipCommentUntil("\n", false, noPanic)
 	case r == '/' && l.peekIs(1, '*'):
 		return l.skipCommentUntil("*/", true, noPanic)

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -65,11 +65,10 @@ var lexerTestCases = []struct {
 	{"# foo", nil},
 	{"# foo\n0", []*Token{{Kind: "<int>", Space: "", Raw: "0", Base: 10, Comments: []TokenComment{{Space: "", Raw: "# foo\n", Pos: 0, End: 6}}}}},
 	{"-- foo\n0", []*Token{{Kind: "<int>", Space: "", Raw: "0", Base: 10, Comments: []TokenComment{{Space: "", Raw: "-- foo\n", Pos: 0, End: 7}}}}},
-	{"// foo\n0", []*Token{{Kind: "<int>", Space: "", Raw: "0", Base: 10, Comments: []TokenComment{{Space: "", Raw: "// foo\n", Pos: 0, End: 7}}}}},
 	{"/* foo */ 0", []*Token{{Kind: "<int>", Space: " ", Raw: "0", Base: 10, Comments: []TokenComment{{Space: "", Raw: "/* foo */", Pos: 0, End: 9}}}}},
-	{"// aaa\n// bbb\n/* foo */ 0", []*Token{{Kind: "<int>", Space: " ", Raw: "0", Base: 10, Comments: []TokenComment{
-		{Space: "", Raw: "// aaa\n", Pos: 0, End: 7},
-		{Space: "", Raw: "// bbb\n", Pos: 7, End: 14},
+	{"-- aaa\n-- bbb\n/* foo */ 0", []*Token{{Kind: "<int>", Space: " ", Raw: "0", Base: 10, Comments: []TokenComment{
+		{Space: "", Raw: "-- aaa\n", Pos: 0, End: 7},
+		{Space: "", Raw: "-- bbb\n", Pos: 7, End: 14},
 		{Space: "", Raw: "/* foo */", Pos: 14, End: 23},
 	}}}},
 	// TokenInt

--- a/split_test.go
+++ b/split_test.go
@@ -1,11 +1,13 @@
 package memefish_test
 
 import (
-	"github.com/cloudspannerecosystem/memefish"
-	"github.com/cloudspannerecosystem/memefish/token"
-	"github.com/google/go-cmp/cmp"
 	"regexp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/cloudspannerecosystem/memefish"
+	"github.com/cloudspannerecosystem/memefish/token"
 )
 
 func TestSplitRawStatements(t *testing.T) {
@@ -45,13 +47,13 @@ func TestSplitRawStatements(t *testing.T) {
 				{Statement: "SELECT 1", End: token.Pos(8)},
 				{Statement: "SELECT 2", Pos: token.Pos(11), End: token.Pos(19)},
 			}},
-		{desc: "single statement with line comment", input: `SELECT 1//
+		{desc: "single statement with line comment", input: `SELECT 1--
 `, want: []*memefish.RawStatement{
-			{Statement: "SELECT 1//\n", End: token.Pos(11)},
+			{Statement: "SELECT 1--\n", End: token.Pos(11)},
 		}},
-		{desc: "semicolon in line comment", input: "SELECT 1 //;\n + 2",
+		{desc: "semicolon in line comment", input: "SELECT 1 --;\n + 2",
 			want: []*memefish.RawStatement{
-				{Statement: "SELECT 1 //;\n + 2", End: token.Pos(17)},
+				{Statement: "SELECT 1 --;\n + 2", End: token.Pos(17)},
 			}},
 		{desc: "semicolon in multi-line comment", input: "SELECT 1 /*;\n*/ + 2",
 			want: []*memefish.RawStatement{


### PR DESCRIPTION
This PR fixes the memefish lexer to correctly reject `//` that are not GoogleSQL comments, which were previously mistakenly treated as comments.

### before (wrong)

```
$ go run github.com/cloudspannerecosystem/memefish/tools/parse@latest -mode statement 'SELECT
  1,
  # 2,
  -- 3,
  // 4,'
--- AST
&ast.QueryStatement{
  Query: &ast.Select{
    Results: []ast.SelectItem{
      &ast.ExprSelectItem{
        Expr: &ast.IntLiteral{
          ValuePos: 9,
          ValueEnd: 10,
          Base:     10,
          Value:    "1",
        },
      },
    },
  },
}
--- SQL
SELECT 1
```

### after (correct)

```
$ go run ./tools/parse -mode statement 'SELECT 
  1,
  # 2,
  -- 3,
  // 4,'
--- Error
syntax error: :5:3: unexpected token: /
  5|    // 4,
   |    ^

--- AST
&ast.QueryStatement{
  Query: &ast.Select{
    Results: []ast.SelectItem{
      &ast.ExprSelectItem{
        Expr: &ast.IntLiteral{
          ValuePos: 9,
          ValueEnd: 10,
          Base:     10,
          Value:    "1",
        },
      },
      &ast.ExprSelectItem{
        Expr: &ast.BadExpr{
          BadNode: &ast.BadNode{
            NodePos: 29,
            NodeEnd: 33,
            Tokens:  []*token.Token{
              &token.Token{
                Kind:     "/",
                Comments: []token.TokenComment{
                  token.TokenComment{
                    Space: "\n  ",
                    Raw:   "# 2,\n",
                    Pos:   14,
                    End:   19,
                  },
                  token.TokenComment{
                    Space: "  ",
                    Raw:   "-- 3,\n",
                    Pos:   21,
                    End:   27,
                  },
                },
                Space: "  ",
                Raw:   "/",
                Pos:   29,
                End:   30,
              },
              &token.Token{
                Kind: "/",
                Raw:  "/",
                Pos:  30,
                End:  31,
              },
              &token.Token{
                Kind:  "<int>",
                Space: " ",
                Raw:   "4",
                Base:  10,
                Pos:   32,
                End:   33,
              },
            },
          },
        },
      },
    },
  },
}
--- SQL
SELECT 1, // 4
```

- close #320 