### PR TITLE
Support named schema in search index statements

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -3715,8 +3715,8 @@ type CreateSearchIndex struct {
 
 	Create token.Pos
 
-	Name             *Ident
-	TableName        *Ident
+	Name             *Path
+	TableName        *Path
 	TokenListPart    []*Ident
 	Rparen           token.Pos     // position of ")" after TokenListPart
 	Storing          *Storing      // optional
@@ -3736,7 +3736,7 @@ type DropSearchIndex struct {
 
 	Drop     token.Pos
 	IfExists bool
-	Name     *Ident
+	Name     *Path
 }
 
 // AlterSearchIndex represents ALTER SEARCH INDEX statement.
@@ -3747,7 +3747,7 @@ type AlterSearchIndex struct {
 	// end = IndexAlteration.end
 
 	Alter           token.Pos
-	Name            *Ident
+	Name            *Path
 	IndexAlteration IndexAlteration
 }
 

--- a/parser.go
+++ b/parser.go
@@ -3789,10 +3789,10 @@ func (p *Parser) parseCreateVectorIndex(pos token.Pos) *ast.CreateVectorIndex {
 func (p *Parser) parseCreateSearchIndex(pos token.Pos) *ast.CreateSearchIndex {
 	p.expectKeywordLike("SEARCH")
 	p.expectKeywordLike("INDEX")
-	name := p.parseIdent()
+	name := p.parsePath()
 
 	p.expect("ON")
-	tableName := p.parseIdent()
+	tableName := p.parsePath()
 
 	p.expect("(")
 	columnName := parseCommaSeparatedList(p, p.parseIdent)
@@ -3832,7 +3832,7 @@ func (p *Parser) parseDropSearchIndex(pos token.Pos) *ast.DropSearchIndex {
 	p.expectKeywordLike("SEARCH")
 	p.expectKeywordLike("INDEX")
 	ifExists := p.parseIfExists()
-	name := p.parseIdent()
+	name := p.parsePath()
 	return &ast.DropSearchIndex{
 		Drop:     pos,
 		IfExists: ifExists,
@@ -3845,7 +3845,7 @@ func (p *Parser) parseAlterSearchIndex(pos token.Pos) *ast.AlterSearchIndex {
 	p.expectKeywordLike("SEARCH")
 	p.expectKeywordLike("INDEX")
 
-	name := p.parseIdent()
+	name := p.parsePath()
 	alteration := p.parseIndexAlteration()
 
 	return &ast.AlterSearchIndex{

--- a/testdata/input/ddl/alter_search_index_fqn.sql
+++ b/testdata/input/ddl/alter_search_index_fqn.sql
@@ -1,0 +1,1 @@
+ALTER SEARCH INDEX AlbumSchema.AlbumsIndex ADD STORED COLUMN AlbumTitle

--- a/testdata/input/ddl/create_search_index_fqn.sql
+++ b/testdata/input/ddl/create_search_index_fqn.sql
@@ -1,0 +1,1 @@
+CREATE SEARCH INDEX AlbumSchema.AlbumsIndex ON AlbumSchema.Albums(AlbumTitle_Tokens)

--- a/testdata/input/ddl/drop_search_index_fqn.sql
+++ b/testdata/input/ddl/drop_search_index_fqn.sql
@@ -1,0 +1,1 @@
+DROP SEARCH INDEX AlbumSchema.AlbumsIndex

--- a/testdata/result/ddl/alter_search_index_add_stored_column.sql.txt
+++ b/testdata/result/ddl/alter_search_index_add_stored_column.sql.txt
@@ -2,10 +2,14 @@
 ALTER SEARCH INDEX AlbumsIndex ADD STORED COLUMN Genre
 --- AST
 &ast.AlterSearchIndex{
-  Name: &ast.Ident{
-    NamePos: 19,
-    NameEnd: 30,
-    Name:    "AlbumsIndex",
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 30,
+        Name:    "AlbumsIndex",
+      },
+    },
   },
   IndexAlteration: &ast.AddStoredColumn{
     Add:  31,

--- a/testdata/result/ddl/alter_search_index_drop_stored_column.sql.txt
+++ b/testdata/result/ddl/alter_search_index_drop_stored_column.sql.txt
@@ -2,10 +2,14 @@
 ALTER SEARCH INDEX AlbumsIndex DROP STORED COLUMN Genre
 --- AST
 &ast.AlterSearchIndex{
-  Name: &ast.Ident{
-    NamePos: 19,
-    NameEnd: 30,
-    Name:    "AlbumsIndex",
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 30,
+        Name:    "AlbumsIndex",
+      },
+    },
   },
   IndexAlteration: &ast.DropStoredColumn{
     Drop: 31,

--- a/testdata/result/ddl/alter_search_index_fqn.sql.txt
+++ b/testdata/result/ddl/alter_search_index_fqn.sql.txt
@@ -1,0 +1,31 @@
+--- alter_search_index_fqn.sql
+ALTER SEARCH INDEX AlbumSchema.AlbumsIndex ADD STORED COLUMN AlbumTitle
+
+--- AST
+&ast.AlterSearchIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 30,
+        Name:    "AlbumSchema",
+      },
+      &ast.Ident{
+        NamePos: 31,
+        NameEnd: 42,
+        Name:    "AlbumsIndex",
+      },
+    },
+  },
+  IndexAlteration: &ast.AddStoredColumn{
+    Add:  43,
+    Name: &ast.Ident{
+      NamePos: 61,
+      NameEnd: 71,
+      Name:    "AlbumTitle",
+    },
+  },
+}
+
+--- SQL
+ALTER SEARCH INDEX AlbumSchema.AlbumsIndex ADD STORED COLUMN AlbumTitle

--- a/testdata/result/ddl/create_search_index_fqn.sql.txt
+++ b/testdata/result/ddl/create_search_index_fqn.sql.txt
@@ -1,0 +1,45 @@
+--- create_search_index_fqn.sql
+CREATE SEARCH INDEX AlbumSchema.AlbumsIndex ON AlbumSchema.Albums(AlbumTitle_Tokens)
+
+--- AST
+&ast.CreateSearchIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 20,
+        NameEnd: 31,
+        Name:    "AlbumSchema",
+      },
+      &ast.Ident{
+        NamePos: 32,
+        NameEnd: 43,
+        Name:    "AlbumsIndex",
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 47,
+        NameEnd: 58,
+        Name:    "AlbumSchema",
+      },
+      &ast.Ident{
+        NamePos: 59,
+        NameEnd: 65,
+        Name:    "Albums",
+      },
+    },
+  },
+  TokenListPart: []*ast.Ident{
+    &ast.Ident{
+      NamePos: 66,
+      NameEnd: 83,
+      Name:    "AlbumTitle_Tokens",
+    },
+  },
+  Rparen: 83,
+}
+
+--- SQL
+CREATE SEARCH INDEX AlbumSchema.AlbumsIndex ON AlbumSchema.Albums(AlbumTitle_Tokens)

