### PR TITLE
Support schema-qualified names in PROPERTY GRAPH elements

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -3932,7 +3932,7 @@ type PropertyGraphElement struct {
 	// pos = Name.pos
 	// end = (DynamicProperties ?? DynamicLabel ?? Properties ?? Keys ?? Alias ?? Name).end
 
-	Name              *Ident
+	Name              *Path
 	Alias             *Ident                          // optional
 	Keys              PropertyGraphElementKeys        // optional
 	Properties        PropertyGraphLabelsOrProperties // optional
@@ -4039,7 +4039,7 @@ type PropertyGraphSourceKey struct {
 
 	Source           token.Pos
 	Keys             *PropertyGraphColumnNameList
-	ElementReference *Ident
+	ElementReference *Path
 	ReferenceColumns *PropertyGraphColumnNameList // optional
 }
 
@@ -4053,7 +4053,7 @@ type PropertyGraphDestinationKey struct {
 
 	Destination      token.Pos
 	Keys             *PropertyGraphColumnNameList
-	ElementReference *Ident
+	ElementReference *Path
 	ReferenceColumns *PropertyGraphColumnNameList // optional
 }
 

--- a/parser.go
+++ b/parser.go
@@ -5024,7 +5024,7 @@ func (p *Parser) parsePropertyGraphElementList() *ast.PropertyGraphElementList {
 }
 
 func (p *Parser) parsePropertyGraphElement() *ast.PropertyGraphElement {
-	name := p.parseIdent()
+	name := p.parsePath()
 
 	var alias *ast.Ident
 	if p.Token.Kind == "AS" {
@@ -5204,7 +5204,7 @@ func (p *Parser) tryParsePropertyGraphElementKeys() ast.PropertyGraphElementKeys
 	p.expectKeywordLike("KEY")
 	sourceColumns := p.parsePropertyGraphColumnNameList()
 	p.expectKeywordLike("REFERENCES")
-	sourceReference := p.parseIdent()
+	sourceReference := p.parsePath()
 	sourceReferenceColumns := p.tryParsePropertyGraphColumnNameList()
 
 	// destination_key
@@ -5212,7 +5212,7 @@ func (p *Parser) tryParsePropertyGraphElementKeys() ast.PropertyGraphElementKeys
 	p.expectKeywordLike("KEY")
 	destinationColumns := p.parsePropertyGraphColumnNameList()
 	p.expectKeywordLike("REFERENCES")
-	destinationReference := p.parseIdent()
+	destinationReference := p.parsePath()
 	destinationReferenceColumns := p.tryParsePropertyGraphColumnNameList()
 
 	return &ast.PropertyGraphEdgeElementKeys{

--- a/testdata/input/ddl/create_property_graph_schema_qualified.sql
+++ b/testdata/input/ddl/create_property_graph_schema_qualified.sql
@@ -1,0 +1,11 @@
+CREATE PROPERTY GRAPH MyGraph
+  NODE TABLES (
+    myschema.NodeTable KEY (id),
+    SimpleNode KEY (id)
+  )
+  EDGE TABLES (
+    myschema.EdgeTable
+      KEY (src_id, dst_id)
+      SOURCE KEY (src_id) REFERENCES myschema.NodeTable (id)
+      DESTINATION KEY (dst_id) REFERENCES SimpleNode (id)
+  )

--- a/testdata/result/ddl/create_or_replace_property_graph_fingraph_verbose.sql.txt
+++ b/testdata/result/ddl/create_or_replace_property_graph_fingraph_verbose.sql.txt
@@ -43,10 +43,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
         Rparen:   638,
         Elements: []*ast.PropertyGraphElement{
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 62,
-              NameEnd: 69,
-              Name:    "Account",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 62,
+                  NameEnd: 69,
+                  Name:    "Account",
+                },
+              },
             },
             Alias: &ast.Ident{
               NamePos: 73,
@@ -127,10 +131,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
             },
           },
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 476,
-              NameEnd: 482,
-              Name:    "Person",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 476,
+                  NameEnd: 482,
+                  Name:    "Person",
+                },
+              },
             },
             Properties: &ast.PropertyGraphSingleProperties{
               Properties: &ast.PropertyGraphPropertiesAre{
@@ -160,10 +168,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
         Rparen:   1207,
         Elements: []*ast.PropertyGraphElement{
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 660,
-              NameEnd: 676,
-              Name:    "PersonOwnAccount",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 660,
+                  NameEnd: 676,
+                  Name:    "PersonOwnAccount",
+                },
+              },
             },
             Alias: &ast.Ident{
               NamePos: 680,
@@ -203,10 +215,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 757,
-                  NameEnd: 763,
-                  Name:    "Person",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 757,
+                      NameEnd: 763,
+                      Name:    "Person",
+                    },
+                  },
                 },
               },
               Destination: &ast.PropertyGraphDestinationKey{
@@ -222,10 +238,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 849,
-                  NameEnd: 856,
-                  Name:    "Account",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 849,
+                      NameEnd: 856,
+                      Name:    "Account",
+                    },
+                  },
                 },
               },
             },
