### PR TITLE
feat: support expression index in CREATE INDEX

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2838,15 +2838,19 @@ type Check struct {
 }
 
 // IndexKey is index key specifier in CREATE TABLE and CREATE INDEX.
+// Note: Expr is only valid in CREATE INDEX.
 //
-//	{{.Name | sql}} {{.Dir}}
+//	{{if .Name}}{{.Name | sql}}{{else}}({{.Expr | sql}}){{end}} {{.Dir}}
 type IndexKey struct {
-	// pos = Name.pos
-	// end = DirPos + len(Dir) || Name.end
+	// pos = Name.pos || Lparen
+	// end = DirPos + len(Dir) || Name.end || Rparen + 1
 
-	DirPos token.Pos // position of Dir
+	DirPos         token.Pos // position of Dir
+	Lparen, Rparen token.Pos // position of "(" and ")" around Expr, optional
 
-	Name *Ident
+	// Name and Expr are mutually exclusive, but one must be set.
+	Name *Ident    // optional
+	Expr Expr      // optional
 	Dir  Direction // optional
 }
 

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -1287,11 +1287,11 @@ func (c *Check) End() token.Pos {
 }
 
 func (i *IndexKey) Pos() token.Pos {
-	return nodePos(wrapNode(i.Name))
+	return posChoice(nodePos(wrapNode(i.Name)), i.Lparen)
 }
 
 func (i *IndexKey) End() token.Pos {
-	return posChoice(posAdd(i.DirPos, len(i.Dir)), nodeEnd(wrapNode(i.Name)))
+	return posChoice(posAdd(i.DirPos, len(i.Dir)), nodeEnd(wrapNode(i.Name)), posAdd(i.Rparen, 1))
 }
 
 func (c *Cluster) Pos() token.Pos {

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -941,7 +941,7 @@ func (a *AutoIncrement) SQL() string {
 }
 
 func (i *IndexKey) SQL() string {
-	return i.Name.SQL() + strOpt(i.Dir != "", " "+string(i.Dir))
+	return sqlOpt("", i.Name, "") + sqlOpt("(", i.Expr, ")") + strOpt(i.Dir != "", " "+string(i.Dir))
 }
 
 func (c *Cluster) SQL() string {

--- a/ast/walk_internal.go
+++ b/ast/walk_internal.go
@@ -592,6 +592,7 @@ func walkInternal(node Node, v Visitor, stack []*stackItem) []*stackItem {
 		stack = append(stack, &stackItem{node: wrapNode(n.Expr), visitor: v.Field("Expr")})
 
 	case *IndexKey:
+		stack = append(stack, &stackItem{node: wrapNode(n.Expr), visitor: v.Field("Expr")})
 		stack = append(stack, &stackItem{node: wrapNode(n.Name), visitor: v.Field("Name")})
 
 	case *Cluster:

--- a/parser.go
+++ b/parser.go
@@ -3902,7 +3902,28 @@ func (p *Parser) parseIndexKey() *ast.IndexKey {
 
 	return &ast.IndexKey{
 		DirPos: dirPos,
+		Lparen: token.InvalidPos,
+		Rparen: token.InvalidPos,
 		Name:   name,
+		Dir:    dir,
+	}
+}
+
+func (p *Parser) parseCreateIndexKey() *ast.IndexKey {
+	if p.Token.Kind != "(" {
+		return p.parseIndexKey()
+	}
+
+	lparen := p.expect("(").Pos
+	expr := p.parseExpr()
+	rparen := p.expect(")").Pos
+	dir, dirPos := p.tryParseDirection()
+
+	return &ast.IndexKey{
+		DirPos: dirPos,
+		Lparen: lparen,
+		Rparen: rparen,
+		Expr:   expr,
 		Dir:    dir,
 	}
 }
@@ -4185,7 +4206,7 @@ func (p *Parser) parseCreateIndex(pos token.Pos) *ast.CreateIndex {
 		if p.Token.Kind == ")" {
 			break
 		}
-		keys = append(keys, p.parseIndexKey())
+		keys = append(keys, p.parseCreateIndexKey())
 		if p.Token.Kind != "," {
 			break
 		}

--- a/testdata/input/ddl/!bad_create_table_primary_key_expr.sql
+++ b/testdata/input/ddl/!bad_create_table_primary_key_expr.sql
@@ -1,0 +1,3 @@
+create table foo (
+  a int64,
+) primary key ((a))

--- a/testdata/input/ddl/create_index_expr.sql
+++ b/testdata/input/ddl/create_index_expr.sql
@@ -1,0 +1,3 @@
+create index VenuesByCity on Venues (
+  (json_value(VenueData.address.city))
+)

--- a/testdata/input/ddl/create_index_expr_dir.sql
+++ b/testdata/input/ddl/create_index_expr_dir.sql
@@ -1,0 +1,3 @@
+create index VenuesByCity on Venues (
+  (json_value(VenueData.address.city)) desc
+)

--- a/testdata/input/ddl/create_index_expr_mixed.sql
+++ b/testdata/input/ddl/create_index_expr_mixed.sql
@@ -1,0 +1,5 @@
+create index VenuesByCityAndName on Venues (
+  (json_value(VenueData.address.city)) asc,
+  VenueName desc,
+  (Rating * 2)
+)

--- a/testdata/input/ddl/create_index_expr_paren_column.sql
+++ b/testdata/input/ddl/create_index_expr_paren_column.sql
@@ -1,0 +1,3 @@
+create index foo_bar on foo (
+  (bar)
+)

--- a/testdata/result/ddl/!bad_create_table_primary_key_expr.sql.txt
+++ b/testdata/result/ddl/!bad_create_table_primary_key_expr.sql.txt
@@ -1,0 +1,127 @@
+--- !bad_create_table_primary_key_expr.sql
+create table foo (
+  a int64,
+) primary key ((a))
+
+--- Error
+syntax error: testdata/input/ddl/!bad_create_table_primary_key_expr.sql:3:16: expected token: <ident>, but: (
+  3|  ) primary key ((a))
+   |                 ^
+
+
+--- AST
+&ast.BadDDL{
+  BadNode: &ast.BadNode{
+    NodeEnd: 49,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind: "CREATE",
+        Raw:  "create",
+        End:  6,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "table",
+        AsString: "table",
+        Pos:      7,
+        End:      12,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      13,
+        End:      16,
+      },
+      &token.Token{
+        Kind:  "(",
+        Space: " ",
+        Raw:   "(",
+        Pos:   17,
+        End:   18,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n  ",
+        Raw:      "a",
+        AsString: "a",
+        Pos:      21,
+        End:      22,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "int64",
+        AsString: "int64",
+        Pos:      23,
+        End:      28,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  28,
+        End:  29,
+      },
+      &token.Token{
+        Kind:  ")",
+        Space: "\n",
+        Raw:   ")",
+        Pos:   30,
+        End:   31,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "primary",
+        AsString: "primary",
+        Pos:      32,
+        End:      39,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "key",
+        AsString: "key",
+        Pos:      40,
+        End:      43,
+      },
+      &token.Token{
+        Kind:  "(",
+        Space: " ",
+        Raw:   "(",
+        Pos:   44,
+        End:   45,
+      },
+      &token.Token{
+        Kind: "(",
+        Raw:  "(",
+        Pos:  45,
+        End:  46,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "a",
+        AsString: "a",
+        Pos:      46,
+        End:      47,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  47,
+        End:  48,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  48,
+        End:  49,
+      },
+    },
+  },
+}
+
+--- SQL
+create table foo ( a int64, ) primary key ((a))

--- a/testdata/result/ddl/create_index_expr.sql.txt
+++ b/testdata/result/ddl/create_index_expr.sql.txt
@@ -1,0 +1,72 @@
+--- create_index_expr.sql
+create index VenuesByCity on Venues (
+  (json_value(VenueData.address.city))
+)
+
+--- AST
+&ast.CreateIndex{
+  Rparen: 77,
+  Name:   &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 25,
+        Name:    "VenuesByCity",
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 29,
+        NameEnd: 35,
+        Name:    "Venues",
+      },
+    },
+  },
+  Keys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Lparen: 40,
+      Rparen: 75,
+      Expr:   &ast.CallExpr{
+        Rparen: 74,
+        Func:   &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 41,
+              NameEnd: 51,
+              Name:    "json_value",
+            },
+          },
+        },
+        Args: []ast.Arg{
+          &ast.ExprArg{
+            Expr: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 52,
+                  NameEnd: 61,
+                  Name:    "VenueData",
+                },
+                &ast.Ident{
+                  NamePos: 62,
+                  NameEnd: 69,
+                  Name:    "address",
+                },
+                &ast.Ident{
+                  NamePos: 70,
+                  NameEnd: 74,
+                  Name:    "city",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE INDEX VenuesByCity ON Venues((json_value(VenueData.address.city)))

--- a/testdata/result/ddl/create_index_expr_dir.sql.txt
+++ b/testdata/result/ddl/create_index_expr_dir.sql.txt
@@ -1,0 +1,73 @@
+--- create_index_expr_dir.sql
+create index VenuesByCity on Venues (
+  (json_value(VenueData.address.city)) desc
+)
+
+--- AST
+&ast.CreateIndex{
+  Rparen: 82,
+  Name:   &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 25,
+        Name:    "VenuesByCity",
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 29,
+        NameEnd: 35,
+        Name:    "Venues",
+      },
+    },
+  },
+  Keys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: 77,
+      Lparen: 40,
+      Rparen: 75,
+      Expr:   &ast.CallExpr{
+        Rparen: 74,
+        Func:   &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 41,
+              NameEnd: 51,
+              Name:    "json_value",
+            },
+          },
+        },
+        Args: []ast.Arg{
+          &ast.ExprArg{
+            Expr: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 52,
+                  NameEnd: 61,
+                  Name:    "VenueData",
+                },
+                &ast.Ident{
+                  NamePos: 62,
+                  NameEnd: 69,
+                  Name:    "address",
+                },
+                &ast.Ident{
+                  NamePos: 70,
+                  NameEnd: 74,
+                  Name:    "city",
+                },
+              },
+            },
+          },
+        },
+      },
+      Dir: "DESC",
+    },
+  },
+}
+
+--- SQL
+CREATE INDEX VenuesByCity ON Venues((json_value(VenueData.address.city)) DESC)