--- a/testdata/result/ddl/create_search_index_full.sql.txt
+++ b/testdata/result/ddl/create_search_index_full.sql.txt
@@ -9,15 +9,23 @@ WHERE Genre IS NOT NULL AND ReleaseTimestamp IS NOT NULL
 OPTIONS(sort_order_sharding=true)
 --- AST
 &ast.CreateSearchIndex{
-  Name: &ast.Ident{
-    NamePos: 20,
-    NameEnd: 35,
-    Name:    "AlbumsIndexFull",
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 20,
+        NameEnd: 35,
+        Name:    "AlbumsIndexFull",
+      },
+    },
   },
-  TableName: &ast.Ident{
-    NamePos: 39,
-    NameEnd: 45,
-    Name:    "Albums",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 39,
+        NameEnd: 45,
+        Name:    "Albums",
+      },
+    },
   },
   TokenListPart: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/ddl/create_search_index_null_filtered.sql.txt
+++ b/testdata/result/ddl/create_search_index_null_filtered.sql.txt
@@ -5,15 +5,23 @@ STORING(Genre)
 WHERE Genre IS NOT NULL
 --- AST
 &ast.CreateSearchIndex{
-  Name: &ast.Ident{
-    NamePos: 20,
-    NameEnd: 31,
-    Name:    "AlbumsIndex",
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 20,
+        NameEnd: 31,
+        Name:    "AlbumsIndex",
+      },
+    },
   },
-  TableName: &ast.Ident{
-    NamePos: 35,
-    NameEnd: 41,
-    Name:    "Albums",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 35,
+        NameEnd: 41,
+        Name:    "Albums",
+      },
+    },
   },
   TokenListPart: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/ddl/create_search_index_simple.sql.txt
+++ b/testdata/result/ddl/create_search_index_simple.sql.txt
@@ -5,15 +5,23 @@ CREATE SEARCH INDEX AlbumsIndex
 --- AST
 &ast.CreateSearchIndex{
   Create: 23,
-  Name:   &ast.Ident{
-    NamePos: 43,
-    NameEnd: 54,
-    Name:    "AlbumsIndex",
+  Name:   &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 43,
+        NameEnd: 54,
+        Name:    "AlbumsIndex",
+      },
+    },
   },
