### PR TITLE
fix: Preserve all comments in SplitRawStatements

### DIFF
--- a/split.go
+++ b/split.go
@@ -35,7 +35,13 @@ func SplitRawStatements(filepath, s string) ([]*RawStatement, error) {
 			if err := lex.NextToken(); err != nil {
 				return nil, err
 			}
-			firstPos = lex.Token.Pos
+
+			// the new firstPos is the first character after the semicolon, which can be the beginning of comments
+			if len(lex.Token.Comments) > 0 {
+				firstPos = lex.Token.Comments[0].Pos
+			} else {
+				firstPos = lex.Token.Pos
+			}
 			continue
 		}
 

--- a/split_test.go
+++ b/split_test.go
@@ -69,6 +69,20 @@ func TestSplitRawStatements(t *testing.T) {
 			want: []*memefish.RawStatement{
 				{Statement: "SELECT `1;2;3`", End: token.Pos(14)},
 			}},
+		{desc: "semicolon in leading comment", input: "-- comment;\nSELECT 123",
+			want: []*memefish.RawStatement{
+				{Statement: "-- comment;\nSELECT 123", End: token.Pos(22)},
+			}},
+		{desc: "semicolon in leading single-line comment of 2nd statement", input: "SELECT 1; -- comment;\nSELECT 2",
+			want: []*memefish.RawStatement{
+				{Statement: "SELECT 1", End: token.Pos(8)},
+				{Statement: "-- comment;\nSELECT 2", Pos: token.Pos(10), End: token.Pos(30)},
+			}},
+		{desc: "semicolon in leading multi-line comment of 2nd statement", input: "SELECT 1; /*;\n*/ SELECT 2",
+			want: []*memefish.RawStatement{
+				{Statement: "SELECT 1", End: token.Pos(8)},
+				{Statement: "/*;\n*/ SELECT 2", Pos: token.Pos(10), End: token.Pos(25)},
+			}},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			stmts, err := memefish.SplitRawStatements("", test.input)


### PR DESCRIPTION
```
// SplitRawStatements splits an input string to statement strings at terminating semicolons without parsing.
// It preserves all comments.
```
 
In the current implemention, comments after semicolons are wrongly stripped.
This PR fixes this bug.