--- a/testdata/result/ddl/create_index_expr_mixed.sql.txt
+++ b/testdata/result/ddl/create_index_expr_mixed.sql.txt
@@ -1,0 +1,105 @@
+--- create_index_expr_mixed.sql
+create index VenuesByCityAndName on Venues (
+  (json_value(VenueData.address.city)) asc,
+  VenueName desc,
+  (Rating * 2)
+)
+
+--- AST
+&ast.CreateIndex{
+  Rparen: 122,
+  Name:   &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 32,
+        Name:    "VenuesByCityAndName",
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 36,
+        NameEnd: 42,
+        Name:    "Venues",
+      },
+    },
+  },
+  Keys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: 84,
+      Lparen: 47,
+      Rparen: 82,
+      Expr:   &ast.CallExpr{
+        Rparen: 81,
+        Func:   &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 48,
+              NameEnd: 58,
+              Name:    "json_value",
+            },
+          },
+        },
+        Args: []ast.Arg{
+          &ast.ExprArg{
+            Expr: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 59,
+                  NameEnd: 68,
+                  Name:    "VenueData",
+                },
+                &ast.Ident{
+                  NamePos: 69,
+                  NameEnd: 76,
+                  Name:    "address",
+                },
+                &ast.Ident{
+                  NamePos: 77,
+                  NameEnd: 81,
+                  Name:    "city",
+                },
+              },
+            },
+          },
+        },
+      },
+      Dir: "ASC",
+    },
+    &ast.IndexKey{
+      DirPos: 101,
+      Lparen: -1,
+      Rparen: -1,
+      Name:   &ast.Ident{
+        NamePos: 91,
+        NameEnd: 100,
+        Name:    "VenueName",
+      },
+      Dir: "DESC",
+    },
+    &ast.IndexKey{
+      DirPos: -1,
+      Lparen: 109,
+      Rparen: 120,
+      Expr:   &ast.BinaryExpr{
+        Op:   "*",
+        Left: &ast.Ident{
+          NamePos: 110,
+          NameEnd: 116,
+          Name:    "Rating",
+        },
+        Right: &ast.IntLiteral{
+          ValuePos: 119,
+          ValueEnd: 120,
+          Base:     10,
+          Value:    "2",
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE INDEX VenuesByCityAndName ON Venues((json_value(VenueData.address.city)) ASC, VenueName DESC, (Rating * 2))

--- a/testdata/result/ddl/create_index_expr_paren_column.sql.txt
+++ b/testdata/result/ddl/create_index_expr_paren_column.sql.txt
@@ -1,12 +1,11 @@
---- create_index.sql
+--- create_index_expr_paren_column.sql
 create index foo_bar on foo (
-  bar desc,
-  baz asc,
+  (bar)
 )
 
 --- AST
 &ast.CreateIndex{
-  Rparen: 53,
+  Rparen: 38,
   Name:   &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
@@ -27,29 +26,17 @@ create index foo_bar on foo (
   },
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
-      DirPos: 36,
-      Lparen: -1,
-      Rparen: -1,
-      Name:   &ast.Ident{
-        NamePos: 32,
-        NameEnd: 35,
+      DirPos: -1,
+      Lparen: 32,
+      Rparen: 36,
+      Expr:   &ast.Ident{
+        NamePos: 33,
+        NameEnd: 36,
         Name:    "bar",
       },
-      Dir: "DESC",
-    },
-    &ast.IndexKey{
-      DirPos: 48,
-      Lparen: -1,
-      Rparen: -1,
-      Name:   &ast.Ident{
-        NamePos: 44,
-        NameEnd: 47,
-        Name:    "baz",
-      },
-      Dir: "ASC",
     },
   },
 }
 
 --- SQL
-CREATE INDEX foo_bar ON foo(bar DESC, baz ASC)
+CREATE INDEX foo_bar ON foo((bar))

--- a/testdata/result/ddl/create_index_if_not_exists.sql.txt
+++ b/testdata/result/ddl/create_index_if_not_exists.sql.txt
@@ -26,6 +26,8 @@ create index if not exists foo_bar on foo (bar)
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 43,
         NameEnd: 46,

--- a/testdata/result/ddl/create_index_interleave.sql.txt
+++ b/testdata/result/ddl/create_index_interleave.sql.txt
@@ -28,6 +28,8 @@ create index foo_bar on foo (
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: 36,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 32,
         NameEnd: 35,

--- a/testdata/result/ddl/create_index_options.sql.txt
+++ b/testdata/result/ddl/create_index_options.sql.txt
@@ -25,6 +25,8 @@ CREATE INDEX SingersByFirstLastName ON Singers(FirstName, LastName)
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 47,
         NameEnd: 56,
@@ -33,6 +35,8 @@ CREATE INDEX SingersByFirstLastName ON Singers(FirstName, LastName)
     },
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 58,
         NameEnd: 66,

--- a/testdata/result/ddl/create_index_storing.sql.txt
+++ b/testdata/result/ddl/create_index_storing.sql.txt
@@ -27,6 +27,8 @@ create index foo_bar on foo (
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: 36,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 32,
         NameEnd: 35,

--- a/testdata/result/ddl/create_index_where.sql.txt
+++ b/testdata/result/ddl/create_index_where.sql.txt
@@ -32,6 +32,8 @@ options (locality_group = 'spill_to_hdd')
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 32,
         NameEnd: 35,
@@ -40,6 +42,8 @@ options (locality_group = 'spill_to_hdd')
     },
     &ast.IndexKey{
       DirPos: 43,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 39,
         NameEnd: 42,

--- a/testdata/result/ddl/create_table.sql.txt
+++ b/testdata/result/ddl/create_table.sql.txt
@@ -540,6 +540,8 @@ create table foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 863,
         NameEnd: 866,
@@ -548,6 +550,8 @@ create table foo (
     },
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 868,
         NameEnd: 871,

--- a/testdata/result/ddl/create_table_anonymous_primary_key.sql.txt
+++ b/testdata/result/ddl/create_table_anonymous_primary_key.sql.txt
@@ -56,6 +56,8 @@ CREATE TABLE PKsTable(
         Columns: []*ast.IndexKey{
           &ast.IndexKey{
             DirPos: -1,
+            Lparen: -1,
+            Rparen: -1,
             Name:   &ast.Ident{
               NamePos: 64,
               NameEnd: 67,
@@ -64,6 +66,8 @@ CREATE TABLE PKsTable(
           },
           &ast.IndexKey{
             DirPos: -1,
+            Lparen: -1,
+            Rparen: -1,
             Name:   &ast.Ident{
               NamePos: 69,
               NameEnd: 72,

--- a/testdata/result/ddl/create_table_cluster_on_delete_no_action.sql.txt
+++ b/testdata/result/ddl/create_table_cluster_on_delete_no_action.sql.txt
@@ -36,6 +36,8 @@ create table foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 47,
         NameEnd: 50,

--- a/testdata/result/ddl/create_table_cluster_set_on_delete.sql.txt
+++ b/testdata/result/ddl/create_table_cluster_set_on_delete.sql.txt
@@ -36,6 +36,8 @@ create table foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 46,
         NameEnd: 49,

--- a/testdata/result/ddl/create_table_cluster_without_parent.sql.txt
+++ b/testdata/result/ddl/create_table_cluster_without_parent.sql.txt
@@ -51,6 +51,8 @@ create table foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 59,
         NameEnd: 62,
@@ -59,6 +61,8 @@ create table foo (
     },
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 64,
         NameEnd: 67,

--- a/testdata/result/ddl/create_table_for_format_test.sql.txt
+++ b/testdata/result/ddl/create_table_for_format_test.sql.txt
@@ -313,6 +313,8 @@ create table if not exists foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 458,
         NameEnd: 461,

--- a/testdata/result/ddl/create_table_fulltext_albums.sql.txt
+++ b/testdata/result/ddl/create_table_fulltext_albums.sql.txt
@@ -185,6 +185,8 @@ CREATE TABLE Albums (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 568,
         NameEnd: 575,

--- a/testdata/result/ddl/create_table_if_not_exists.sql.txt
+++ b/testdata/result/ddl/create_table_if_not_exists.sql.txt
@@ -52,6 +52,8 @@ create table if not exists foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 85,
         NameEnd: 88,
@@ -60,6 +62,8 @@ create table if not exists foo (
     },
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 90,
         NameEnd: 93,

--- a/testdata/result/ddl/create_table_options.sql.txt
+++ b/testdata/result/ddl/create_table_options.sql.txt
@@ -119,6 +119,8 @@ CREATE TABLE Singers (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 195,
         NameEnd: 203,

--- a/testdata/result/ddl/create_table_placement_key.sql.txt
+++ b/testdata/result/ddl/create_table_placement_key.sql.txt
@@ -76,6 +76,8 @@ CREATE TABLE Singers (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 153,
         NameEnd: 161,

--- a/testdata/result/ddl/create_table_synonyms.sql.txt
+++ b/testdata/result/ddl/create_table_synonyms.sql.txt
@@ -58,6 +58,8 @@ CREATE TABLE Singers (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 118,
         NameEnd: 126,

--- a/testdata/result/ddl/create_table_synonyms_abnormal.sql.txt
+++ b/testdata/result/ddl/create_table_synonyms_abnormal.sql.txt
@@ -61,6 +61,8 @@ CREATE TABLE Singers (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 186,
         NameEnd: 194,

--- a/testdata/result/ddl/create_table_trailing_comma.sql.txt
+++ b/testdata/result/ddl/create_table_trailing_comma.sql.txt
@@ -53,6 +53,8 @@ create table foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: 66,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 62,
         NameEnd: 65,
@@ -62,6 +64,8 @@ create table foo (
     },
     &ast.IndexKey{
       DirPos: 77,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 73,
         NameEnd: 76,

--- a/testdata/result/ddl/create_table_types.sql.txt
+++ b/testdata/result/ddl/create_table_types.sql.txt
@@ -581,6 +581,8 @@ create table types (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 795,
         NameEnd: 796,

--- a/testdata/result/ddl/create_table_with_sequence_function.sql.txt
+++ b/testdata/result/ddl/create_table_with_sequence_function.sql.txt
@@ -94,6 +94,8 @@ CREATE TABLE foo
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 141,
         NameEnd: 143,

--- a/testdata/result/ddl/create_uniq_null_filtered_index.sql.txt
+++ b/testdata/result/ddl/create_uniq_null_filtered_index.sql.txt
@@ -27,6 +27,8 @@ create unique null_filtered index foo_bar on foo (foo)
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 50,
         NameEnd: 53,

--- a/testdata/result/ddl/named_schema_create_table_backquoted.sql.txt
+++ b/testdata/result/ddl/named_schema_create_table_backquoted.sql.txt
@@ -37,6 +37,8 @@ CREATE TABLE `ORDER`.`ORDER`(PK INT64) PRIMARY KEY(PK)
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 51,
         NameEnd: 53,

--- a/testdata/result/ddl/named_schemas_create_index.sql.txt
+++ b/testdata/result/ddl/named_schemas_create_index.sql.txt
@@ -34,6 +34,8 @@ CREATE INDEX sch1.indexOnSingers ON sch1.Singers(FirstName)
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 49,
         NameEnd: 58,

--- a/testdata/result/ddl/named_schemas_create_table.sql.txt
+++ b/testdata/result/ddl/named_schemas_create_table.sql.txt
@@ -101,6 +101,8 @@ CREATE TABLE sch1.Singers (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 153,
         NameEnd: 161,

--- a/testdata/result/ddl/named_schemas_create_table_foreign_key.sql.txt
+++ b/testdata/result/ddl/named_schemas_create_table_foreign_key.sql.txt
@@ -131,6 +131,8 @@ CREATE TABLE sch1.ShoppingCarts (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 290,
         NameEnd: 296,

--- a/testdata/result/ddl/named_schemas_create_table_interleave.sql.txt
+++ b/testdata/result/ddl/named_schemas_create_table_interleave.sql.txt
@@ -74,6 +74,8 @@ CREATE TABLE sch1.Albums (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 120,
         NameEnd: 128,
@@ -82,6 +84,8 @@ CREATE TABLE sch1.Albums (
     },
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 130,
         NameEnd: 137,

--- a/testdata/result/statement/!bad_create_table_primary_key_expr.sql.txt
+++ b/testdata/result/statement/!bad_create_table_primary_key_expr.sql.txt
@@ -1,0 +1,127 @@
+--- !bad_create_table_primary_key_expr.sql
+create table foo (
+  a int64,
+) primary key ((a))
+
+--- Error
+syntax error: testdata/input/ddl/!bad_create_table_primary_key_expr.sql:3:16: expected token: <ident>, but: (
+  3|  ) primary key ((a))
+   |                 ^
+
+
+--- AST
+&ast.BadDDL{
+  BadNode: &ast.BadNode{
+    NodeEnd: 49,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind: "CREATE",
+        Raw:  "create",
+        End:  6,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "table",
+        AsString: "table",
+        Pos:      7,
+        End:      12,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      13,
+        End:      16,
+      },
+      &token.Token{
+        Kind:  "(",
+        Space: " ",
+        Raw:   "(",
+        Pos:   17,
+        End:   18,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    "\n  ",
+        Raw:      "a",
+        AsString: "a",
+        Pos:      21,
+        End:      22,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "int64",
+        AsString: "int64",
+        Pos:      23,
+        End:      28,
+      },
+      &token.Token{
+        Kind: ",",
+        Raw:  ",",
+        Pos:  28,
+        End:  29,
+      },
+      &token.Token{
+        Kind:  ")",
+        Space: "\n",
+        Raw:   ")",
+        Pos:   30,
+        End:   31,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "primary",
+        AsString: "primary",
+        Pos:      32,
+        End:      39,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "key",
+        AsString: "key",
+        Pos:      40,
+        End:      43,
+      },
+      &token.Token{
+        Kind:  "(",
+        Space: " ",
+        Raw:   "(",
+        Pos:   44,
+        End:   45,
+      },
+      &token.Token{
+        Kind: "(",
+        Raw:  "(",
+        Pos:  45,
+        End:  46,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Raw:      "a",
+        AsString: "a",
+        Pos:      46,
+        End:      47,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  47,
+        End:  48,
+      },
+      &token.Token{
+        Kind: ")",
+        Raw:  ")",
+        Pos:  48,
+        End:  49,
+      },
+    },
+  },
+}
+
+--- SQL
+create table foo ( a int64, ) primary key ((a))

--- a/testdata/result/statement/create_index.sql.txt
+++ b/testdata/result/statement/create_index.sql.txt
@@ -28,6 +28,8 @@ create index foo_bar on foo (
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: 36,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 32,
         NameEnd: 35,
@@ -37,6 +39,8 @@ create index foo_bar on foo (
     },
     &ast.IndexKey{
       DirPos: 48,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 44,
         NameEnd: 47,

--- a/testdata/result/statement/create_index_expr.sql.txt
+++ b/testdata/result/statement/create_index_expr.sql.txt
@@ -1,0 +1,72 @@
+--- create_index_expr.sql
+create index VenuesByCity on Venues (
+  (json_value(VenueData.address.city))
+)
+
+--- AST
+&ast.CreateIndex{
+  Rparen: 77,
+  Name:   &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 25,
+        Name:    "VenuesByCity",
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 29,
+        NameEnd: 35,
+        Name:    "Venues",
+      },
+    },
+  },
+  Keys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: -1,
+      Lparen: 40,
+      Rparen: 75,
+      Expr:   &ast.CallExpr{
+        Rparen: 74,
+        Func:   &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 41,
+              NameEnd: 51,
+              Name:    "json_value",
+            },
+          },
+        },
+        Args: []ast.Arg{
+          &ast.ExprArg{
+            Expr: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 52,
+                  NameEnd: 61,
+                  Name:    "VenueData",
+                },
+                &ast.Ident{
+                  NamePos: 62,
+                  NameEnd: 69,
+                  Name:    "address",
+                },
+                &ast.Ident{
+                  NamePos: 70,
+                  NameEnd: 74,
+                  Name:    "city",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE INDEX VenuesByCity ON Venues((json_value(VenueData.address.city)))

--- a/testdata/result/statement/create_index_expr_dir.sql.txt
+++ b/testdata/result/statement/create_index_expr_dir.sql.txt
@@ -1,0 +1,73 @@
+--- create_index_expr_dir.sql
+create index VenuesByCity on Venues (
+  (json_value(VenueData.address.city)) desc
+)
+
+--- AST
+&ast.CreateIndex{
+  Rparen: 82,
+  Name:   &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 25,
+        Name:    "VenuesByCity",
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 29,
+        NameEnd: 35,
+        Name:    "Venues",
+      },
+    },
+  },
+  Keys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: 77,
+      Lparen: 40,
+      Rparen: 75,
+      Expr:   &ast.CallExpr{
+        Rparen: 74,
+        Func:   &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 41,
+              NameEnd: 51,
+              Name:    "json_value",
+            },
+          },
+        },
+        Args: []ast.Arg{
+          &ast.ExprArg{
+            Expr: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 52,
+                  NameEnd: 61,
+                  Name:    "VenueData",
+                },
+                &ast.Ident{
+                  NamePos: 62,
+                  NameEnd: 69,
+                  Name:    "address",
+                },
+                &ast.Ident{
+                  NamePos: 70,
+                  NameEnd: 74,
+                  Name:    "city",
+                },
+              },
+            },
+          },
+        },
+      },
+      Dir: "DESC",
+    },
+  },
+}
+
+--- SQL
+CREATE INDEX VenuesByCity ON Venues((json_value(VenueData.address.city)) DESC)

--- a/testdata/result/statement/create_index_expr_mixed.sql.txt
+++ b/testdata/result/statement/create_index_expr_mixed.sql.txt
@@ -1,0 +1,105 @@
+--- create_index_expr_mixed.sql
+create index VenuesByCityAndName on Venues (
+  (json_value(VenueData.address.city)) asc,
+  VenueName desc,
+  (Rating * 2)
+)
+
+--- AST
+&ast.CreateIndex{
+  Rparen: 122,
+  Name:   &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 32,
+        Name:    "VenuesByCityAndName",
+      },
+    },
+  },
+  TableName: &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 36,
+        NameEnd: 42,
+        Name:    "Venues",
+      },
+    },
+  },
+  Keys: []*ast.IndexKey{
+    &ast.IndexKey{
+      DirPos: 84,
+      Lparen: 47,
+      Rparen: 82,
+      Expr:   &ast.CallExpr{
+        Rparen: 81,
+        Func:   &ast.Path{
+          Idents: []*ast.Ident{
+            &ast.Ident{
+              NamePos: 48,
+              NameEnd: 58,
+              Name:    "json_value",
+            },
+          },
+        },
+        Args: []ast.Arg{
+          &ast.ExprArg{
+            Expr: &ast.Path{
+              Idents: []*ast.Ident{
+                &ast.Ident{
+                  NamePos: 59,
+                  NameEnd: 68,
+                  Name:    "VenueData",
+                },
+                &ast.Ident{
+                  NamePos: 69,
+                  NameEnd: 76,
+                  Name:    "address",
+                },
+                &ast.Ident{
+                  NamePos: 77,
+                  NameEnd: 81,
+                  Name:    "city",
+                },
+              },
+            },
+          },
+        },
+      },
+      Dir: "ASC",
+    },
+    &ast.IndexKey{
+      DirPos: 101,
+      Lparen: -1,
+      Rparen: -1,
+      Name:   &ast.Ident{
+        NamePos: 91,
+        NameEnd: 100,
+        Name:    "VenueName",
+      },
+      Dir: "DESC",
+    },
+    &ast.IndexKey{
+      DirPos: -1,
+      Lparen: 109,
+      Rparen: 120,
+      Expr:   &ast.BinaryExpr{
+        Op:   "*",
+        Left: &ast.Ident{
+          NamePos: 110,
+          NameEnd: 116,
+          Name:    "Rating",
+        },
+        Right: &ast.IntLiteral{
+          ValuePos: 119,
+          ValueEnd: 120,
+          Base:     10,
+          Value:    "2",
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE INDEX VenuesByCityAndName ON Venues((json_value(VenueData.address.city)) ASC, VenueName DESC, (Rating * 2))

--- a/testdata/result/statement/create_index_expr_paren_column.sql.txt
+++ b/testdata/result/statement/create_index_expr_paren_column.sql.txt
@@ -1,12 +1,11 @@
---- create_index.sql
+--- create_index_expr_paren_column.sql
 create index foo_bar on foo (
-  bar desc,
-  baz asc,
+  (bar)
 )
 
 --- AST
 &ast.CreateIndex{
-  Rparen: 53,
+  Rparen: 38,
   Name:   &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{
@@ -27,29 +26,17 @@ create index foo_bar on foo (
   },
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
-      DirPos: 36,
-      Lparen: -1,
-      Rparen: -1,
-      Name:   &ast.Ident{
-        NamePos: 32,
-        NameEnd: 35,
+      DirPos: -1,
+      Lparen: 32,
+      Rparen: 36,
+      Expr:   &ast.Ident{
+        NamePos: 33,
+        NameEnd: 36,
         Name:    "bar",
       },
-      Dir: "DESC",
-    },
-    &ast.IndexKey{
-      DirPos: 48,
-      Lparen: -1,
-      Rparen: -1,
-      Name:   &ast.Ident{
-        NamePos: 44,
-        NameEnd: 47,
-        Name:    "baz",
-      },
-      Dir: "ASC",
     },
   },
 }
 
 --- SQL
-CREATE INDEX foo_bar ON foo(bar DESC, baz ASC)
+CREATE INDEX foo_bar ON foo((bar))

--- a/testdata/result/statement/create_index_if_not_exists.sql.txt
+++ b/testdata/result/statement/create_index_if_not_exists.sql.txt
@@ -26,6 +26,8 @@ create index if not exists foo_bar on foo (bar)
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 43,
         NameEnd: 46,

--- a/testdata/result/statement/create_index_interleave.sql.txt
+++ b/testdata/result/statement/create_index_interleave.sql.txt
@@ -28,6 +28,8 @@ create index foo_bar on foo (
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: 36,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 32,
         NameEnd: 35,

--- a/testdata/result/statement/create_index_options.sql.txt
+++ b/testdata/result/statement/create_index_options.sql.txt
@@ -25,6 +25,8 @@ CREATE INDEX SingersByFirstLastName ON Singers(FirstName, LastName)
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 47,
         NameEnd: 56,
@@ -33,6 +35,8 @@ CREATE INDEX SingersByFirstLastName ON Singers(FirstName, LastName)
     },
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 58,
         NameEnd: 66,

--- a/testdata/result/statement/create_index_storing.sql.txt
+++ b/testdata/result/statement/create_index_storing.sql.txt
@@ -27,6 +27,8 @@ create index foo_bar on foo (
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: 36,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 32,
         NameEnd: 35,

--- a/testdata/result/statement/create_index_where.sql.txt
+++ b/testdata/result/statement/create_index_where.sql.txt
@@ -32,6 +32,8 @@ options (locality_group = 'spill_to_hdd')
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 32,
         NameEnd: 35,
@@ -40,6 +42,8 @@ options (locality_group = 'spill_to_hdd')
     },
     &ast.IndexKey{
       DirPos: 43,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 39,
         NameEnd: 42,

--- a/testdata/result/statement/create_table.sql.txt
+++ b/testdata/result/statement/create_table.sql.txt
@@ -540,6 +540,8 @@ create table foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 863,
         NameEnd: 866,
@@ -548,6 +550,8 @@ create table foo (
     },
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 868,
         NameEnd: 871,

--- a/testdata/result/statement/create_table_anonymous_primary_key.sql.txt
+++ b/testdata/result/statement/create_table_anonymous_primary_key.sql.txt
@@ -56,6 +56,8 @@ CREATE TABLE PKsTable(
         Columns: []*ast.IndexKey{
           &ast.IndexKey{
             DirPos: -1,
+            Lparen: -1,
+            Rparen: -1,
             Name:   &ast.Ident{
               NamePos: 64,
               NameEnd: 67,
@@ -64,6 +66,8 @@ CREATE TABLE PKsTable(
           },
           &ast.IndexKey{
             DirPos: -1,
+            Lparen: -1,
+            Rparen: -1,
             Name:   &ast.Ident{
               NamePos: 69,
               NameEnd: 72,

--- a/testdata/result/statement/create_table_cluster_on_delete_no_action.sql.txt
+++ b/testdata/result/statement/create_table_cluster_on_delete_no_action.sql.txt
@@ -36,6 +36,8 @@ create table foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 47,
         NameEnd: 50,

--- a/testdata/result/statement/create_table_cluster_set_on_delete.sql.txt
+++ b/testdata/result/statement/create_table_cluster_set_on_delete.sql.txt
@@ -36,6 +36,8 @@ create table foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 46,
         NameEnd: 49,

--- a/testdata/result/statement/create_table_cluster_without_parent.sql.txt
+++ b/testdata/result/statement/create_table_cluster_without_parent.sql.txt
@@ -51,6 +51,8 @@ create table foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 59,
         NameEnd: 62,
@@ -59,6 +61,8 @@ create table foo (
     },
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 64,
         NameEnd: 67,

--- a/testdata/result/statement/create_table_for_format_test.sql.txt
+++ b/testdata/result/statement/create_table_for_format_test.sql.txt
@@ -313,6 +313,8 @@ create table if not exists foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 458,
         NameEnd: 461,

--- a/testdata/result/statement/create_table_fulltext_albums.sql.txt
+++ b/testdata/result/statement/create_table_fulltext_albums.sql.txt
@@ -185,6 +185,8 @@ CREATE TABLE Albums (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 568,
         NameEnd: 575,

--- a/testdata/result/statement/create_table_if_not_exists.sql.txt
+++ b/testdata/result/statement/create_table_if_not_exists.sql.txt
@@ -52,6 +52,8 @@ create table if not exists foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 85,
         NameEnd: 88,
@@ -60,6 +62,8 @@ create table if not exists foo (
     },
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 90,
         NameEnd: 93,

--- a/testdata/result/statement/create_table_options.sql.txt
+++ b/testdata/result/statement/create_table_options.sql.txt
@@ -119,6 +119,8 @@ CREATE TABLE Singers (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 195,
         NameEnd: 203,

--- a/testdata/result/statement/create_table_placement_key.sql.txt
+++ b/testdata/result/statement/create_table_placement_key.sql.txt
@@ -76,6 +76,8 @@ CREATE TABLE Singers (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 153,
         NameEnd: 161,

--- a/testdata/result/statement/create_table_synonyms.sql.txt
+++ b/testdata/result/statement/create_table_synonyms.sql.txt
@@ -58,6 +58,8 @@ CREATE TABLE Singers (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 118,
         NameEnd: 126,

--- a/testdata/result/statement/create_table_synonyms_abnormal.sql.txt
+++ b/testdata/result/statement/create_table_synonyms_abnormal.sql.txt
@@ -61,6 +61,8 @@ CREATE TABLE Singers (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 186,
         NameEnd: 194,

--- a/testdata/result/statement/create_table_trailing_comma.sql.txt
+++ b/testdata/result/statement/create_table_trailing_comma.sql.txt
@@ -53,6 +53,8 @@ create table foo (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: 66,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 62,
         NameEnd: 65,
@@ -62,6 +64,8 @@ create table foo (
     },
     &ast.IndexKey{
       DirPos: 77,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 73,
         NameEnd: 76,

--- a/testdata/result/statement/create_table_types.sql.txt
+++ b/testdata/result/statement/create_table_types.sql.txt
@@ -581,6 +581,8 @@ create table types (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 795,
         NameEnd: 796,

--- a/testdata/result/statement/create_table_with_sequence_function.sql.txt
+++ b/testdata/result/statement/create_table_with_sequence_function.sql.txt
@@ -94,6 +94,8 @@ CREATE TABLE foo
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 141,
         NameEnd: 143,

--- a/testdata/result/statement/create_uniq_null_filtered_index.sql.txt
+++ b/testdata/result/statement/create_uniq_null_filtered_index.sql.txt
@@ -27,6 +27,8 @@ create unique null_filtered index foo_bar on foo (foo)
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 50,
         NameEnd: 53,

--- a/testdata/result/statement/named_schema_create_table_backquoted.sql.txt
+++ b/testdata/result/statement/named_schema_create_table_backquoted.sql.txt
@@ -37,6 +37,8 @@ CREATE TABLE `ORDER`.`ORDER`(PK INT64) PRIMARY KEY(PK)
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 51,
         NameEnd: 53,

--- a/testdata/result/statement/named_schemas_create_index.sql.txt
+++ b/testdata/result/statement/named_schemas_create_index.sql.txt
@@ -34,6 +34,8 @@ CREATE INDEX sch1.indexOnSingers ON sch1.Singers(FirstName)
   Keys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 49,
         NameEnd: 58,

--- a/testdata/result/statement/named_schemas_create_table.sql.txt
+++ b/testdata/result/statement/named_schemas_create_table.sql.txt
@@ -101,6 +101,8 @@ CREATE TABLE sch1.Singers (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 153,
         NameEnd: 161,

--- a/testdata/result/statement/named_schemas_create_table_foreign_key.sql.txt
+++ b/testdata/result/statement/named_schemas_create_table_foreign_key.sql.txt
@@ -131,6 +131,8 @@ CREATE TABLE sch1.ShoppingCarts (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 290,
         NameEnd: 296,

--- a/testdata/result/statement/named_schemas_create_table_interleave.sql.txt
+++ b/testdata/result/statement/named_schemas_create_table_interleave.sql.txt
@@ -74,6 +74,8 @@ CREATE TABLE sch1.Albums (
   PrimaryKeys: []*ast.IndexKey{
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 120,
         NameEnd: 128,
@@ -82,6 +84,8 @@ CREATE TABLE sch1.Albums (
     },
     &ast.IndexKey{
       DirPos: -1,
+      Lparen: -1,
+      Rparen: -1,
       Name:   &ast.Ident{
         NamePos: 130,
         NameEnd: 137,


### PR DESCRIPTION
Fixes #411

This PR adds support for [expression index](https://cloud.google.com/spanner/docs/secondary-indexes#expression-index) in `CREATE INDEX`.

https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#create_index
```
key_part:
  { column_name | ( expression ) } [ { ASC | DESC } ]
```

```sql
CREATE INDEX VenuesByCity ON Venues((JSON_VALUE(VenueData.address.city)));
```

## Summary

- add `Expr`, `Lparen`, and `Rparen` to `ast.IndexKey`; `Name` and `Expr` are mutually exclusive
- parse `( expression )` key parts only in `CREATE INDEX`; `PRIMARY KEY` in `CREATE TABLE` still rejects them
- add goldens for a single expression key, a directed expression key, mixed column and expression keys, a parenthesized column name, and a `!bad_` case for `PRIMARY KEY ((expr))`

## Note

`IndexKey` keeps `Name *Ident` for column names and gains `Expr Expr` for expression key parts, so existing code that reads `key.Name` keeps working.

The parenthesized expression is parsed as `(` + `parseExpr()` + `)` instead of reusing `parseParenExpr`, because `parseParenExpr` also accepts `(a, b)` as a struct literal and `(SELECT ...)` as a scalar subquery, which the `key_part` grammar does not allow.