### PR TITLE
feat: support generated expressions in ALTER COLUMN

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -3089,15 +3089,16 @@ type AlterColumn struct {
 
 // AlterColumnType is action to change the data type of the column in ALTER COLUMN.
 //
-//	{{.Type | sql}} {{if .NotNull}}NOT NULL{{end}} {{.DefaultExpr | sqlOpt}}
+//	{{.Type | sql}} {{if .NotNull}}NOT NULL{{end}} {{.DefaultExpr | sqlOpt}} {{.GeneratedExpr | sqlOpt}}
 type AlterColumnType struct {
 	// pos = Type.pos
-	// end = DefaultExpr.end || Null + 4 || Type.end
+	// end = GeneratedExpr.end || DefaultExpr.end || Null + 4 || Type.end
 
-	Type        SchemaType
-	Null        token.Pos // position of "NULL" keyword, optional
-	NotNull     bool
-	DefaultExpr *ColumnDefaultExpr // optional
+	Type          SchemaType
+	Null          token.Pos // position of "NULL" keyword, optional
+	NotNull       bool
+	DefaultExpr   *ColumnDefaultExpr   // optional, mutually exclusive with GeneratedExpr
+	GeneratedExpr *GeneratedColumnExpr // optional, mutually exclusive with DefaultExpr
 }
 
 // AlterColumnSetOptions is SET OPTIONS node in ALTER COLUMN.

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -1451,7 +1451,7 @@ func (a *AlterColumnType) Pos() token.Pos {
 }
 
 func (a *AlterColumnType) End() token.Pos {
-	return posChoice(nodeEnd(wrapNode(a.DefaultExpr)), posAdd(a.Null, 4), nodeEnd(wrapNode(a.Type)))
+	return posChoice(nodeEnd(wrapNode(a.GeneratedExpr)), nodeEnd(wrapNode(a.DefaultExpr)), posAdd(a.Null, 4), nodeEnd(wrapNode(a.Type)))
 }
 
 func (a *AlterColumnSetOptions) Pos() token.Pos {

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -988,7 +988,8 @@ func (a *AlterColumn) SQL() string {
 func (a *AlterColumnType) SQL() string {
 	return a.Type.SQL() +
 		strOpt(a.NotNull, " NOT NULL") +
-		sqlOpt(" ", a.DefaultExpr, "")
+		sqlOpt(" ", a.DefaultExpr, "") +
+		sqlOpt(" ", a.GeneratedExpr, "")
 }
 
 func (a *AlterColumnSetOptions) SQL() string { return "SET " + a.Options.SQL() }

--- a/ast/walk_internal.go
+++ b/ast/walk_internal.go
@@ -660,6 +660,7 @@ func walkInternal(node Node, v Visitor, stack []*stackItem) []*stackItem {
 		stack = append(stack, &stackItem{node: wrapNode(n.Name), visitor: v.Field("Name")})
 
 	case *AlterColumnType:
+		stack = append(stack, &stackItem{node: wrapNode(n.GeneratedExpr), visitor: v.Field("GeneratedExpr")})
 		stack = append(stack, &stackItem{node: wrapNode(n.DefaultExpr), visitor: v.Field("DefaultExpr")})
 		stack = append(stack, &stackItem{node: wrapNode(n.Type), visitor: v.Field("Type")})
 

--- a/parser.go
+++ b/parser.go
@@ -3687,14 +3687,6 @@ func (p *Parser) parseTypeNotNull() (t ast.SchemaType, notNull bool, null token.
 	return
 }
 
-func (p *Parser) tryParseColumnDefaultExpr() *ast.ColumnDefaultExpr {
-	if p.Token.Kind != "DEFAULT" {
-		return nil
-	}
-
-	return p.parseColumnDefaultExpr()
-}
-
 func (p *Parser) parseColumnDefaultExpr() *ast.ColumnDefaultExpr {
 	def := p.expect("DEFAULT").Pos
 	p.expect("(")
@@ -4597,12 +4589,21 @@ func (p *Parser) parseColumnAlteration() ast.ColumnAlteration {
 		}
 	default:
 		t, notNull, null := p.parseTypeNotNull()
-		defaultExpr := p.tryParseColumnDefaultExpr()
+
+		var defaultExpr *ast.ColumnDefaultExpr
+		var generatedExpr *ast.GeneratedColumnExpr
+		switch p.Token.Kind {
+		case "DEFAULT":
+			defaultExpr = p.parseColumnDefaultExpr()
+		case "AS":
+			generatedExpr = p.parseGeneratedColumnExpr()
+		}
 		return &ast.AlterColumnType{
-			Type:        t,
-			Null:        null,
-			NotNull:     notNull,
-			DefaultExpr: defaultExpr,
+			Type:          t,
+			Null:          null,
+			NotNull:       notNull,
+			DefaultExpr:   defaultExpr,
+			GeneratedExpr: generatedExpr,
 		}
 	}
 }

--- a/testdata/input/ddl/!bad_alter_table_alter_column_default_then_generated.sql
+++ b/testdata/input/ddl/!bad_alter_table_alter_column_default_then_generated.sql
@@ -1,0 +1,1 @@
+ALTER TABLE metrics ALTER COLUMN doubled INT64 DEFAULT (0) AS (source * 2)

--- a/testdata/input/ddl/!bad_alter_table_alter_column_generated_then_default.sql
+++ b/testdata/input/ddl/!bad_alter_table_alter_column_generated_then_default.sql
@@ -1,0 +1,1 @@
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2) DEFAULT (0)

--- a/testdata/input/ddl/alter_table_alter_column_generated.sql
+++ b/testdata/input/ddl/alter_table_alter_column_generated.sql
@@ -1,0 +1,1 @@
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2)

--- a/testdata/input/ddl/alter_table_alter_column_generated_not_null.sql
+++ b/testdata/input/ddl/alter_table_alter_column_generated_not_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ALTER COLUMN normalized_name STRING(MAX) NOT NULL AS (LOWER(name))

--- a/testdata/input/ddl/alter_table_alter_column_generated_stored.sql
+++ b/testdata/input/ddl/alter_table_alter_column_generated_stored.sql
@@ -1,0 +1,1 @@
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2) STORED