-  TableName: &ast.Ident{
-    NamePos: 60,
-    NameEnd: 66,
-    Name:    "Albums",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 60,
+        NameEnd: 66,
+        Name:    "Albums",
+      },
+    },
   },
   TokenListPart: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/ddl/drop_search_index.sql.txt
+++ b/testdata/result/ddl/drop_search_index.sql.txt
@@ -3,10 +3,14 @@ DROP SEARCH INDEX IF EXISTS AlbumsIndex
 --- AST
 &ast.DropSearchIndex{
   IfExists: true,
-  Name:     &ast.Ident{
-    NamePos: 28,
-    NameEnd: 39,
-    Name:    "AlbumsIndex",
+  Name:     &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 28,
+        NameEnd: 39,
+        Name:    "AlbumsIndex",
+      },
+    },
   },
 }
 

--- a/testdata/result/ddl/drop_search_index_fqn.sql.txt
+++ b/testdata/result/ddl/drop_search_index_fqn.sql.txt
@@ -1,0 +1,23 @@
+--- drop_search_index_fqn.sql
+DROP SEARCH INDEX AlbumSchema.AlbumsIndex
+
+--- AST
+&ast.DropSearchIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 18,
+        NameEnd: 29,
+        Name:    "AlbumSchema",
+      },
+      &ast.Ident{
+        NamePos: 30,
+        NameEnd: 41,
+        Name:    "AlbumsIndex",
+      },
+    },
+  },
+}
+
+--- SQL
+DROP SEARCH INDEX AlbumSchema.AlbumsIndex

--- a/testdata/result/statement/alter_search_index_add_stored_column.sql.txt
+++ b/testdata/result/statement/alter_search_index_add_stored_column.sql.txt
@@ -2,10 +2,14 @@
 ALTER SEARCH INDEX AlbumsIndex ADD STORED COLUMN Genre
 --- AST
 &ast.AlterSearchIndex{
-  Name: &ast.Ident{
-    NamePos: 19,
-    NameEnd: 30,
-    Name:    "AlbumsIndex",
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 30,
+        Name:    "AlbumsIndex",
+      },
+    },
   },
   IndexAlteration: &ast.AddStoredColumn{
     Add:  31,

--- a/testdata/result/statement/alter_search_index_drop_stored_column.sql.txt
+++ b/testdata/result/statement/alter_search_index_drop_stored_column.sql.txt
@@ -2,10 +2,14 @@
 ALTER SEARCH INDEX AlbumsIndex DROP STORED COLUMN Genre
 --- AST
 &ast.AlterSearchIndex{
-  Name: &ast.Ident{
-    NamePos: 19,
-    NameEnd: 30,
-    Name:    "AlbumsIndex",
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 30,
+        Name:    "AlbumsIndex",
+      },
+    },
   },
   IndexAlteration: &ast.DropStoredColumn{
     Drop: 31,

--- a/testdata/result/statement/alter_search_index_fqn.sql.txt
+++ b/testdata/result/statement/alter_search_index_fqn.sql.txt
@@ -1,0 +1,31 @@
+--- alter_search_index_fqn.sql
+ALTER SEARCH INDEX AlbumSchema.AlbumsIndex ADD STORED COLUMN AlbumTitle
+
+--- AST
+&ast.AlterSearchIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 30,
+        Name:    "AlbumSchema",
+      },
+      &ast.Ident{
+        NamePos: 31,
+        NameEnd: 42,
+        Name:    "AlbumsIndex",
+      },
+    },
+  },
+  IndexAlteration: &ast.AddStoredColumn{
+    Add:  43,
+    Name: &ast.Ident{
+      NamePos: 61,
+      NameEnd: 71,
+      Name:    "AlbumTitle",
+    },
+  },
+}
+
+--- SQL
+ALTER SEARCH INDEX AlbumSchema.AlbumsIndex ADD STORED COLUMN AlbumTitle

--- a/testdata/result/statement/create_search_index_fqn.sql.txt
+++ b/testdata/result/statement/create_search_index_fqn.sql.txt
@@ -1,0 +1,45 @@
+--- create_search_index_fqn.sql
+CREATE SEARCH INDEX AlbumSchema.AlbumsIndex ON AlbumSchema.Albums(AlbumTitle_Tokens)
+
+--- AST
+&ast.CreateSearchIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 20,
+        NameEnd: 31,
+        Name:    "AlbumSchema",
+      },
+      &ast.Ident{
+        NamePos: 32,
+        NameEnd: 43,
+        Name:    "AlbumsIndex",
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 47,
+        NameEnd: 58,
+        Name:    "AlbumSchema",
+      },
+      &ast.Ident{
+        NamePos: 59,
+        NameEnd: 65,
+        Name:    "Albums",
+      },
+    },
+  },
+  TokenListPart: []*ast.Ident{
+    &ast.Ident{
+      NamePos: 66,
+      NameEnd: 83,
+      Name:    "AlbumTitle_Tokens",
+    },
+  },
+  Rparen: 83,
+}
+
+--- SQL
+CREATE SEARCH INDEX AlbumSchema.AlbumsIndex ON AlbumSchema.Albums(AlbumTitle_Tokens)

