### PR TITLE
fix: supress lint warnings

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -428,10 +428,9 @@ type Constraint interface {
 	isConstraint()
 }
 
-func (ForeignKey) isConstraint() {}
-func (Check) isConstraint()      {}
+func (ForeignKey) isConstraint()      {}
+func (Check) isConstraint()           {}
 func (TablePrimaryKey) isConstraint() {}
-
 
 // TableAlteration represents ALTER TABLE action.
 type TableAlteration interface {

--- a/ast/sql_test.go
+++ b/ast/sql_test.go
@@ -84,6 +84,7 @@ func constValues(t *testing.T, name string) []*astcatalog.ConstValueDef {
 	def := loadCatalog(t).Consts[astcatalog.ConstType(name)]
 	if def == nil {
 		t.Fatalf("%s is not registered in AST catalog", name)
+		return nil
 	}
 	return def.Values
 }

--- a/parser.go
+++ b/parser.go
@@ -75,7 +75,7 @@ func (p *Parser) ParseQuery() (*ast.QueryStatement, error) {
 func (p *Parser) ParseGQLQuery() (stmt *ast.GQLGraphQuery, err error) {
 	p.nextToken()
 
-	l := p.Clone()
+	l := p.cloneLexer()
 	defer func() {
 		if r := recover(); r != nil {
 			p.handleParseStatementError(r, l)
@@ -140,7 +140,7 @@ func (p *Parser) ParseType() (ast.Type, error) {
 // ParseSchemaType parses a schema type.
 func (p *Parser) ParseSchemaType() (t ast.SchemaType, err error) {
 	p.nextToken()
-	l := p.Clone()
+	l := p.cloneLexer()
 	defer func() {
 		if r := recover(); r != nil {
 			t = p.handleParseTypeError(r, l)
@@ -237,7 +237,7 @@ func (p *Parser) ParseDMLs() ([]ast.DML, error) {
 }
 
 func (p *Parser) parseStatement() (stmt ast.Statement) {
-	l := p.Clone()
+	l := p.cloneLexer()
 	defer func() {
 		// Panic on tryParseHint()
 		if r := recover(); r != nil {
@@ -250,7 +250,7 @@ func (p *Parser) parseStatement() (stmt ast.Statement) {
 }
 
 func (p *Parser) parseStatementInternal(hint *ast.Hint) (stmt ast.Statement) {
-	l := p.Clone()
+	l := p.cloneLexer()
 	defer func() {
 		if r := recover(); r != nil {
 			stmt = &ast.BadStatement{
@@ -333,7 +333,7 @@ func parseStatements[T ast.Node](p *Parser, doParse func() T) []T {
 // ================================================================================
 
 func (p *Parser) parseQueryStatement() (stmt *ast.QueryStatement) {
-	l := p.Clone()
+	l := p.cloneLexer()
 	defer func() {
 		if r := recover(); r != nil {
 			// When parsing is failed on tryParseHint, the result of these methods are discarded
@@ -508,7 +508,7 @@ func (p *Parser) parseCTE() *ast.CTE {
 }
 
 func (p *Parser) parseQueryExpr() (query ast.QueryExpr) {
-	l := p.Clone()
+	l := p.cloneLexer()
 	defer func() {
 		if r := recover(); r != nil {
 			query = p.handleParseQueryExprError(false, r, l)
@@ -586,7 +586,7 @@ func (p *Parser) parseFromQuery() *ast.FromQuery {
 
 // parseSimpleQueryExpr parses simple QueryExpr, which can be wrapped in Query or CompoundQuery.
 func (p *Parser) parseSimpleQueryExpr() (query ast.QueryExpr) {
-	l := p.Clone()
+	l := p.cloneLexer()
 	defer func() {
 		if r := recover(); r != nil {
 			query = p.handleParseQueryExprError(true, r, l)
@@ -680,7 +680,7 @@ func (p *Parser) parseSelectResults() []ast.SelectItem {
 
 // lookaheadStarModifierExcept is needed to distinct "* EXCEPT (columns)" and "* EXCEPT {ALL|DISTINCT}".
 func (p *Parser) lookaheadStarModifierExcept() bool {
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	defer func() {
 		p.Lexer = lexer
 	}()
@@ -1411,7 +1411,7 @@ func (p *Parser) parseTableSampleSize() *ast.TableSampleSize {
 // ================================================================================
 
 func (p *Parser) parseExpr() (expr ast.Expr) {
-	l := p.Clone()
+	l := p.cloneLexer()
 	defer func() {
 		if r := recover(); r != nil {
 			expr = p.handleParseExprError(r, l)
@@ -1777,7 +1777,7 @@ func (p *Parser) parseSelector() ast.Expr {
 	for {
 		switch p.Token.Kind {
 		case ".":
-			lexer := p.Clone()
+			lexer := p.cloneLexer()
 			p.nextToken()
 			if p.Token.Kind == "*" { // expr.* case
 				p.Lexer = lexer
@@ -1930,7 +1930,7 @@ func (p *Parser) parseLit() ast.Expr {
 }
 
 func (p *Parser) lookaheadCallExpr() bool {
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	defer func() {
 		p.Lexer = lexer
 	}()
@@ -2021,7 +2021,7 @@ func (p *Parser) parseCallLike() ast.Expr {
 }
 
 func (p *Parser) lookaheadNamedArg() bool {
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	defer func() {
 		p.Lexer = lexer
 	}()
@@ -2053,7 +2053,7 @@ func (p *Parser) tryParseNamedArg() *ast.NamedArg {
 }
 
 func (p *Parser) lookaheadLambdaArg() bool {
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	defer func() {
 		p.Lexer = lexer
 	}()
@@ -2370,7 +2370,7 @@ func (p *Parser) parseWithExprVar() *ast.WithExprVar {
 }
 
 func (p *Parser) lookaheadWithExprVar() bool {
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	defer func() {
 		p.Lexer = lexer
 	}()
@@ -2665,7 +2665,7 @@ func (p *Parser) parseIntervalLiteral() ast.Expr {
 }
 
 func (p *Parser) lookaheadSubQuery() bool {
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	defer func() {
 		p.Lexer = lexer
 	}()
@@ -2727,7 +2727,7 @@ func (p *Parser) parseNamedType() *ast.NamedType {
 }
 
 func (p *Parser) parseType() (t ast.Type) {
-	l := p.Clone()
+	l := p.cloneLexer()
 	defer func() {
 		if r := recover(); r != nil {
 			t = p.handleParseTypeError(r, l)
@@ -2948,7 +2948,7 @@ func (p *Parser) parseNewConstructors() ast.Expr {
 }
 
 func (p *Parser) parseFieldType() *ast.StructField {
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	// Try to parse as "x INT64" case.
 	if p.Token.Kind == token.TokenIdent {
 		ident := p.parseIdent()
@@ -2992,7 +2992,7 @@ func (p *Parser) lookaheadSimpleType() bool {
 // ================================================================================
 
 func (p *Parser) parseDDL() (ddl ast.DDL) {
-	l := p.Clone()
+	l := p.cloneLexer()
 	defer func() {
 		if r := recover(); r != nil {
 			ddl = &ast.BadDDL{BadNode: p.handleParseStatementError(r, l)}
@@ -3762,7 +3762,7 @@ func (p *Parser) tryParseCluster() *ast.Cluster {
 	if p.Token.Kind != "," {
 		return nil
 	}
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	pos := p.expect(",").Pos
 	if !p.Token.IsKeywordLike("INTERLEAVE") {
 		p.Lexer = lexer
@@ -3795,7 +3795,7 @@ func (p *Parser) tryParseCreateRowDeletionPolicy() *ast.CreateRowDeletionPolicy 
 		return nil
 	}
 
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	pos := p.expect(",").Pos
 	if !p.Token.IsKeywordLike("ROW") {
 		p.Lexer = lexer
@@ -4236,7 +4236,7 @@ func (p *Parser) tryParseDeterminism() ast.Determinism {
 	}
 
 	if p.Token.Kind == "NOT" {
-		lexer := p.Clone()
+		lexer := p.cloneLexer()
 		p.nextToken()
 		if p.Token.IsKeywordLike("DETERMINISTIC") {
 			p.nextToken() // DETERMINISTIC
@@ -4937,7 +4937,7 @@ func (p *Parser) tryParseSelectPrivilegeOnAllViewsInSchema() *ast.SelectPrivileg
 	if p.Token.Kind != "SELECT" {
 		return nil
 	}
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	pos := p.expect("SELECT").Pos
 	if p.Token.Kind != "ON" {
 		p.Lexer = lexer
@@ -4967,7 +4967,7 @@ func (p *Parser) tryParseSelectPrivilegeOnView() *ast.SelectPrivilegeOnView {
 	if p.Token.Kind != "SELECT" {
 		return nil
 	}
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	pos := p.expect("SELECT").Pos
 	if p.Token.Kind != "ON" {
 		p.Lexer = lexer
@@ -5040,7 +5040,7 @@ func (p *Parser) tryParseSelectPrivilegeOnAllChangeStreamsInSchema() *ast.Select
 	if p.Token.Kind != "SELECT" {
 		return nil
 	}
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	pos := p.expect("SELECT").Pos
 	if p.Token.Kind != "ON" {
 		p.Lexer = lexer
@@ -5072,7 +5072,7 @@ func (p *Parser) tryParseSelectPrivilegeOnChangeStream() *ast.SelectPrivilegeOnC
 	if p.Token.Kind != "SELECT" {
 		return nil
 	}
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	pos := p.expect("SELECT").Pos
 	if p.Token.Kind != "ON" {
 		p.Lexer = lexer
@@ -5094,7 +5094,7 @@ func (p *Parser) tryParseSelectPrivilegeOnChangeStream() *ast.SelectPrivilegeOnC
 }
 
 func (p *Parser) tryParsePrivilegeOnAllTablesInSchema() *ast.PrivilegeOnAllTablesInSchema {
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	privileges := parseCommaSeparatedList(p, p.parseSchemaTablePrivilege)
 	if p.Token.Kind != "ON" {
 		p.Lexer = lexer
@@ -5500,7 +5500,7 @@ func (p *Parser) tryParsePropertyGraphColumnNameList() *ast.PropertyGraphColumnN
 }
 
 func (p *Parser) lookaheadPropertyGraphDynamicLabel() bool {
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	defer func() {
 		p.Lexer = lexer
 	}()
@@ -5532,7 +5532,7 @@ func (p *Parser) tryParsePropertyGraphDynamicLabel() *ast.PropertyGraphDynamicLa
 }
 
 func (p *Parser) lookaheadPropertyGraphDynamicProperties() bool {
-	lexer := p.Clone()
+	lexer := p.cloneLexer()
 	defer func() {
 		p.Lexer = lexer
 	}()
@@ -5915,7 +5915,7 @@ func (p *Parser) parseIfExists() bool {
 // parseDML parses non-nested DML with optional hints.
 // This function is parseStatements friendly.
 func (p *Parser) parseDML() (dml ast.DML) {
-	l := p.Clone()
+	l := p.cloneLexer()
 	defer func() {
 		// Panic on tryParseHint()
 		if r := recover(); r != nil {
@@ -5931,7 +5931,7 @@ func (p *Parser) parseDML() (dml ast.DML) {
 // The behavior is controlled by nested flag.
 // Note: It is recommended to use parseDML if you want to parse a complete DML statement.
 func (p *Parser) parseDMLInternal(hint *ast.Hint, nested bool) (dml ast.DML) {
-	l := p.Lexer.Clone()
+	l := p.cloneLexer()
 	defer func() {
 		if r := recover(); r != nil {
 			dml = &ast.BadDML{
@@ -6671,7 +6671,7 @@ func (p *Parser) parseGQLMultiLinearQueryStatement() *ast.GQLMultiLinearQuerySta
 }
 
 func (p *Parser) parseGQLLinearQueryStatement() (stmt ast.GQLLinearQueryStatement) {
-	l := p.Clone()
+	l := p.cloneLexer()
 	defer func() {
 		if r := recover(); r != nil {
 			stmt = &ast.BadGQLLinearQueryStatement{BadNode: p.handleParseStatementError(r, l)}
@@ -7028,4 +7028,12 @@ func (p *Parser) parseRenameTable(pos token.Pos) *ast.RenameTable {
 
 func (p *Parser) nextToken() {
 	p.Lexer.nextToken(false)
+}
+
+// cloneLexer copies the current lexer state for backtracking.
+func (p *Parser) cloneLexer() *Lexer {
+	// To avoid `staticcheck` warning `QF1008 - Omit embedded fields from selector expression`,
+	// we need to assign `p.Lexer` to a local variable first.
+	l := p.Lexer
+	return l.Clone()
 }


### PR DESCRIPTION
I did:

- run `make fmt`
- introduce `p.cloneLexer()` for replacing `p.Clone()`. It intends to clone the current lexer state, but it seems unclear. To fix this, we introduce a new `cloneLexer` method to explicit clone.
- add an explicit `nil` return