@@ -249,10 +269,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
             },
           },
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 954,
-              NameEnd: 976,
-              Name:    "AccountTransferAccount",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 954,
+                  NameEnd: 976,
+                  Name:    "AccountTransferAccount",
+                },
+              },
             },
             Keys: &ast.PropertyGraphEdgeElementKeys{
               Source: &ast.PropertyGraphSourceKey{
@@ -268,10 +292,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 1010,
-                  NameEnd: 1017,
-                  Name:    "Account",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 1010,
+                      NameEnd: 1017,
+                      Name:    "Account",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         1018,
@@ -298,10 +326,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 1078,
-                  NameEnd: 1085,
-                  Name:    "Account",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 1078,
+                      NameEnd: 1085,
+                      Name:    "Account",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         1086,

--- a/testdata/result/ddl/create_property_graph_if_not_exists_fingraph.sql.txt
+++ b/testdata/result/ddl/create_property_graph_if_not_exists_fingraph.sql.txt
@@ -30,17 +30,25 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
         Rparen:   87,
         Elements: []*ast.PropertyGraphElement{
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 65,
-              NameEnd: 72,
-              Name:    "Account",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 65,
+                  NameEnd: 72,
+                  Name:    "Account",
+                },
+              },
             },
           },
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 78,
-              NameEnd: 84,
-              Name:    "Person",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 78,
+                  NameEnd: 84,
+                  Name:    "Person",
+                },
+              },
             },
           },
         },
