### PR TITLE
ci: update hugo version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.133.0'
+          hugo-version: '0.161.0'
           extended: true
       - name: Build docs
         run: make docs


### PR DESCRIPTION
Since Hugo's version on CI is outdated, the CI was failed.