### PR TITLE
fix: drop duplicate "syntax error:" prefix in parseFromQuery

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -576,9 +576,9 @@ func (p *Parser) parseFromQuery() *ast.FromQuery {
 	// Although it can be parsed, it is better to reject invalid GoogleSQL queries.
 	switch p.Token.Kind {
 	case "ORDER":
-		panic(p.errorfAtToken(&p.Token, "syntax error: ORDER BY not supported after FROM query; Consider using pipe operator `|> ORDER BY` or parentheses around the FROM query."))
+		panic(p.errorfAtToken(&p.Token, "ORDER BY not supported after FROM query; Consider using pipe operator `|> ORDER BY` or parentheses around the FROM query."))
 	case "LIMIT":
-		panic(p.errorfAtToken(&p.Token, "syntax error: LIMIT not supported after FROM query; Consider using pipe operator `|> LIMIT` or parentheses around the FROM query."))
+		panic(p.errorfAtToken(&p.Token, "LIMIT not supported after FROM query; Consider using pipe operator `|> LIMIT` or parentheses around the FROM query."))
 	}
 
 	return &ast.FromQuery{From: from}

--- a/testdata/input/query/!bad_from_query_limit.sql
+++ b/testdata/input/query/!bad_from_query_limit.sql
@@ -1,0 +1,1 @@
+FROM t LIMIT 1

--- a/testdata/input/query/!bad_from_query_order_by.sql
+++ b/testdata/input/query/!bad_from_query_order_by.sql
@@ -1,0 +1,1 @@
+FROM t ORDER BY x

--- a/testdata/result/query/!bad_from_query_limit.sql.txt
+++ b/testdata/result/query/!bad_from_query_limit.sql.txt
@@ -1,0 +1,49 @@
+--- !bad_from_query_limit.sql
+FROM t LIMIT 1
+--- Error
+syntax error: testdata/input/query/!bad_from_query_limit.sql:1:8: LIMIT not supported after FROM query; Consider using pipe operator `|> LIMIT` or parentheses around the FROM query.
+  1|  FROM t LIMIT 1
+   |         ^~~~~
+
+
+--- AST
+&ast.QueryStatement{
+  Query: &ast.BadQueryExpr{
+    BadNode: &ast.BadNode{
+      NodeEnd: 14,
+      Tokens:  []*token.Token{
+        &token.Token{
+          Kind: "FROM",
+          Raw:  "FROM",
+          End:  4,
+        },
+        &token.Token{
+          Kind:     "<ident>",
+          Space:    " ",
+          Raw:      "t",
+          AsString: "t",
+          Pos:      5,
+          End:      6,
+        },
+        &token.Token{
+          Kind:  "LIMIT",
+          Space: " ",
+          Raw:   "LIMIT",
+          Pos:   7,
+          End:   12,
+        },
+        &token.Token{
+          Kind:  "<int>",
+          Space: " ",
+          Raw:   "1",
+          Base:  10,
+          Pos:   13,
+          End:   14,
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+FROM t LIMIT 1

--- a/testdata/result/query/!bad_from_query_order_by.sql.txt
+++ b/testdata/result/query/!bad_from_query_order_by.sql.txt
@@ -1,0 +1,56 @@
+--- !bad_from_query_order_by.sql
+FROM t ORDER BY x
+--- Error
+syntax error: testdata/input/query/!bad_from_query_order_by.sql:1:8: ORDER BY not supported after FROM query; Consider using pipe operator `|> ORDER BY` or parentheses around the FROM query.
+  1|  FROM t ORDER BY x
+   |         ^~~~~
+
+
+--- AST
+&ast.QueryStatement{
+  Query: &ast.BadQueryExpr{
+    BadNode: &ast.BadNode{
+      NodeEnd: 17,
+      Tokens:  []*token.Token{
+        &token.Token{
+          Kind: "FROM",
+          Raw:  "FROM",
+          End:  4,
+        },
+        &token.Token{
+          Kind:     "<ident>",
+          Space:    " ",
+          Raw:      "t",
+          AsString: "t",
+          Pos:      5,
+          End:      6,
+        },
+        &token.Token{
+          Kind:  "ORDER",
+          Space: " ",
+          Raw:   "ORDER",
+          Pos:   7,
+          End:   12,
+        },
+        &token.Token{
+          Kind:  "BY",
+          Space: " ",
+          Raw:   "BY",
+          Pos:   13,
+          End:   15,
+        },
+        &token.Token{
+          Kind:     "<ident>",
+          Space:    " ",
+          Raw:      "x",
+          AsString: "x",
+          Pos:      16,
+          End:      17,
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+FROM t ORDER BY x

--- a/testdata/result/statement/!bad_from_query_limit.sql.txt
+++ b/testdata/result/statement/!bad_from_query_limit.sql.txt
@@ -1,0 +1,49 @@
+--- !bad_from_query_limit.sql
+FROM t LIMIT 1
+--- Error
+syntax error: testdata/input/query/!bad_from_query_limit.sql:1:8: LIMIT not supported after FROM query; Consider using pipe operator `|> LIMIT` or parentheses around the FROM query.
+  1|  FROM t LIMIT 1
+   |         ^~~~~
+
+
+--- AST
+&ast.QueryStatement{
+  Query: &ast.BadQueryExpr{
+    BadNode: &ast.BadNode{
+      NodeEnd: 14,
+      Tokens:  []*token.Token{
+        &token.Token{
+          Kind: "FROM",
+          Raw:  "FROM",
+          End:  4,
+        },
+        &token.Token{
+          Kind:     "<ident>",
+          Space:    " ",
+          Raw:      "t",
+          AsString: "t",
+          Pos:      5,
+          End:      6,
+        },
+        &token.Token{
+          Kind:  "LIMIT",
+          Space: " ",
+          Raw:   "LIMIT",
+          Pos:   7,
+          End:   12,
+        },
+        &token.Token{
+          Kind:  "<int>",
+          Space: " ",
+          Raw:   "1",
+          Base:  10,
+          Pos:   13,
+          End:   14,
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+FROM t LIMIT 1

--- a/testdata/result/statement/!bad_from_query_order_by.sql.txt
+++ b/testdata/result/statement/!bad_from_query_order_by.sql.txt
@@ -1,0 +1,56 @@
+--- !bad_from_query_order_by.sql
+FROM t ORDER BY x
+--- Error
+syntax error: testdata/input/query/!bad_from_query_order_by.sql:1:8: ORDER BY not supported after FROM query; Consider using pipe operator `|> ORDER BY` or parentheses around the FROM query.
+  1|  FROM t ORDER BY x
+   |         ^~~~~
+
+
+--- AST
+&ast.QueryStatement{
+  Query: &ast.BadQueryExpr{
+    BadNode: &ast.BadNode{
+      NodeEnd: 17,
+      Tokens:  []*token.Token{
+        &token.Token{
+          Kind: "FROM",
+          Raw:  "FROM",
+          End:  4,
+        },
+        &token.Token{
+          Kind:     "<ident>",
+          Space:    " ",
+          Raw:      "t",
+          AsString: "t",
+          Pos:      5,
+          End:      6,
+        },
+        &token.Token{
+          Kind:  "ORDER",
+          Space: " ",
+          Raw:   "ORDER",
+          Pos:   7,
+          End:   12,
+        },
+        &token.Token{
+          Kind:  "BY",
+          Space: " ",
+          Raw:   "BY",
+          Pos:   13,
+          End:   15,
+        },
+        &token.Token{
+          Kind:     "<ident>",
+          Space:    " ",
+          Raw:      "x",
+          AsString: "x",
+          Pos:      16,
+          End:      17,
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+FROM t ORDER BY x


### PR DESCRIPTION
## Summary
- `parseFromQuery` baked a literal `syntax error: ` into ORDER BY / LIMIT rejection messages, but `Error.Error()` already prepends that prefix, producing `syntax error: syntax error: ...`.
- Remove the literal prefix so these messages match every other `errorfAtToken` call site.
- Add `!bad_` goldens for `FROM t ORDER BY x` and `FROM t LIMIT 1`.

## Test plan
- [x] `make lint && make test`
- [x] `go run ./tools/parse 'FROM t ORDER BY x'` shows a single `syntax error:` prefix


Made with [Cursor](https://cursor.com)