@@ -53,10 +61,14 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
         Rparen:   399,
         Elements: []*ast.PropertyGraphElement{
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 109,
-              NameEnd: 125,
-              Name:    "PersonOwnAccount",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 109,
+                  NameEnd: 125,
+                  Name:    "PersonOwnAccount",
+                },
+              },
             },
             Keys: &ast.PropertyGraphEdgeElementKeys{
               Source: &ast.PropertyGraphSourceKey{
@@ -72,10 +84,14 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 159,
-                  NameEnd: 165,
-                  Name:    "Person",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 159,
+                      NameEnd: 165,
+                      Name:    "Person",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         166,
@@ -102,10 +118,14 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 217,
-                  NameEnd: 224,
-                  Name:    "Account",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 217,
+                      NameEnd: 224,
+                      Name:    "Account",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         225,
@@ -136,10 +156,14 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
             },
           },
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 252,
-              NameEnd: 274,
-              Name:    "AccountTransferAccount",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 252,
+                  NameEnd: 274,
+                  Name:    "AccountTransferAccount",
+                },
+              },
             },
             Keys: &ast.PropertyGraphEdgeElementKeys{
               Source: &ast.PropertyGraphSourceKey{
@@ -155,10 +179,14 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 308,
-                  NameEnd: 315,
-                  Name:    "Account",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 308,
+                      NameEnd: 315,
+                      Name:    "Account",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         316,
@@ -185,10 +213,14 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 362,
-                  NameEnd: 369,
-                  Name:    "Account",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 362,
+                      NameEnd: 369,
+                      Name:    "Account",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         370,

--- a/testdata/result/ddl/create_property_graph_schema_qualified.sql.txt
+++ b/testdata/result/ddl/create_property_graph_schema_qualified.sql.txt
@@ -1,0 +1,213 @@
+--- create_property_graph_schema_qualified.sql
+CREATE PROPERTY GRAPH MyGraph
+  NODE TABLES (
+    myschema.NodeTable KEY (id),
+    SimpleNode KEY (id)
+  )
+  EDGE TABLES (
+    myschema.EdgeTable
+      KEY (src_id, dst_id)
+      SOURCE KEY (src_id) REFERENCES myschema.NodeTable (id)
+      DESTINATION KEY (dst_id) REFERENCES SimpleNode (id)
+  )
+
+--- AST
+&ast.CreatePropertyGraph{
+  Name: &ast.Ident{
+    NamePos: 22,
+    NameEnd: 29,
+    Name:    "MyGraph",
+  },
+  Content: &ast.PropertyGraphContent{
+    NodeTables: &ast.PropertyGraphNodeTables{
+      Node:   32,
+      Tables: &ast.PropertyGraphElementList{
+        Lparen:   44,
+        Rparen:   105,
+        Elements: []*ast.PropertyGraphElement{
+          &ast.PropertyGraphElement{
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 50,
+                  NameEnd: 58,
+                  Name:    "myschema",
+                },
+                &ast.Ident{
+                  NamePos: 59,
+                  NameEnd: 68,
+                  Name:    "NodeTable",
+                },
+              },
+            },
+            Keys: &ast.PropertyGraphNodeElementKey{
+              Key: &ast.PropertyGraphElementKey{
+                Key:  69,
+                Keys: &ast.PropertyGraphColumnNameList{
+                  Lparen:         73,
+                  Rparen:         76,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 74,
+                      NameEnd: 76,
+                      Name:    "id",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          &ast.PropertyGraphElement{
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 83,
+                  NameEnd: 93,
+                  Name:    "SimpleNode",
+                },
+              },
+            },
+            Keys: &ast.PropertyGraphNodeElementKey{
+              Key: &ast.PropertyGraphElementKey{
+                Key:  94,
+                Keys: &ast.PropertyGraphColumnNameList{
+                  Lparen:         98,
+                  Rparen:         101,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 99,
+                      NameEnd: 101,
+                      Name:    "id",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    EdgeTables: &ast.PropertyGraphEdgeTables{
+      Edge:   109,
+      Tables: &ast.PropertyGraphElementList{
+        Lparen:   121,
+        Rparen:   294,
+        Elements: []*ast.PropertyGraphElement{
+          &ast.PropertyGraphElement{
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 127,
+                  NameEnd: 135,
+                  Name:    "myschema",
+                },
+                &ast.Ident{
+                  NamePos: 136,
+                  NameEnd: 145,
+                  Name:    "EdgeTable",
+                },
+              },
+            },
+            Keys: &ast.PropertyGraphEdgeElementKeys{
+              Element: &ast.PropertyGraphElementKey{
+                Key:  152,
+                Keys: &ast.PropertyGraphColumnNameList{
+                  Lparen:         156,
+                  Rparen:         171,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 157,
+                      NameEnd: 163,
+                      Name:    "src_id",
+                    },
+                    &ast.Ident{
+                      NamePos: 165,
+                      NameEnd: 171,
+                      Name:    "dst_id",
+                    },
+                  },
+                },
+              },
+              Source: &ast.PropertyGraphSourceKey{
+                Source: 179,
+                Keys:   &ast.PropertyGraphColumnNameList{
+                  Lparen:         190,
+                  Rparen:         197,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 191,
+                      NameEnd: 197,
+                      Name:    "src_id",
+                    },
+                  },
+                },
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 210,
+                      NameEnd: 218,
+                      Name:    "myschema",
+                    },
+                    &ast.Ident{
+                      NamePos: 219,
+                      NameEnd: 228,
+                      Name:    "NodeTable",
+                    },
+                  },
+                },
+                ReferenceColumns: &ast.PropertyGraphColumnNameList{
+                  Lparen:         229,
+                  Rparen:         232,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 230,
+                      NameEnd: 232,
+                      Name:    "id",
+                    },
+                  },
+                },
+              },
+              Destination: &ast.PropertyGraphDestinationKey{
+                Destination: 240,
+                Keys:        &ast.PropertyGraphColumnNameList{
+                  Lparen:         256,
+                  Rparen:         263,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 257,
+                      NameEnd: 263,
+                      Name:    "dst_id",
+                    },
+                  },
+                },
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 276,
+                      NameEnd: 286,
+                      Name:    "SimpleNode",
+                    },
+                  },
+                },
+                ReferenceColumns: &ast.PropertyGraphColumnNameList{
+                  Lparen:         287,
+                  Rparen:         290,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 288,
+                      NameEnd: 290,
+                      Name:    "id",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE PROPERTY GRAPH MyGraph NODE TABLES (myschema.NodeTable KEY (id), SimpleNode KEY (id)) EDGE TABLES (myschema.EdgeTable KEY (src_id, dst_id) SOURCE KEY (src_id) REFERENCES myschema.NodeTable (id) DESTINATION KEY (dst_id) REFERENCES SimpleNode (id))

--- a/testdata/result/ddl/create_property_graph_schemaless.sql.txt
+++ b/testdata/result/ddl/create_property_graph_schemaless.sql.txt
@@ -28,10 +28,14 @@ CREATE PROPERTY GRAPH FinGraph
         Rparen:   129,
         Elements: []*ast.PropertyGraphElement{
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 51,
-              NameEnd: 60,
-              Name:    "GraphNode",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 51,
+                  NameEnd: 60,
+                  Name:    "GraphNode",
+                },
+              },
             },
             DynamicLabel: &ast.PropertyGraphDynamicLabel{
               Dynamic:    67,
@@ -62,10 +66,14 @@ CREATE PROPERTY GRAPH FinGraph
         Rparen:   333,
         Elements: []*ast.PropertyGraphElement{
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 151,
-              NameEnd: 160,
-              Name:    "GraphEdge",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 151,
+                  NameEnd: 160,
+                  Name:    "GraphEdge",
+                },
+              },
             },
             Keys: &ast.PropertyGraphEdgeElementKeys{
               Source: &ast.PropertyGraphSourceKey{
@@ -81,10 +89,14 @@ CREATE PROPERTY GRAPH FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 194,
-                  NameEnd: 203,
-                  Name:    "GraphNode",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 194,
+                      NameEnd: 203,
+                      Name:    "GraphNode",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         203,
@@ -111,10 +123,14 @@ CREATE PROPERTY GRAPH FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 251,
-                  NameEnd: 260,
-                  Name:    "GraphNode",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 251,
+                      NameEnd: 260,
+                      Name:    "GraphNode",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         260,

--- a/testdata/result/statement/create_or_replace_property_graph_fingraph_verbose.sql.txt
+++ b/testdata/result/statement/create_or_replace_property_graph_fingraph_verbose.sql.txt
@@ -43,10 +43,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
         Rparen:   638,
         Elements: []*ast.PropertyGraphElement{
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 62,
-              NameEnd: 69,
-              Name:    "Account",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 62,
+                  NameEnd: 69,
+                  Name:    "Account",
+                },
+              },
             },
             Alias: &ast.Ident{
               NamePos: 73,
@@ -127,10 +131,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
             },
           },
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 476,
-              NameEnd: 482,
-              Name:    "Person",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 476,
+                  NameEnd: 482,
+                  Name:    "Person",
+                },
+              },
             },
             Properties: &ast.PropertyGraphSingleProperties{
               Properties: &ast.PropertyGraphPropertiesAre{
@@ -160,10 +168,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
         Rparen:   1207,
         Elements: []*ast.PropertyGraphElement{
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 660,
-              NameEnd: 676,
-              Name:    "PersonOwnAccount",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 660,
+                  NameEnd: 676,
+                  Name:    "PersonOwnAccount",
+                },
+              },
             },
             Alias: &ast.Ident{
               NamePos: 680,
@@ -203,10 +215,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 757,
-                  NameEnd: 763,
-                  Name:    "Person",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 757,
+                      NameEnd: 763,
+                      Name:    "Person",
+                    },
+                  },
                 },
               },
               Destination: &ast.PropertyGraphDestinationKey{
@@ -222,10 +238,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 849,
-                  NameEnd: 856,
-                  Name:    "Account",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 849,
+                      NameEnd: 856,
+                      Name:    "Account",
+                    },
+                  },
                 },
               },
             },