--- a/testdata/result/ddl/!bad_alter_table_alter_column_default_then_generated.sql.txt
+++ b/testdata/result/ddl/!bad_alter_table_alter_column_default_then_generated.sql.txt
@@ -1,0 +1,49 @@
+--- !bad_alter_table_alter_column_default_then_generated.sql
+ALTER TABLE metrics ALTER COLUMN doubled INT64 DEFAULT (0) AS (source * 2)
+
+--- Error
+syntax error: testdata/input/ddl/!bad_alter_table_alter_column_default_then_generated.sql:1:60: expected token: <eof>, but: AS
+  1|  ALTER TABLE metrics ALTER COLUMN doubled INT64 DEFAULT (0) AS (source * 2)
+   |                                                             ^~
+
+
+--- AST
+&ast.AlterTable{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 19,
+        Name:    "metrics",
+      },
+    },
+  },
+  TableAlteration: &ast.AlterColumn{
+    Alter: 20,
+    Name:  &ast.Ident{
+      NamePos: 33,
+      NameEnd: 40,
+      Name:    "doubled",
+    },
+    Alteration: &ast.AlterColumnType{
+      Type: &ast.ScalarSchemaType{
+        NamePos: 41,
+        Name:    "INT64",
+      },
+      Null:        -1,
+      DefaultExpr: &ast.ColumnDefaultExpr{
+        Default: 47,
+        Rparen:  57,
+        Expr:    &ast.IntLiteral{
+          ValuePos: 56,
+          ValueEnd: 57,
+          Base:     10,
+          Value:    "0",
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE metrics ALTER COLUMN doubled INT64 DEFAULT (0)

--- a/testdata/result/ddl/!bad_alter_table_alter_column_generated_then_default.sql.txt
+++ b/testdata/result/ddl/!bad_alter_table_alter_column_generated_then_default.sql.txt
@@ -1,0 +1,58 @@
+--- !bad_alter_table_alter_column_generated_then_default.sql
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2) DEFAULT (0)
+
+--- Error
+syntax error: testdata/input/ddl/!bad_alter_table_alter_column_generated_then_default.sql:1:64: expected token: <eof>, but: DEFAULT
+  1|  ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2) DEFAULT (0)
+   |                                                                 ^~~~~~~
+
+
+--- AST
+&ast.AlterTable{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 19,
+        Name:    "metrics",
+      },
+    },
+  },
+  TableAlteration: &ast.AlterColumn{
+    Alter: 20,
+    Name:  &ast.Ident{
+      NamePos: 33,
+      NameEnd: 40,
+      Name:    "doubled",
+    },
+    Alteration: &ast.AlterColumnType{
+      Type: &ast.ScalarSchemaType{
+        NamePos: 41,
+        Name:    "INT64",
+      },
+      Null:          -1,
+      GeneratedExpr: &ast.GeneratedColumnExpr{
+        As:     47,
+        Stored: -1,
+        Rparen: 61,
+        Expr:   &ast.BinaryExpr{
+          Op:   "*",
+          Left: &ast.Ident{
+            NamePos: 51,
+            NameEnd: 57,
+            Name:    "source",
+          },
+          Right: &ast.IntLiteral{
+            ValuePos: 60,
+            ValueEnd: 61,
+            Base:     10,
+            Value:    "2",
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2)

--- a/testdata/result/ddl/alter_table_alter_column_generated.sql.txt
+++ b/testdata/result/ddl/alter_table_alter_column_generated.sql.txt
@@ -1,0 +1,52 @@
+--- alter_table_alter_column_generated.sql
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2)
+
+--- AST
+&ast.AlterTable{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 19,
+        Name:    "metrics",
+      },
+    },
+  },
+  TableAlteration: &ast.AlterColumn{
+    Alter: 20,
+    Name:  &ast.Ident{
+      NamePos: 33,
+      NameEnd: 40,
+      Name:    "doubled",
+    },
+    Alteration: &ast.AlterColumnType{
+      Type: &ast.ScalarSchemaType{
+        NamePos: 41,
+        Name:    "INT64",
+      },
+      Null:          -1,
+      GeneratedExpr: &ast.GeneratedColumnExpr{
+        As:     47,
+        Stored: -1,
+        Rparen: 61,
+        Expr:   &ast.BinaryExpr{
+          Op:   "*",
+          Left: &ast.Ident{
+            NamePos: 51,
+            NameEnd: 57,
+            Name:    "source",
+          },
+          Right: &ast.IntLiteral{
+            ValuePos: 60,
+            ValueEnd: 61,
+            Base:     10,
+            Value:    "2",
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2)

--- a/testdata/result/ddl/alter_table_alter_column_generated_not_null.sql.txt
+++ b/testdata/result/ddl/alter_table_alter_column_generated_not_null.sql.txt
@@ -1,0 +1,62 @@
+--- alter_table_alter_column_generated_not_null.sql
+ALTER TABLE users ALTER COLUMN normalized_name STRING(MAX) NOT NULL AS (LOWER(name))
+
+--- AST
+&ast.AlterTable{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 17,
+        Name:    "users",
+      },
+    },
+  },
+  TableAlteration: &ast.AlterColumn{
+    Alter: 18,
+    Name:  &ast.Ident{
+      NamePos: 31,
+      NameEnd: 46,
+      Name:    "normalized_name",
+    },
+    Alteration: &ast.AlterColumnType{
+      Type: &ast.SizedSchemaType{
+        NamePos: 47,
+        Rparen:  57,
+        Name:    "STRING",
+        Max:     true,
+      },
+      Null:          63,
+      NotNull:       true,
+      GeneratedExpr: &ast.GeneratedColumnExpr{
+        As:     68,
+        Stored: -1,
+        Rparen: 83,
+        Expr:   &ast.CallExpr{
+          Rparen: 82,
+          Func:   &ast.Path{
+            Idents: []*ast.Ident{
+              &ast.Ident{
+                NamePos: 72,
+                NameEnd: 77,
+                Name:    "LOWER",
+              },
+            },
+          },
+          Args: []ast.Arg{
+            &ast.ExprArg{
+              Expr: &ast.Ident{
+                NamePos: 78,
+                NameEnd: 82,
+                Name:    "name",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE users ALTER COLUMN normalized_name STRING(MAX) NOT NULL AS (LOWER(name))

--- a/testdata/result/ddl/alter_table_alter_column_generated_stored.sql.txt
+++ b/testdata/result/ddl/alter_table_alter_column_generated_stored.sql.txt
@@ -1,0 +1,52 @@
+--- alter_table_alter_column_generated_stored.sql
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2) STORED
+
+--- AST
+&ast.AlterTable{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 19,
+        Name:    "metrics",
+      },
+    },
+  },
+  TableAlteration: &ast.AlterColumn{
+    Alter: 20,
+    Name:  &ast.Ident{
+      NamePos: 33,
+      NameEnd: 40,
+      Name:    "doubled",
+    },
+    Alteration: &ast.AlterColumnType{
+      Type: &ast.ScalarSchemaType{
+        NamePos: 41,
+        Name:    "INT64",
+      },
+      Null:          -1,
+      GeneratedExpr: &ast.GeneratedColumnExpr{
+        As:     47,
+        Stored: 63,
+        Rparen: 61,
+        Expr:   &ast.BinaryExpr{
+          Op:   "*",
+          Left: &ast.Ident{
+            NamePos: 51,
+            NameEnd: 57,
+            Name:    "source",
+          },
+          Right: &ast.IntLiteral{
+            ValuePos: 60,
+            ValueEnd: 61,
+            Base:     10,
+            Value:    "2",
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2) STORED

--- a/testdata/result/statement/!bad_alter_table_alter_column_default_then_generated.sql.txt
+++ b/testdata/result/statement/!bad_alter_table_alter_column_default_then_generated.sql.txt
@@ -1,0 +1,49 @@
+--- !bad_alter_table_alter_column_default_then_generated.sql
+ALTER TABLE metrics ALTER COLUMN doubled INT64 DEFAULT (0) AS (source * 2)
+
+--- Error
+syntax error: testdata/input/ddl/!bad_alter_table_alter_column_default_then_generated.sql:1:60: expected token: <eof>, but: AS
+  1|  ALTER TABLE metrics ALTER COLUMN doubled INT64 DEFAULT (0) AS (source * 2)
+   |                                                             ^~
+
+
+--- AST
+&ast.AlterTable{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 19,
+        Name:    "metrics",
+      },
+    },
+  },
+  TableAlteration: &ast.AlterColumn{
+    Alter: 20,
+    Name:  &ast.Ident{
+      NamePos: 33,
+      NameEnd: 40,
+      Name:    "doubled",
+    },
+    Alteration: &ast.AlterColumnType{
+      Type: &ast.ScalarSchemaType{
+        NamePos: 41,
+        Name:    "INT64",
+      },
+      Null:        -1,
+      DefaultExpr: &ast.ColumnDefaultExpr{
+        Default: 47,
+        Rparen:  57,
+        Expr:    &ast.IntLiteral{
+          ValuePos: 56,
+          ValueEnd: 57,
+          Base:     10,
+          Value:    "0",
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE metrics ALTER COLUMN doubled INT64 DEFAULT (0)

--- a/testdata/result/statement/!bad_alter_table_alter_column_generated_then_default.sql.txt
+++ b/testdata/result/statement/!bad_alter_table_alter_column_generated_then_default.sql.txt
@@ -1,0 +1,58 @@
+--- !bad_alter_table_alter_column_generated_then_default.sql
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2) DEFAULT (0)
+
+--- Error
+syntax error: testdata/input/ddl/!bad_alter_table_alter_column_generated_then_default.sql:1:64: expected token: <eof>, but: DEFAULT
+  1|  ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2) DEFAULT (0)
+   |                                                                 ^~~~~~~
+
+
+--- AST
+&ast.AlterTable{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 19,
+        Name:    "metrics",
+      },
+    },
+  },
+  TableAlteration: &ast.AlterColumn{
+    Alter: 20,
+    Name:  &ast.Ident{
+      NamePos: 33,
+      NameEnd: 40,
+      Name:    "doubled",
+    },
+    Alteration: &ast.AlterColumnType{
+      Type: &ast.ScalarSchemaType{
+        NamePos: 41,
+        Name:    "INT64",
+      },
+      Null:          -1,
+      GeneratedExpr: &ast.GeneratedColumnExpr{
+        As:     47,
+        Stored: -1,
+        Rparen: 61,
+        Expr:   &ast.BinaryExpr{
+          Op:   "*",
+          Left: &ast.Ident{
+            NamePos: 51,
+            NameEnd: 57,
+            Name:    "source",
+          },
+          Right: &ast.IntLiteral{
+            ValuePos: 60,
+            ValueEnd: 61,
+            Base:     10,
+            Value:    "2",
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2)

--- a/testdata/result/statement/alter_table_alter_column_generated.sql.txt
+++ b/testdata/result/statement/alter_table_alter_column_generated.sql.txt
@@ -1,0 +1,52 @@
+--- alter_table_alter_column_generated.sql
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2)
+
+--- AST
+&ast.AlterTable{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 19,
+        Name:    "metrics",
+      },
+    },
+  },
+  TableAlteration: &ast.AlterColumn{
+    Alter: 20,
+    Name:  &ast.Ident{
+      NamePos: 33,
+      NameEnd: 40,
+      Name:    "doubled",
+    },
+    Alteration: &ast.AlterColumnType{
+      Type: &ast.ScalarSchemaType{
+        NamePos: 41,
+        Name:    "INT64",
+      },
+      Null:          -1,
+      GeneratedExpr: &ast.GeneratedColumnExpr{
+        As:     47,
+        Stored: -1,
+        Rparen: 61,
+        Expr:   &ast.BinaryExpr{
+          Op:   "*",
+          Left: &ast.Ident{
+            NamePos: 51,
+            NameEnd: 57,
+            Name:    "source",
+          },
+          Right: &ast.IntLiteral{
+            ValuePos: 60,
+            ValueEnd: 61,
+            Base:     10,
+            Value:    "2",
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2)

--- a/testdata/result/statement/alter_table_alter_column_generated_not_null.sql.txt
+++ b/testdata/result/statement/alter_table_alter_column_generated_not_null.sql.txt
@@ -1,0 +1,62 @@
+--- alter_table_alter_column_generated_not_null.sql
+ALTER TABLE users ALTER COLUMN normalized_name STRING(MAX) NOT NULL AS (LOWER(name))
+
+--- AST
+&ast.AlterTable{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 17,
+        Name:    "users",
+      },
+    },
+  },
+  TableAlteration: &ast.AlterColumn{
+    Alter: 18,
+    Name:  &ast.Ident{
+      NamePos: 31,
+      NameEnd: 46,
+      Name:    "normalized_name",
+    },
+    Alteration: &ast.AlterColumnType{
+      Type: &ast.SizedSchemaType{
+        NamePos: 47,
+        Rparen:  57,
+        Name:    "STRING",
+        Max:     true,
+      },
+      Null:          63,
+      NotNull:       true,
+      GeneratedExpr: &ast.GeneratedColumnExpr{
+        As:     68,
+        Stored: -1,
+        Rparen: 83,
+        Expr:   &ast.CallExpr{
+          Rparen: 82,
+          Func:   &ast.Path{
+            Idents: []*ast.Ident{
+              &ast.Ident{
+                NamePos: 72,
+                NameEnd: 77,
+                Name:    "LOWER",
+              },
+            },
+          },
+          Args: []ast.Arg{
+            &ast.ExprArg{
+              Expr: &ast.Ident{
+                NamePos: 78,
+                NameEnd: 82,
+                Name:    "name",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE users ALTER COLUMN normalized_name STRING(MAX) NOT NULL AS (LOWER(name))

--- a/testdata/result/statement/alter_table_alter_column_generated_stored.sql.txt
+++ b/testdata/result/statement/alter_table_alter_column_generated_stored.sql.txt
@@ -1,0 +1,52 @@
+--- alter_table_alter_column_generated_stored.sql
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2) STORED
+
+--- AST
+&ast.AlterTable{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 12,
+        NameEnd: 19,
+        Name:    "metrics",
+      },
+    },
+  },
+  TableAlteration: &ast.AlterColumn{
+    Alter: 20,
+    Name:  &ast.Ident{
+      NamePos: 33,
+      NameEnd: 40,
+      Name:    "doubled",
+    },
+    Alteration: &ast.AlterColumnType{
+      Type: &ast.ScalarSchemaType{
+        NamePos: 41,
+        Name:    "INT64",
+      },
+      Null:          -1,
+      GeneratedExpr: &ast.GeneratedColumnExpr{
+        As:     47,
+        Stored: 63,
+        Rparen: 61,
+        Expr:   &ast.BinaryExpr{
+          Op:   "*",
+          Left: &ast.Ident{
+            NamePos: 51,
+            NameEnd: 57,
+            Name:    "source",
+          },
+          Right: &ast.IntLiteral{
+            ValuePos: 60,
+            ValueEnd: 61,
+            Base:     10,
+            Value:    "2",
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER TABLE metrics ALTER COLUMN doubled INT64 AS (source * 2) STORED


### PR DESCRIPTION
This PR adds support of `ALTER TABLE ... ALTER COLUMN ... data_type [NOT NULL] AS (expression)
  [STORED]`;
Note: `STORED` is not documented, but it is supported and explicitly tested in [test cases in cloud-spanner-emulator](https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/blob/5fb62b353d14cfa6b1ce510561c2ce809d905cc2/tests/conformance/data/schema_changes/generated_column.test#L139).

- fixed #95 