### PR TITLE
feat: add UUID scalar type support

### DIFF
--- a/ast/ast_const.go
+++ b/ast/ast_const.go
@@ -122,6 +122,7 @@ const (
 	JSONTypeName      ScalarTypeName = "JSON"
 	TokenListTypeName ScalarTypeName = "TOKENLIST"
 	IntervalTypeName  ScalarTypeName = "INTERVAL"
+	UUIDTypeName      ScalarTypeName = "UUID"
 )
 
 type OnDeleteAction string

--- a/parser.go
+++ b/parser.go
@@ -2738,6 +2738,7 @@ var simpleTypes = []string{
 	"JSON",
 	"TOKENLIST",
 	"INTERVAL",
+	"UUID",
 }
 
 func (p *Parser) parseSimpleType() *ast.SimpleType {
@@ -5488,6 +5489,7 @@ var scalarSchemaTypes = []string{
 	"NUMERIC",
 	"JSON",
 	"TOKENLIST",
+	"UUID",
 }
 
 var sizedSchemaTypes = []string{

--- a/testdata/input/ddl/create_table_with_uuid.sql
+++ b/testdata/input/ddl/create_table_with_uuid.sql
@@ -1,0 +1,4 @@
+create table foo (
+  id uuid not null default (new_uuid()),
+  name string(max)
+) primary key (id)

--- a/testdata/result/ddl/create_table_with_uuid.sql.txt
+++ b/testdata/result/ddl/create_table_with_uuid.sql.txt
@@ -1,0 +1,85 @@
+--- create_table_with_uuid.sql
+create table foo (
+  id uuid not null default (new_uuid()),
+  name string(max)
+) primary key (id)
+
+--- AST
+&ast.CreateTable{
+  Rparen:           79,
+  PrimaryKeyRparen: 96,
+  Name:             &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 16,
+        Name:    "foo",
+      },
+    },
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: 33,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 21,
+        NameEnd: 23,
+        Name:    "id",
+      },
+      Type: &ast.ScalarSchemaType{
+        NamePos: 24,
+        Name:    "UUID",
+      },
+      NotNull:          true,
+      DefaultSemantics: &ast.ColumnDefaultExpr{
+        Default: 38,
+        Rparen:  57,
+        Expr:    &ast.CallExpr{
+          Rparen: 56,
+          Func:   &ast.Path{
+            Idents: []*ast.Ident{
+              &ast.Ident{
+                NamePos: 47,
+                NameEnd: 55,
+                Name:    "new_uuid",
+              },
+            },
+          },
+        },
+      },
+      Hidden: -1,
+    },
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 62,
+        NameEnd: 66,
+        Name:    "name",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 67,
+        Rparen:  77,
+        Name:    "STRING",
+        Max:     true,
+      },
+      Hidden: -1,
+    },
+  },
+  PrimaryKeys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 94,
+        NameEnd: 96,
+        Name:    "id",
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE TABLE foo (
+  id UUID NOT NULL DEFAULT (new_uuid()),
+  name STRING(MAX)
+) PRIMARY KEY (id)

--- a/testdata/result/statement/create_table_with_uuid.sql.txt
+++ b/testdata/result/statement/create_table_with_uuid.sql.txt
@@ -1,0 +1,85 @@
+--- create_table_with_uuid.sql
+create table foo (
+  id uuid not null default (new_uuid()),
+  name string(max)
+) primary key (id)
+
+--- AST
+&ast.CreateTable{
+  Rparen:           79,
+  PrimaryKeyRparen: 96,
+  Name:             &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 16,
+        Name:    "foo",
+      },
+    },
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: 33,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 21,
+        NameEnd: 23,
+        Name:    "id",
+      },
+      Type: &ast.ScalarSchemaType{
+        NamePos: 24,
+        Name:    "UUID",
+      },
+      NotNull:          true,
+      DefaultSemantics: &ast.ColumnDefaultExpr{
+        Default: 38,
+        Rparen:  57,
+        Expr:    &ast.CallExpr{
+          Rparen: 56,
+          Func:   &ast.Path{
+            Idents: []*ast.Ident{
+              &ast.Ident{
+                NamePos: 47,
+                NameEnd: 55,
+                Name:    "new_uuid",
+              },
+            },
+          },
+        },
+      },
+      Hidden: -1,
+    },
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 62,
+        NameEnd: 66,
+        Name:    "name",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 67,
+        Rparen:  77,
+        Name:    "STRING",
+        Max:     true,
+      },
+      Hidden: -1,
+    },
+  },
+  PrimaryKeys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Name:   &ast.Ident{
+        NamePos: 94,
+        NameEnd: 96,
+        Name:    "id",
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE TABLE foo (
+  id UUID NOT NULL DEFAULT (new_uuid()),
+  name STRING(MAX)
+) PRIMARY KEY (id)


### PR DESCRIPTION
## Summary

Cloud Spanner supports a native [UUID data type](https://cloud.google.com/spanner/docs/reference/standard-sql/data-types#uuid_type), but memefish does not currently recognize it. This PR adds UUID as a scalar type so that DDL statements with UUID columns can be parsed correctly.

## Changes

- Add `UUIDTypeName` constant to `ast/ast_const.go`
- Add `"UUID"` to `simpleTypes` (expression-level type parsing, e.g. `CAST(x AS UUID)`)
- Add `"UUID"` to `scalarSchemaTypes` (DDL column type parsing)
- Add test case: `CREATE TABLE` with a `UUID` column and `DEFAULT (NEW_UUID())`

## Example

```sql
CREATE TABLE users (
  user_id UUID NOT NULL DEFAULT (NEW_UUID()),
  name STRING(MAX)
) PRIMARY KEY (user_id)
```

This DDL is valid in Cloud Spanner but currently fails to parse with memefish.

## Test plan

- [x] New test case `create_table_with_uuid` passes (DDL and statement parsing)
- [x] Existing tests unaffected