### PR TITLE
feat: support ALTER VECTOR INDEX SET OPTIONS

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -554,8 +554,9 @@ type VectorIndexAlteration interface {
 	isVectorIndexAlteration()
 }
 
-func (AddStoredColumn) isVectorIndexAlteration()  {}
-func (DropStoredColumn) isVectorIndexAlteration() {}
+func (VectorIndexSetOptions) isVectorIndexAlteration() {}
+func (AddStoredColumn) isVectorIndexAlteration()       {}
+func (DropStoredColumn) isVectorIndexAlteration()      {}
 
 // DML represents data manipulation language in SQL.
 //
@@ -3315,6 +3316,18 @@ type AlterVectorIndex struct {
 	Alter      token.Pos
 	Name       *Path
 	Alteration VectorIndexAlteration
+}
+
+// VectorIndexSetOptions is SET OPTIONS clause in ALTER VECTOR INDEX.
+//
+//	SET {{.Options | sql}}
+type VectorIndexSetOptions struct {
+	// pos = Set
+	// end = Options.end
+
+	Set token.Pos // position of "SET" keyword
+
+	Options *Options
 }
 
 // CreateChangeStream is CREATE CHANGE STREAM statement node.

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -1582,6 +1582,14 @@ func (a *AlterVectorIndex) End() token.Pos {
 	return nodeEnd(wrapNode(a.Alteration))
 }
 
+func (v *VectorIndexSetOptions) Pos() token.Pos {
+	return v.Set
+}
+
+func (v *VectorIndexSetOptions) End() token.Pos {
+	return nodeEnd(wrapNode(v.Options))
+}
+
 func (c *CreateChangeStream) Pos() token.Pos {
 	return c.Create
 }

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -1048,6 +1048,8 @@ func (a *AlterVectorIndex) SQL() string {
 	return "ALTER VECTOR INDEX " + a.Name.SQL() + " " + a.Alteration.SQL()
 }
 
+func (a *VectorIndexSetOptions) SQL() string { return "SET " + a.Options.SQL() }
+
 func (c *CreateChangeStream) SQL() string {
 	return "CREATE CHANGE STREAM " + c.Name.SQL() +
 		sqlOpt(" ", c.For, "") +

--- a/ast/walk_internal.go
+++ b/ast/walk_internal.go
@@ -725,6 +725,9 @@ func walkInternal(node Node, v Visitor, stack []*stackItem) []*stackItem {
 		stack = append(stack, &stackItem{node: wrapNode(n.Alteration), visitor: v.Field("Alteration")})
 		stack = append(stack, &stackItem{node: wrapNode(n.Name), visitor: v.Field("Name")})
 
+	case *VectorIndexSetOptions:
+		stack = append(stack, &stackItem{node: wrapNode(n.Options), visitor: v.Field("Options")})
+
 	case *CreateChangeStream:
 		stack = append(stack, &stackItem{node: wrapNode(n.Options), visitor: v.Field("Options")})
 		stack = append(stack, &stackItem{node: wrapNode(n.For), visitor: v.Field("For")})

--- a/parser.go
+++ b/parser.go
@@ -3996,8 +3996,10 @@ func (p *Parser) parseVectorIndexAlteration() ast.VectorIndexAlteration {
 		return p.parseAddStoredColumn()
 	case p.Token.IsKeywordLike("DROP"):
 		return p.parseDropStoredColumn()
+	case p.Token.Kind == "SET":
+		return p.parseVectorIndexSetOptions()
 	default:
-		panic(p.errorfAtToken(&p.Token, "expected pseudo keyword: ADD, DROP, but: %s", p.Token.AsString))
+		panic(p.errorfAtToken(&p.Token, "expected token: SET, pseudo keyword: ADD, DROP, but: %s", p.Token.AsString))
 	}
 }
 
@@ -4808,6 +4810,16 @@ func (p *Parser) parseDropStoredColumn() *ast.DropStoredColumn {
 		Name: name,
 	}
 }
+
+func (p *Parser) parseVectorIndexSetOptions() *ast.VectorIndexSetOptions {
+	set := p.expect("SET").Pos
+	options := p.parseOptions()
+	return &ast.VectorIndexSetOptions{
+		Set:     set,
+		Options: options,
+	}
+}
+
 func (p *Parser) parseDropTable(pos token.Pos) *ast.DropTable {
 	p.expectKeywordLike("TABLE")
 	ifExists := p.parseIfExists()

--- a/testdata/input/ddl/!bad_alter_vector_index_set_options_missing_options.sql
+++ b/testdata/input/ddl/!bad_alter_vector_index_set_options_missing_options.sql
@@ -1,0 +1,1 @@
+ALTER VECTOR INDEX IncidentVectorIndex SET (disable_search = true)

--- a/testdata/input/ddl/!bad_alter_vector_index_set_options_missing_value.sql
+++ b/testdata/input/ddl/!bad_alter_vector_index_set_options_missing_value.sql
@@ -1,0 +1,1 @@
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search =)