@@ -249,10 +269,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
             },
           },
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 954,
-              NameEnd: 976,
-              Name:    "AccountTransferAccount",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 954,
+                  NameEnd: 976,
+                  Name:    "AccountTransferAccount",
+                },
+              },
             },
             Keys: &ast.PropertyGraphEdgeElementKeys{
               Source: &ast.PropertyGraphSourceKey{
@@ -268,10 +292,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 1010,
-                  NameEnd: 1017,
-                  Name:    "Account",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 1010,
+                      NameEnd: 1017,
+                      Name:    "Account",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         1018,
@@ -298,10 +326,14 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 1078,
-                  NameEnd: 1085,
-                  Name:    "Account",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 1078,
+                      NameEnd: 1085,
+                      Name:    "Account",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         1086,

--- a/testdata/result/statement/create_property_graph_if_not_exists_fingraph.sql.txt
+++ b/testdata/result/statement/create_property_graph_if_not_exists_fingraph.sql.txt
@@ -30,17 +30,25 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
         Rparen:   87,
         Elements: []*ast.PropertyGraphElement{
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 65,
-              NameEnd: 72,
-              Name:    "Account",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 65,
+                  NameEnd: 72,
+                  Name:    "Account",
+                },
+              },
             },
           },
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 78,
-              NameEnd: 84,
-              Name:    "Person",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 78,
+                  NameEnd: 84,
+                  Name:    "Person",
+                },
+              },
             },
           },
         },