--- a/testdata/result/statement/create_search_index_full.sql.txt
+++ b/testdata/result/statement/create_search_index_full.sql.txt
@@ -9,15 +9,23 @@ WHERE Genre IS NOT NULL AND ReleaseTimestamp IS NOT NULL
 OPTIONS(sort_order_sharding=true)
 --- AST
 &ast.CreateSearchIndex{
-  Name: &ast.Ident{
-    NamePos: 20,
-    NameEnd: 35,
-    Name:    "AlbumsIndexFull",
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 20,
+        NameEnd: 35,
+        Name:    "AlbumsIndexFull",
+      },
+    },
   },
-  TableName: &ast.Ident{
-    NamePos: 39,
-    NameEnd: 45,
-    Name:    "Albums",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 39,
+        NameEnd: 45,
+        Name:    "Albums",
+      },
+    },
   },
   TokenListPart: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/statement/create_search_index_null_filtered.sql.txt
+++ b/testdata/result/statement/create_search_index_null_filtered.sql.txt
@@ -5,15 +5,23 @@ STORING(Genre)
 WHERE Genre IS NOT NULL
 --- AST
 &ast.CreateSearchIndex{
-  Name: &ast.Ident{
-    NamePos: 20,
-    NameEnd: 31,
-    Name:    "AlbumsIndex",
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 20,
+        NameEnd: 31,
+        Name:    "AlbumsIndex",
+      },
+    },
   },
-  TableName: &ast.Ident{
-    NamePos: 35,
-    NameEnd: 41,
-    Name:    "Albums",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 35,
+        NameEnd: 41,
+        Name:    "Albums",
+      },
+    },
   },
   TokenListPart: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/statement/create_search_index_simple.sql.txt
+++ b/testdata/result/statement/create_search_index_simple.sql.txt
@@ -5,15 +5,23 @@ CREATE SEARCH INDEX AlbumsIndex
 --- AST
 &ast.CreateSearchIndex{
   Create: 23,
-  Name:   &ast.Ident{
-    NamePos: 43,
-    NameEnd: 54,
-    Name:    "AlbumsIndex",
+  Name:   &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 43,
+        NameEnd: 54,
+        Name:    "AlbumsIndex",
+      },
+    },
   },
-  TableName: &ast.Ident{
-    NamePos: 60,
-    NameEnd: 66,
-    Name:    "Albums",
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 60,
+        NameEnd: 66,
+        Name:    "Albums",
+      },
+    },
   },
   TokenListPart: []*ast.Ident{
     &ast.Ident{

--- a/testdata/result/statement/drop_search_index.sql.txt
+++ b/testdata/result/statement/drop_search_index.sql.txt
@@ -3,10 +3,14 @@ DROP SEARCH INDEX IF EXISTS AlbumsIndex
 --- AST
 &ast.DropSearchIndex{
   IfExists: true,
-  Name:     &ast.Ident{
-    NamePos: 28,
-    NameEnd: 39,
-    Name:    "AlbumsIndex",
+  Name:     &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 28,
+        NameEnd: 39,
+        Name:    "AlbumsIndex",
+      },
+    },
   },
 }
 

--- a/testdata/result/statement/drop_search_index_fqn.sql.txt
+++ b/testdata/result/statement/drop_search_index_fqn.sql.txt
@@ -1,0 +1,23 @@
+--- drop_search_index_fqn.sql
+DROP SEARCH INDEX AlbumSchema.AlbumsIndex
+
+--- AST
+&ast.DropSearchIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 18,
+        NameEnd: 29,
+        Name:    "AlbumSchema",
+      },
+      &ast.Ident{
+        NamePos: 30,
+        NameEnd: 41,
+        Name:    "AlbumsIndex",
+      },
+    },
+  },
+}
+
+--- SQL
+DROP SEARCH INDEX AlbumSchema.AlbumsIndex


### PR DESCRIPTION
Support fully qualified names (FQN) in `SEARCH INDEX` related statements (`CREATE`, `ALTER`, `DROP`).
This resolves the discrepancy between `memefish` and Cloud Spanner's support for objects within named schemas.

Breaking changes: The type of `Name` in `CreateSearchIndex`, `AlterSearchIndex`, `DropSearchIndex` are changed to `*ast.Path` from `*ast.Ident`.

* close #330 