--- a/testdata/input/ddl/alter_vector_index_set_options_false.sql
+++ b/testdata/input/ddl/alter_vector_index_set_options_false.sql
@@ -1,0 +1,1 @@
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = false)

--- a/testdata/input/ddl/alter_vector_index_set_options_null.sql
+++ b/testdata/input/ddl/alter_vector_index_set_options_null.sql
@@ -1,0 +1,1 @@
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = null)

--- a/testdata/input/ddl/alter_vector_index_set_options_true.sql
+++ b/testdata/input/ddl/alter_vector_index_set_options_true.sql
@@ -1,0 +1,1 @@
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = true)

--- a/testdata/result/ddl/!bad_alter_vector_index_set_options_missing_options.sql.txt
+++ b/testdata/result/ddl/!bad_alter_vector_index_set_options_missing_options.sql.txt
@@ -1,0 +1,91 @@
+--- !bad_alter_vector_index_set_options_missing_options.sql
+ALTER VECTOR INDEX IncidentVectorIndex SET (disable_search = true)
+
+--- Error
+syntax error: testdata/input/ddl/!bad_alter_vector_index_set_options_missing_options.sql:1:44: expected token: <ident>, but: (
+  1|  ALTER VECTOR INDEX IncidentVectorIndex SET (disable_search = true)
+   |                                             ^
+
+
+--- AST
+&ast.BadDDL{
+  BadNode: &ast.BadNode{
+    NodeEnd: 66,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "ALTER",
+        AsString: "ALTER",
+        End:      5,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "VECTOR",
+        AsString: "VECTOR",
+        Pos:      6,
+        End:      12,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "INDEX",
+        AsString: "INDEX",
+        Pos:      13,
+        End:      18,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "IncidentVectorIndex",
+        AsString: "IncidentVectorIndex",
+        Pos:      19,
+        End:      38,
+      },
+      &token.Token{
+        Kind:  "SET",
+        Space: " ",
+        Raw:   "SET",
+        Pos:   39,
+        End:   42,
+      },
+      &token.Token{
+        Kind:  "(",
+        Space: " ",
+        Raw:   "(",
+        Pos:   43,
+        End:   44,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "disable_search",
+        AsString: "disable_search",
+        Pos:      44,
+        End:      58,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   59,
+        End:   60,
+      },
+      &token.Token{
+        Kind:  "TRUE",
+        Space: " ",
+        Raw:   "true",
+        Pos:   61,
+        End:   65,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  65,
+        End:  66,
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX IncidentVectorIndex SET (disable_search = true)

--- a/testdata/result/ddl/!bad_alter_vector_index_set_options_missing_value.sql.txt
+++ b/testdata/result/ddl/!bad_alter_vector_index_set_options_missing_value.sql.txt
@@ -1,0 +1,46 @@
+--- !bad_alter_vector_index_set_options_missing_value.sql
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search =)
+
+--- Error
+syntax error: testdata/input/ddl/!bad_alter_vector_index_set_options_missing_value.sql:1:69: unexpected token: )
+  1|  ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search =)
+   |                                                                      ^
+
+
+--- AST
+&ast.AlterVectorIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 38,
+        Name:    "IncidentVectorIndex",
+      },
+    },
+  },
+  Alteration: &ast.VectorIndexSetOptions{
+    Set:     39,
+    Options: &ast.Options{
+      Options: 43,
+      Rparen:  68,
+      Records: []*ast.OptionsDef{
+        &ast.OptionsDef{
+          Name: &ast.Ident{
+            NamePos: 52,
+            NameEnd: 66,
+            Name:    "disable_search",
+          },
+          Value: &ast.BadExpr{
+            BadNode: &ast.BadNode{
+              NodePos: 68,
+              NodeEnd: 68,
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = )

--- a/testdata/result/ddl/alter_vector_index_set_options_false.sql.txt
+++ b/testdata/result/ddl/alter_vector_index_set_options_false.sql.txt
@@ -1,0 +1,37 @@
+--- alter_vector_index_set_options_false.sql
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = false)
+
+--- AST
+&ast.AlterVectorIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 38,
+        Name:    "IncidentVectorIndex",
+      },
+    },
+  },
+  Alteration: &ast.VectorIndexSetOptions{
+    Set:     39,
+    Options: &ast.Options{
+      Options: 43,
+      Rparen:  74,
+      Records: []*ast.OptionsDef{
+        &ast.OptionsDef{
+          Name: &ast.Ident{
+            NamePos: 52,
+            NameEnd: 66,
+            Name:    "disable_search",
+          },
+          Value: &ast.BoolLiteral{
+            ValuePos: 69,
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = false)

--- a/testdata/result/ddl/alter_vector_index_set_options_null.sql.txt
+++ b/testdata/result/ddl/alter_vector_index_set_options_null.sql.txt
@@ -1,0 +1,37 @@
+--- alter_vector_index_set_options_null.sql
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = null)
+
+--- AST
+&ast.AlterVectorIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 38,
+        Name:    "IncidentVectorIndex",
+      },
+    },
+  },
+  Alteration: &ast.VectorIndexSetOptions{
+    Set:     39,
+    Options: &ast.Options{
+      Options: 43,
+      Rparen:  73,
+      Records: []*ast.OptionsDef{
+        &ast.OptionsDef{
+          Name: &ast.Ident{
+            NamePos: 52,
+            NameEnd: 66,
+            Name:    "disable_search",
+          },
+          Value: &ast.NullLiteral{
+            Null: 69,
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = null)

--- a/testdata/result/ddl/alter_vector_index_set_options_true.sql.txt
+++ b/testdata/result/ddl/alter_vector_index_set_options_true.sql.txt
@@ -1,0 +1,38 @@
+--- alter_vector_index_set_options_true.sql
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = true)
+
+--- AST
+&ast.AlterVectorIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 38,
+        Name:    "IncidentVectorIndex",
+      },
+    },
+  },
+  Alteration: &ast.VectorIndexSetOptions{
+    Set:     39,
+    Options: &ast.Options{
+      Options: 43,
+      Rparen:  73,
+      Records: []*ast.OptionsDef{
+        &ast.OptionsDef{
+          Name: &ast.Ident{
+            NamePos: 52,
+            NameEnd: 66,
+            Name:    "disable_search",
+          },
+          Value: &ast.BoolLiteral{
+            ValuePos: 69,
+            Value:    true,
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = true)

--- a/testdata/result/statement/!bad_alter_vector_index_set_options_missing_options.sql.txt
+++ b/testdata/result/statement/!bad_alter_vector_index_set_options_missing_options.sql.txt
@@ -1,0 +1,91 @@
+--- !bad_alter_vector_index_set_options_missing_options.sql
+ALTER VECTOR INDEX IncidentVectorIndex SET (disable_search = true)
+
+--- Error
+syntax error: testdata/input/ddl/!bad_alter_vector_index_set_options_missing_options.sql:1:44: expected token: <ident>, but: (
+  1|  ALTER VECTOR INDEX IncidentVectorIndex SET (disable_search = true)
+   |                                             ^
+
+
+--- AST
+&ast.BadDDL{
+  BadNode: &ast.BadNode{
+    NodeEnd: 66,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "ALTER",
+        AsString: "ALTER",
+        End:      5,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "VECTOR",
+        AsString: "VECTOR",
+        Pos:      6,
+        End:      12,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "INDEX",
+        AsString: "INDEX",
+        Pos:      13,
+        End:      18,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "IncidentVectorIndex",
+        AsString: "IncidentVectorIndex",
+        Pos:      19,
+        End:      38,
+      },
+      &token.Token{
+        Kind:  "SET",
+        Space: " ",
+        Raw:   "SET",
+        Pos:   39,
+        End:   42,
+      },
+      &token.Token{
+        Kind:  "(",
+        Space: " ",
+        Raw:   "(",
+        Pos:   43,
+        End:   44,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "disable_search",
+        AsString: "disable_search",
+        Pos:      44,
+        End:      58,
+      },
+      &token.Token{
+        Kind:  "=",
+        Space: " ",
+        Raw:   "=",
+        Pos:   59,
+        End:   60,
+      },
+      &token.Token{
+        Kind:  "TRUE",
+        Space: " ",
+        Raw:   "true",
+        Pos:   61,
+        End:   65,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  65,
+        End:  66,
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX IncidentVectorIndex SET (disable_search = true)

--- a/testdata/result/statement/!bad_alter_vector_index_set_options_missing_value.sql.txt
+++ b/testdata/result/statement/!bad_alter_vector_index_set_options_missing_value.sql.txt
@@ -1,0 +1,46 @@
+--- !bad_alter_vector_index_set_options_missing_value.sql
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search =)
+
+--- Error
+syntax error: testdata/input/ddl/!bad_alter_vector_index_set_options_missing_value.sql:1:69: unexpected token: )
+  1|  ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search =)
+   |                                                                      ^
+
+
+--- AST
+&ast.AlterVectorIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 38,
+        Name:    "IncidentVectorIndex",
+      },
+    },
+  },
+  Alteration: &ast.VectorIndexSetOptions{
+    Set:     39,
+    Options: &ast.Options{
+      Options: 43,
+      Rparen:  68,
+      Records: []*ast.OptionsDef{
+        &ast.OptionsDef{
+          Name: &ast.Ident{
+            NamePos: 52,
+            NameEnd: 66,
+            Name:    "disable_search",
+          },
+          Value: &ast.BadExpr{
+            BadNode: &ast.BadNode{
+              NodePos: 68,
+              NodeEnd: 68,
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = )

--- a/testdata/result/statement/alter_vector_index_set_options_false.sql.txt
+++ b/testdata/result/statement/alter_vector_index_set_options_false.sql.txt
@@ -1,0 +1,37 @@
+--- alter_vector_index_set_options_false.sql
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = false)
+
+--- AST
+&ast.AlterVectorIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 38,
+        Name:    "IncidentVectorIndex",
+      },
+    },
+  },
+  Alteration: &ast.VectorIndexSetOptions{
+    Set:     39,
+    Options: &ast.Options{
+      Options: 43,
+      Rparen:  74,
+      Records: []*ast.OptionsDef{
+        &ast.OptionsDef{
+          Name: &ast.Ident{
+            NamePos: 52,
+            NameEnd: 66,
+            Name:    "disable_search",
+          },
+          Value: &ast.BoolLiteral{
+            ValuePos: 69,
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = false)

--- a/testdata/result/statement/alter_vector_index_set_options_null.sql.txt
+++ b/testdata/result/statement/alter_vector_index_set_options_null.sql.txt
@@ -1,0 +1,37 @@
+--- alter_vector_index_set_options_null.sql
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = null)
+
+--- AST
+&ast.AlterVectorIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 38,
+        Name:    "IncidentVectorIndex",
+      },
+    },
+  },
+  Alteration: &ast.VectorIndexSetOptions{
+    Set:     39,
+    Options: &ast.Options{
+      Options: 43,
+      Rparen:  73,
+      Records: []*ast.OptionsDef{
+        &ast.OptionsDef{
+          Name: &ast.Ident{
+            NamePos: 52,
+            NameEnd: 66,
+            Name:    "disable_search",
+          },
+          Value: &ast.NullLiteral{
+            Null: 69,
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = null)

--- a/testdata/result/statement/alter_vector_index_set_options_true.sql.txt
+++ b/testdata/result/statement/alter_vector_index_set_options_true.sql.txt
@@ -1,0 +1,38 @@
+--- alter_vector_index_set_options_true.sql
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = true)
+
+--- AST
+&ast.AlterVectorIndex{
+  Name: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 38,
+        Name:    "IncidentVectorIndex",
+      },
+    },
+  },
+  Alteration: &ast.VectorIndexSetOptions{
+    Set:     39,
+    Options: &ast.Options{
+      Options: 43,
+      Rparen:  73,
+      Records: []*ast.OptionsDef{
+        &ast.OptionsDef{
+          Name: &ast.Ident{
+            NamePos: 52,
+            NameEnd: 66,
+            Name:    "disable_search",
+          },
+          Value: &ast.BoolLiteral{
+            ValuePos: 69,
+            Value:    true,
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+ALTER VECTOR INDEX IncidentVectorIndex SET OPTIONS (disable_search = true)


### PR DESCRIPTION
## Summary

- add `ast.VectorIndexSetOptions` as a `VectorIndexAlteration`;
- parse and unparse `ALTER VECTOR INDEX ... SET OPTIONS (...)`;
- reuse the existing `ast.Options` representation;
- cover the documented `disable_search = true`, `false`, and `null` forms;
- add parser golden tests for every documented `disable_search` value;
- add negative coverage for a missing `OPTIONS` keyword and a missing option
  value.

## Compatibility

This is an additive AST change. Existing `ADD STORED COLUMN` and
`DROP STORED COLUMN` behavior is unchanged.

## Related Issue

- fixes #367