### PR TITLE
fix: avoid panic in token.QuoteSQLIdent("")

### DIFF
--- a/token/quote.go
+++ b/token/quote.go
@@ -112,6 +112,11 @@ func quoteSingleEscape(r, quote rune, isString bool) string {
 }
 
 func needQuoteSQLIdent(s string) bool {
+	// An empty identifier cannot be written without backquotes.
+	if s == "" {
+		return true
+	}
+
 	// When s is keyword, it should be quoted.
 	if IsKeyword(s) {
 		return true

--- a/token/quote.go
+++ b/token/quote.go
@@ -112,7 +112,7 @@ func quoteSingleEscape(r, quote rune, isString bool) string {
 }
 
 func needQuoteSQLIdent(s string) bool {
-	// An empty identifier cannot be written without backquotes.
+	// QuoteSQLIdent formats identifiers without validating them.
 	if s == "" {
 		return true
 	}

--- a/token/quote_test.go
+++ b/token/quote_test.go
@@ -8,6 +8,7 @@ var quoteTestCases = []struct {
 	input          string
 	str, bytes, id string
 }{
+	{"", `""`, `b""`, "``"},
 	{"foo", `"foo"`, `b"foo"`, "foo"},
 	{"if", `"if"`, `b"if"`, "`if`"},
 	{"\u0000", `"\x00"`, `b"\x00"`, "`\\x00`"},


### PR DESCRIPTION
## Summary
- Make `QuoteSQLIdent("")` return two backticks instead of panicking.
- Add regression coverage for the empty input.

## Related Issues

- fixes #406