@@ -53,10 +61,14 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
         Rparen:   399,
         Elements: []*ast.PropertyGraphElement{
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 109,
-              NameEnd: 125,
-              Name:    "PersonOwnAccount",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 109,
+                  NameEnd: 125,
+                  Name:    "PersonOwnAccount",
+                },
+              },
             },
             Keys: &ast.PropertyGraphEdgeElementKeys{
               Source: &ast.PropertyGraphSourceKey{
@@ -72,10 +84,14 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 159,
-                  NameEnd: 165,
-                  Name:    "Person",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 159,
+                      NameEnd: 165,
+                      Name:    "Person",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         166,
@@ -102,10 +118,14 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 217,
-                  NameEnd: 224,
-                  Name:    "Account",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 217,
+                      NameEnd: 224,
+                      Name:    "Account",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         225,
@@ -136,10 +156,14 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
             },
           },
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 252,
-              NameEnd: 274,
-              Name:    "AccountTransferAccount",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 252,
+                  NameEnd: 274,
+                  Name:    "AccountTransferAccount",
+                },
+              },
             },
             Keys: &ast.PropertyGraphEdgeElementKeys{
               Source: &ast.PropertyGraphSourceKey{
@@ -155,10 +179,14 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 308,
-                  NameEnd: 315,
-                  Name:    "Account",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 308,
+                      NameEnd: 315,
+                      Name:    "Account",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         316,
@@ -185,10 +213,14 @@ CREATE PROPERTY GRAPH IF NOT EXISTS FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 362,
-                  NameEnd: 369,
-                  Name:    "Account",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 362,
+                      NameEnd: 369,
+                      Name:    "Account",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         370,

--- a/testdata/result/statement/create_property_graph_schema_qualified.sql.txt
+++ b/testdata/result/statement/create_property_graph_schema_qualified.sql.txt
@@ -1,0 +1,213 @@
+--- create_property_graph_schema_qualified.sql
+CREATE PROPERTY GRAPH MyGraph
+  NODE TABLES (
+    myschema.NodeTable KEY (id),
+    SimpleNode KEY (id)
+  )
+  EDGE TABLES (
+    myschema.EdgeTable
+      KEY (src_id, dst_id)
+      SOURCE KEY (src_id) REFERENCES myschema.NodeTable (id)
+      DESTINATION KEY (dst_id) REFERENCES SimpleNode (id)
+  )
+
+--- AST
+&ast.CreatePropertyGraph{
+  Name: &ast.Ident{
+    NamePos: 22,
+    NameEnd: 29,
+    Name:    "MyGraph",
+  },
+  Content: &ast.PropertyGraphContent{
+    NodeTables: &ast.PropertyGraphNodeTables{
+      Node:   32,
+      Tables: &ast.PropertyGraphElementList{
+        Lparen:   44,
+        Rparen:   105,
+        Elements: []*ast.PropertyGraphElement{
+          &ast.PropertyGraphElement{
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 50,
+                  NameEnd: 58,
+                  Name:    "myschema",
+                },
+                &ast.Ident{
+                  NamePos: 59,
+                  NameEnd: 68,
+                  Name:    "NodeTable",
+                },
+              },
+            },
+            Keys: &ast.PropertyGraphNodeElementKey{
+              Key: &ast.PropertyGraphElementKey{
+                Key:  69,
+                Keys: &ast.PropertyGraphColumnNameList{
+                  Lparen:         73,
+                  Rparen:         76,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 74,
+                      NameEnd: 76,
+                      Name:    "id",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          &ast.PropertyGraphElement{
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 83,
+                  NameEnd: 93,
+                  Name:    "SimpleNode",
+                },
+              },
+            },
+            Keys: &ast.PropertyGraphNodeElementKey{
+              Key: &ast.PropertyGraphElementKey{
+                Key:  94,
+                Keys: &ast.PropertyGraphColumnNameList{
+                  Lparen:         98,
+                  Rparen:         101,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 99,
+                      NameEnd: 101,
+                      Name:    "id",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    EdgeTables: &ast.PropertyGraphEdgeTables{
+      Edge:   109,
+      Tables: &ast.PropertyGraphElementList{
+        Lparen:   121,
+        Rparen:   294,
+        Elements: []*ast.PropertyGraphElement{
+          &ast.PropertyGraphElement{
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 127,
+                  NameEnd: 135,
+                  Name:    "myschema",
+                },
+                &ast.Ident{
+                  NamePos: 136,
+                  NameEnd: 145,
+                  Name:    "EdgeTable",
+                },
+              },
+            },
+            Keys: &ast.PropertyGraphEdgeElementKeys{
+              Element: &ast.PropertyGraphElementKey{
+                Key:  152,
+                Keys: &ast.PropertyGraphColumnNameList{
+                  Lparen:         156,
+                  Rparen:         171,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 157,
+                      NameEnd: 163,
+                      Name:    "src_id",
+                    },
+                    &ast.Ident{
+                      NamePos: 165,
+                      NameEnd: 171,
+                      Name:    "dst_id",
+                    },
+                  },
+                },
+              },
+              Source: &ast.PropertyGraphSourceKey{
+                Source: 179,
+                Keys:   &ast.PropertyGraphColumnNameList{
+                  Lparen:         190,
+                  Rparen:         197,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 191,
+                      NameEnd: 197,
+                      Name:    "src_id",
+                    },
+                  },
+                },
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 210,
+                      NameEnd: 218,
+                      Name:    "myschema",
+                    },
+                    &ast.Ident{
+                      NamePos: 219,
+                      NameEnd: 228,
+                      Name:    "NodeTable",
+                    },
+                  },
+                },
+                ReferenceColumns: &ast.PropertyGraphColumnNameList{
+                  Lparen:         229,
+                  Rparen:         232,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 230,
+                      NameEnd: 232,
+                      Name:    "id",
+                    },
+                  },
+                },
+              },
+              Destination: &ast.PropertyGraphDestinationKey{
+                Destination: 240,
+                Keys:        &ast.PropertyGraphColumnNameList{
+                  Lparen:         256,
+                  Rparen:         263,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 257,
+                      NameEnd: 263,
+                      Name:    "dst_id",
+                    },
+                  },
+                },
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 276,
+                      NameEnd: 286,
+                      Name:    "SimpleNode",
+                    },
+                  },
+                },
+                ReferenceColumns: &ast.PropertyGraphColumnNameList{
+                  Lparen:         287,
+                  Rparen:         290,
+                  ColumnNameList: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 288,
+                      NameEnd: 290,
+                      Name:    "id",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE PROPERTY GRAPH MyGraph NODE TABLES (myschema.NodeTable KEY (id), SimpleNode KEY (id)) EDGE TABLES (myschema.EdgeTable KEY (src_id, dst_id) SOURCE KEY (src_id) REFERENCES myschema.NodeTable (id) DESTINATION KEY (dst_id) REFERENCES SimpleNode (id))

--- a/testdata/result/statement/create_property_graph_schemaless.sql.txt
+++ b/testdata/result/statement/create_property_graph_schemaless.sql.txt
@@ -28,10 +28,14 @@ CREATE PROPERTY GRAPH FinGraph
         Rparen:   129,
         Elements: []*ast.PropertyGraphElement{
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 51,
-              NameEnd: 60,
-              Name:    "GraphNode",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 51,
+                  NameEnd: 60,
+                  Name:    "GraphNode",
+                },
+              },
             },
             DynamicLabel: &ast.PropertyGraphDynamicLabel{
               Dynamic:    67,
@@ -62,10 +66,14 @@ CREATE PROPERTY GRAPH FinGraph
         Rparen:   333,
         Elements: []*ast.PropertyGraphElement{
           &ast.PropertyGraphElement{
-            Name: &ast.Ident{
-              NamePos: 151,
-              NameEnd: 160,
-              Name:    "GraphEdge",
+            Name: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 151,
+                  NameEnd: 160,
+                  Name:    "GraphEdge",
+                },
+              },
             },
             Keys: &ast.PropertyGraphEdgeElementKeys{
               Source: &ast.PropertyGraphSourceKey{
@@ -81,10 +89,14 @@ CREATE PROPERTY GRAPH FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 194,
-                  NameEnd: 203,
-                  Name:    "GraphNode",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 194,
+                      NameEnd: 203,
+                      Name:    "GraphNode",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         203,
@@ -111,10 +123,14 @@ CREATE PROPERTY GRAPH FinGraph
                     },
                   },
                 },
-                ElementReference: &ast.Ident{
-                  NamePos: 251,
-                  NameEnd: 260,
-                  Name:    "GraphNode",
+                ElementReference: &ast.Path{
+                  Idents: []*ast.Ident{
+                    &ast.Ident{
+                      NamePos: 251,
+                      NameEnd: 260,
+                      Name:    "GraphNode",
+                    },
+                  },
                 },
                 ReferenceColumns: &ast.PropertyGraphColumnNameList{
                   Lparen:         260,


### PR DESCRIPTION
This PR adds support for schema-qualified (dotted) table names in `CREATE PROPERTY GRAPH` NODE/EDGE TABLES and REFERENCES clauses.

Before this change, schema-qualified names like `myschema.MyTable` in a NODE TABLES clause caused a parse error: `Expected ) or , but got .`.

**Breaking changes**: The types of the following fields are changed to `*ast.Path` from `*ast.Ident`:
- `PropertyGraphElement.Name`
- `PropertyGraphSourceKey.ElementReference`
- `PropertyGraphDestinationKey.ElementReference`

## Local verification

- `go test ./...` — all tests pass
- `make lint` — 0 issues
- `make gen` — generated files up to date

## Related

- #98
- #298