### PR TITLE
doc: update Hugo theme and config

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,4 @@ module github.com/couldspannerecosystem/memefish/docs
 
 go 1.21.0
 
-require github.com/thingsym/hugo-theme-techdoc v1.0.1 // indirect
+require github.com/thingsym/hugo-theme-techdoc v1.1.0 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,4 @@
 github.com/thingsym/hugo-theme-techdoc v1.0.1 h1:YesixDLh7bRLFpcoyqflL3KUA+VFFw4l/9g/PuRHa4M=
 github.com/thingsym/hugo-theme-techdoc v1.0.1/go.mod h1:LTThnoCpG8nsum5q10OLrG1LdJNI3BXzV4Qr557cmAY=
+github.com/thingsym/hugo-theme-techdoc v1.1.0 h1:esTvysjySUcYKvBWAA6PFVS0opFpI90Q0a8NEs+zzeo=
+github.com/thingsym/hugo-theme-techdoc v1.1.0/go.mod h1:mPVjsx03IhxAZIKDKX8LKHNHjv6uszgMpH9MU1J4u8Q=

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -2,7 +2,6 @@ theme = "github.com/thingsym/hugo-theme-techdoc"
 
 baseURL = "https://cloudspannerecosystem.dev/memefish/"
 title = "méméfish"
-languageCode = "en-US"
 defaultContentLanguage = "en"
 
 canonifyurls = true
@@ -12,6 +11,12 @@ pygmentscodefences = true
 pygmentscodefencesguesssyntax = true
 
 summaryLength = 30
+
+[languages]
+  [languages.en]
+    label = "English"
+    locale = "en_US"
+    weight = 1
 
 [markup]
   defaultMarkdownHandler = "goldmark"


### PR DESCRIPTION
- Update `hugo-theme-techdoc` to v1.1.0
- Update deprecated config