### PR TITLE
fix: use comma separator in StarModifierExcept.SQL()

### DIFF
--- a/ast/sql.go
+++ b/ast/sql.go
@@ -250,7 +250,7 @@ func (s *SubQuery) SQL() string {
 	return "(" + s.Query.SQL() + ")"
 }
 
-func (s *StarModifierExcept) SQL() string { return "EXCEPT (" + sqlJoin(s.Columns, " ") + ")" }
+func (s *StarModifierExcept) SQL() string { return "EXCEPT (" + sqlJoin(s.Columns, ", ") + ")" }
 
 func (s *StarModifierReplaceItem) SQL() string { return s.Expr.SQL() + " AS " + s.Name.SQL() }
 

--- a/testdata/input/query/select_star_except_multi.sql
+++ b/testdata/input/query/select_star_except_multi.sql
@@ -1,0 +1,1 @@
+SELECT * EXCEPT (fruit, vegetable) FROM (SELECT "apple" AS fruit, "carrot" AS vegetable, 1 AS n)

--- a/testdata/result/query/select_star_except_multi.sql.txt
+++ b/testdata/result/query/select_star_except_multi.sql.txt
@@ -1,0 +1,89 @@
+--- select_star_except_multi.sql
+SELECT * EXCEPT (fruit, vegetable) FROM (SELECT "apple" AS fruit, "carrot" AS vegetable, 1 AS n)
+--- AST
+&ast.QueryStatement{
+  Query: &ast.Select{
+    Results: []ast.SelectItem{
+      &ast.Star{
+        Star:   7,
+        Except: &ast.StarModifierExcept{
+          Except:  9,
+          Rparen:  33,
+          Columns: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 17,
+              NameEnd: 22,
+              Name:    "fruit",
+            },
+            &ast.Ident{
+              NamePos: 24,
+              NameEnd: 33,
+              Name:    "vegetable",
+            },
+          },
+        },
+      },
+    },
+    From: &ast.From{
+      From:   35,
+      Source: &ast.SubQueryTableExpr{
+        Lparen: 40,
+        Rparen: 95,
+        Query:  &ast.Select{
+          Select:  41,
+          Results: []ast.SelectItem{
+            &ast.Alias{
+              Expr: &ast.StringLiteral{
+                ValuePos: 48,
+                ValueEnd: 55,
+                Value:    "apple",
+              },
+              As: &ast.AsAlias{
+                As:    56,
+                Alias: &ast.Ident{
+                  NamePos: 59,
+                  NameEnd: 64,
+                  Name:    "fruit",
+                },
+              },
+            },
+            &ast.Alias{
+              Expr: &ast.StringLiteral{
+                ValuePos: 66,
+                ValueEnd: 74,
+                Value:    "carrot",
+              },
+              As: &ast.AsAlias{
+                As:    75,
+                Alias: &ast.Ident{
+                  NamePos: 78,
+                  NameEnd: 87,
+                  Name:    "vegetable",
+                },
+              },
+            },
+            &ast.Alias{
+              Expr: &ast.IntLiteral{
+                ValuePos: 89,
+                ValueEnd: 90,
+                Base:     10,
+                Value:    "1",
+              },
+              As: &ast.AsAlias{
+                As:    91,
+                Alias: &ast.Ident{
+                  NamePos: 94,
+                  NameEnd: 95,
+                  Name:    "n",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+SELECT * EXCEPT (fruit, vegetable) FROM (SELECT "apple" AS fruit, "carrot" AS vegetable, 1 AS n)

--- a/testdata/result/statement/select_star_except_multi.sql.txt
+++ b/testdata/result/statement/select_star_except_multi.sql.txt
@@ -1,0 +1,89 @@
+--- select_star_except_multi.sql
+SELECT * EXCEPT (fruit, vegetable) FROM (SELECT "apple" AS fruit, "carrot" AS vegetable, 1 AS n)
+--- AST
+&ast.QueryStatement{
+  Query: &ast.Select{
+    Results: []ast.SelectItem{
+      &ast.Star{
+        Star:   7,
+        Except: &ast.StarModifierExcept{
+          Except:  9,
+          Rparen:  33,
+          Columns: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 17,
+              NameEnd: 22,
+              Name:    "fruit",
+            },
+            &ast.Ident{
+              NamePos: 24,
+              NameEnd: 33,
+              Name:    "vegetable",
+            },
+          },
+        },
+      },
+    },
+    From: &ast.From{
+      From:   35,
+      Source: &ast.SubQueryTableExpr{
+        Lparen: 40,
+        Rparen: 95,
+        Query:  &ast.Select{
+          Select:  41,
+          Results: []ast.SelectItem{
+            &ast.Alias{
+              Expr: &ast.StringLiteral{
+                ValuePos: 48,
+                ValueEnd: 55,
+                Value:    "apple",
+              },
+              As: &ast.AsAlias{
+                As:    56,
+                Alias: &ast.Ident{
+                  NamePos: 59,
+                  NameEnd: 64,
+                  Name:    "fruit",
+                },
+              },
+            },
+            &ast.Alias{
+              Expr: &ast.StringLiteral{
+                ValuePos: 66,
+                ValueEnd: 74,
+                Value:    "carrot",
+              },
+              As: &ast.AsAlias{
+                As:    75,
+                Alias: &ast.Ident{
+                  NamePos: 78,
+                  NameEnd: 87,
+                  Name:    "vegetable",
+                },
+              },
+            },
+            &ast.Alias{
+              Expr: &ast.IntLiteral{
+                ValuePos: 89,
+                ValueEnd: 90,
+                Base:     10,
+                Value:    "1",
+              },
+              As: &ast.AsAlias{
+                As:    91,
+                Alias: &ast.Ident{
+                  NamePos: 94,
+                  NameEnd: 95,
+                  Name:    "n",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+SELECT * EXCEPT (fruit, vegetable) FROM (SELECT "apple" AS fruit, "carrot" AS vegetable, 1 AS n)


### PR DESCRIPTION
This PR fixes `SQL()` of `StarModifierExcept` (`SELECT * EXCEPT (a, b, ...)`)

- fixes #380 