### PR TITLE
feat: support INSERT IGNORE and INSERT UPDATE

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -4546,7 +4546,7 @@ type AssertRowsModified struct {
 // Insert is INSERT statement node.
 //
 //	{{.Hint | sqlOpt}}
-//	INSERT {{if .InsertOrType}}OR .InsertOrType{{end}}INTO {{.TableName | sql}}{{.TableHint | sqlOpt}} {{.As | sqlOpt}} ({{.Columns | sqlJoin ","}}) {{.Input | sql}}
+//	INSERT {{if not .Or.Invalid}}OR{{end}} {{.InsertOrType}} INTO {{.TableName | sql}}{{.TableHint | sqlOpt}} {{.As | sqlOpt}} ({{.Columns | sqlJoin ","}}) {{.Input | sql}}
 //	{{.OnConflict | sqlOpt}}
 //	{{.AssertRowsModified | sqlOpt}}
 //	{{.ThenReturn | sqlOpt}}
@@ -4555,6 +4555,7 @@ type Insert struct {
 	// end = (ThenReturn ?? AssertRowsModified ?? OnConflict ?? Input).end
 
 	Insert token.Pos // position of "INSERT" keyword
+	Or     token.Pos // position of "OR" keyword, optional
 
 	InsertOrType InsertOrType
 

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -1478,7 +1478,8 @@ func (a *AssertRowsModified) SQL() string {
 func (i *Insert) SQL() string {
 	return sqlOpt("", i.Hint, " ") +
 		"INSERT " +
-		strOpt(i.InsertOrType != "", "OR "+string(i.InsertOrType)+" ") +
+		strOpt(!i.Or.Invalid(), "OR ") +
+		strOpt(i.InsertOrType != "", string(i.InsertOrType)+" ") +
 		"INTO " + i.TableName.SQL() +
 		sqlOpt("", i.TableHint, "") +
 		sqlOpt(" ", i.As, "") + " (" +

--- a/parser.go
+++ b/parser.go
@@ -6376,16 +6376,19 @@ func (p *Parser) tryParseThenReturn() *ast.ThenReturn {
 
 func (p *Parser) parseInsert(pos token.Pos, hint *ast.Hint, nested bool) *ast.Insert {
 	var insertOrType ast.InsertOrType
-	if p.Token.Kind == "OR" {
+	hasOr := p.Token.Kind == "OR"
+	if hasOr {
 		p.nextToken()
-		switch {
-		case p.Token.IsKeywordLike("UPDATE"):
-			insertOrType = ast.InsertOrTypeUpdate
-		case p.Token.Kind == "IGNORE":
-			insertOrType = ast.InsertOrTypeIgnore
-		default:
-			p.panicfAtToken(&p.Token, "expected pseudo keyword: UPDATE, IGNORE, but: %s", p.Token.AsString)
-		}
+	}
+	switch {
+	case p.Token.IsKeywordLike("UPDATE"):
+		insertOrType = ast.InsertOrTypeUpdate
+	case p.Token.Kind == "IGNORE":
+		insertOrType = ast.InsertOrTypeIgnore
+	case hasOr:
+		p.panicfAtToken(&p.Token, "expected pseudo keyword: UPDATE, IGNORE, but: %s", p.Token.AsString)
+	}
+	if insertOrType != "" {
 		p.nextToken()
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -6376,8 +6376,9 @@ func (p *Parser) tryParseThenReturn() *ast.ThenReturn {
 
 func (p *Parser) parseInsert(pos token.Pos, hint *ast.Hint, nested bool) *ast.Insert {
 	var insertOrType ast.InsertOrType
-	hasOr := p.Token.Kind == "OR"
-	if hasOr {
+	or := token.InvalidPos
+	if p.Token.Kind == "OR" {
+		or = p.Token.Pos
 		p.nextToken()
 	}
 	switch {
@@ -6385,7 +6386,7 @@ func (p *Parser) parseInsert(pos token.Pos, hint *ast.Hint, nested bool) *ast.In
 		insertOrType = ast.InsertOrTypeUpdate
 	case p.Token.Kind == "IGNORE":
 		insertOrType = ast.InsertOrTypeIgnore
-	case hasOr:
+	case !or.Invalid():
 		p.panicfAtToken(&p.Token, "expected pseudo keyword: UPDATE, IGNORE, but: %s", p.Token.AsString)
 	}
 	if insertOrType != "" {
@@ -6434,6 +6435,7 @@ func (p *Parser) parseInsert(pos token.Pos, hint *ast.Hint, nested bool) *ast.In
 
 	return &ast.Insert{
 		Insert:             pos,
+		Or:                 or,
 		Hint:               hint,
 		InsertOrType:       insertOrType,
 		TableName:          name,

--- a/testdata/input/dml/insert_ignore.sql
+++ b/testdata/input/dml/insert_ignore.sql
@@ -1,0 +1,2 @@
+INSERT IGNORE INTO foo
+(foo, bar) VALUES (1, 2)

--- a/testdata/input/dml/insert_update.sql
+++ b/testdata/input/dml/insert_update.sql
@@ -1,0 +1,2 @@
+INSERT UPDATE INTO foo
+(foo, bar) VALUES (1, 2)

--- a/testdata/result/dml/!bad_insert.sql.txt
+++ b/testdata/result/dml/!bad_insert.sql.txt
@@ -10,6 +10,7 @@ syntax error: testdata/input/dml/!bad_insert.sql:2:1: expected beginning of simp
 
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/!bad_insert_with_hint.sql.txt
+++ b/testdata/result/dml/!bad_insert_with_hint.sql.txt
@@ -12,6 +12,7 @@ syntax error: testdata/input/dml/!bad_insert_with_hint.sql:3:1: expected beginni
 --- AST
 &ast.Insert{
   Insert: 26,
+  Or:     -1,
   Hint:   &ast.Hint{
     Rbrace:  24,
     Records: []*ast.HintRecord{

--- a/testdata/result/dml/insert_assert_rows_modified.sql.txt
+++ b/testdata/result/dml/insert_assert_rows_modified.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (x, y) VALUES (1, 2) ASSERT_ROWS_MODIFIED 1
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_cte_select.sql.txt
+++ b/testdata/result/dml/insert_cte_select.sql.txt
@@ -4,6 +4,7 @@ with cte AS (select 1 as foo, 2 as bar)
 select *
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_fqn_values.sql.txt
+++ b/testdata/result/dml/insert_fqn_values.sql.txt
@@ -4,6 +4,7 @@ values (1, 2, 3),
        (4, 5, 6)
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_ignore.sql.txt
+++ b/testdata/result/dml/insert_ignore.sql.txt
@@ -1,0 +1,61 @@
+--- insert_ignore.sql
+INSERT IGNORE INTO foo
+(foo, bar) VALUES (1, 2)
+
+--- AST
+&ast.Insert{
+  InsertOrType: "IGNORE",
+  TableName:    &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 22,
+        Name:    "foo",
+      },
+    },
+  },
+  Columns: []*ast.Ident{
+    &ast.Ident{
+      NamePos: 24,
+      NameEnd: 27,
+      Name:    "foo",
+    },
+    &ast.Ident{
+      NamePos: 29,
+      NameEnd: 32,
+      Name:    "bar",
+    },
+  },
+  Input: &ast.ValuesInput{
+    Values: 34,
+    Rows:   []*ast.ValuesRow{
+      &ast.ValuesRow{
+        Lparen: 41,
+        Rparen: 46,
+        Exprs:  []*ast.DefaultExpr{
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 42,
+              ValueEnd: 43,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 45,
+              ValueEnd: 46,
+              Base:     10,
+              Value:    "2",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+INSERT OR IGNORE INTO foo (foo, bar) VALUES (1, 2)

--- a/testdata/result/dml/insert_ignore.sql.txt
+++ b/testdata/result/dml/insert_ignore.sql.txt
@@ -4,6 +4,7 @@ INSERT IGNORE INTO foo
 
 --- AST
 &ast.Insert{
+  Or:           -1,
   InsertOrType: "IGNORE",
   TableName:    &ast.Path{
     Idents: []*ast.Ident{
@@ -58,4 +59,4 @@ INSERT IGNORE INTO foo
 }
 
 --- SQL
-INSERT OR IGNORE INTO foo (foo, bar) VALUES (1, 2)
+INSERT IGNORE INTO foo (foo, bar) VALUES (1, 2)

--- a/testdata/result/dml/insert_into_values.sql.txt
+++ b/testdata/result/dml/insert_into_values.sql.txt
@@ -4,6 +4,7 @@ values (1, 2, 3),
        (4, 5, 6)
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_on_conflict_assert_rows_modified.sql.txt
+++ b/testdata/result/dml/insert_on_conflict_assert_rows_modified.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (x, y) VALUES (1, 2) ON CONFLICT DO NOTHING ASSERT_ROWS_MODIFIED 1
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_on_conflict_do_nothing.sql.txt
+++ b/testdata/result/dml/insert_on_conflict_do_nothing.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar) VALUES (1, 2) ON CONFLICT DO NOTHING
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_on_conflict_do_nothing_columns.sql.txt
+++ b/testdata/result/dml/insert_on_conflict_do_nothing_columns.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar) VALUES (1, 2) ON CONFLICT (foo) DO NOTHING
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_on_conflict_do_nothing_on_constraint.sql.txt
+++ b/testdata/result/dml/insert_on_conflict_do_nothing_on_constraint.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar) VALUES (1, 2) ON CONFLICT ON UNIQUE CONSTRAINT bar_unique DO NOTHING
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_on_conflict_do_update.sql.txt
+++ b/testdata/result/dml/insert_on_conflict_do_update.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar) VALUES (1, 2) ON CONFLICT (foo) DO UPDATE SET bar = 3
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_on_conflict_do_update_alias.sql.txt
+++ b/testdata/result/dml/insert_on_conflict_do_update_alias.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo AS f (x, y) VALUES (1, 2) ON CONFLICT (x) DO UPDATE SET y = f.y + 1
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_on_conflict_do_update_then_return.sql.txt
+++ b/testdata/result/dml/insert_on_conflict_do_update_then_return.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar) VALUES (1, 2) ON CONFLICT (foo) DO UPDATE SET bar = 3 THEN RETURN *
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_on_conflict_do_update_where.sql.txt
+++ b/testdata/result/dml/insert_on_conflict_do_update_where.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar, baz) VALUES (1, 2, 3) ON CONFLICT (foo) DO UPDATE SET bar = 10, baz = DEFAULT WHERE foo > 0
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_on_conflict_subquery.sql.txt
+++ b/testdata/result/dml/insert_on_conflict_subquery.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar) (SELECT foo, bar FROM bar) ON CONFLICT DO NOTHING
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_or_ignore.sql.txt
+++ b/testdata/result/dml/insert_or_ignore.sql.txt
@@ -3,6 +3,7 @@ INSERT OR IGNORE INTO foo
 (foo, bar) VALUES (1, 2)
 --- AST
 &ast.Insert{
+  Or:           7,
   InsertOrType: "IGNORE",
   TableName:    &ast.Path{
     Idents: []*ast.Ident{

--- a/testdata/result/dml/insert_or_update.sql.txt
+++ b/testdata/result/dml/insert_or_update.sql.txt
@@ -3,6 +3,7 @@ INSERT OR UPDATE INTO foo
 (foo, bar) VALUES (1, 2)
 --- AST
 &ast.Insert{
+  Or:           7,
   InsertOrType: "UPDATE",
   TableName:    &ast.Path{
     Idents: []*ast.Ident{

--- a/testdata/result/dml/insert_or_update_then_return_with_action_as.sql.txt
+++ b/testdata/result/dml/insert_or_update_then_return_with_action_as.sql.txt
@@ -4,6 +4,7 @@ INSERT OR UPDATE INTO foo
 THEN RETURN WITH ACTION AS act *
 --- AST
 &ast.Insert{
+  Or:           7,
   InsertOrType: "UPDATE",
   TableName:    &ast.Path{
     Idents: []*ast.Ident{

--- a/testdata/result/dml/insert_select.sql.txt
+++ b/testdata/result/dml/insert_select.sql.txt
@@ -3,6 +3,7 @@ insert foo (foo, bar)
 select * from unnest([(1, 2), (3, 4)])
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_update.sql.txt
+++ b/testdata/result/dml/insert_update.sql.txt
@@ -1,0 +1,61 @@
+--- insert_update.sql
+INSERT UPDATE INTO foo
+(foo, bar) VALUES (1, 2)
+
+--- AST
+&ast.Insert{
+  InsertOrType: "UPDATE",
+  TableName:    &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 22,
+        Name:    "foo",
+      },
+    },
+  },
+  Columns: []*ast.Ident{
+    &ast.Ident{
+      NamePos: 24,
+      NameEnd: 27,
+      Name:    "foo",
+    },
+    &ast.Ident{
+      NamePos: 29,
+      NameEnd: 32,
+      Name:    "bar",
+    },
+  },
+  Input: &ast.ValuesInput{
+    Values: 34,
+    Rows:   []*ast.ValuesRow{
+      &ast.ValuesRow{
+        Lparen: 41,
+        Rparen: 46,
+        Exprs:  []*ast.DefaultExpr{
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 42,
+              ValueEnd: 43,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 45,
+              ValueEnd: 46,
+              Base:     10,
+              Value:    "2",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+INSERT OR UPDATE INTO foo (foo, bar) VALUES (1, 2)

--- a/testdata/result/dml/insert_update.sql.txt
+++ b/testdata/result/dml/insert_update.sql.txt
@@ -4,6 +4,7 @@ INSERT UPDATE INTO foo
 
 --- AST
 &ast.Insert{
+  Or:           -1,
   InsertOrType: "UPDATE",
   TableName:    &ast.Path{
     Idents: []*ast.Ident{
@@ -58,4 +59,4 @@ INSERT UPDATE INTO foo
 }
 
 --- SQL
-INSERT OR UPDATE INTO foo (foo, bar) VALUES (1, 2)
+INSERT UPDATE INTO foo (foo, bar) VALUES (1, 2)

--- a/testdata/result/dml/insert_values.sql.txt
+++ b/testdata/result/dml/insert_values.sql.txt
@@ -4,6 +4,7 @@ values (1, 2, 3),
        (4, 5, 6)
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_values_default.sql.txt
+++ b/testdata/result/dml/insert_values_default.sql.txt
@@ -3,6 +3,7 @@ insert foo (foo, bar)
 values (1, default)
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/insert_with_hint.sql.txt
+++ b/testdata/result/dml/insert_with_hint.sql.txt
@@ -6,6 +6,7 @@ values (1, 2, 3),
 --- AST
 &ast.Insert{
   Insert: 26,
+  Or:     -1,
   Hint:   &ast.Hint{
     Rbrace:  24,
     Records: []*ast.HintRecord{

--- a/testdata/result/dml/insert_with_sequence_function.sql.txt
+++ b/testdata/result/dml/insert_with_sequence_function.sql.txt
@@ -3,6 +3,7 @@ INSERT INTO foo(bar) VALUES (GET_NEXT_SEQUENCE_VALUE(SEQUENCE my_sequence))
 
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/dml/nested_update_delete_update_insert.sql.txt
+++ b/testdata/result/dml/nested_update_delete_update_insert.sql.txt
@@ -172,6 +172,7 @@ WHERE SingerId = 3 AND s.Albums.title = 'Go! Go! Go!'
       Rparen: 275,
       DML:    &ast.Insert{
         Insert:    210,
+        Or:        -1,
         TableName: &ast.Path{
           Idents: []*ast.Ident{
             &ast.Ident{

--- a/testdata/result/dml/nested_update_insert_song.sql.txt
+++ b/testdata/result/dml/nested_update_insert_song.sql.txt
@@ -28,6 +28,7 @@ WHERE s.SingerId = 5 AND s.AlbumInfo.title = "Fire is Hot"
       Rparen: 105,
       DML:    &ast.Insert{
         Insert:    22,
+        Or:        -1,
         TableName: &ast.Path{
           Idents: []*ast.Ident{
             &ast.Ident{

--- a/testdata/result/dml/nested_update_insert_song_paren_query_input.sql.txt
+++ b/testdata/result/dml/nested_update_insert_song_paren_query_input.sql.txt
@@ -30,6 +30,7 @@ WHERE TRUE
       Rparen: 338,
       DML:    &ast.Insert{
         Insert:    223,
+        Or:        -1,
         TableName: &ast.Path{
           Idents: []*ast.Ident{
             &ast.Ident{

--- a/testdata/result/dml/nested_update_insert_song_path.sql.txt
+++ b/testdata/result/dml/nested_update_insert_song_path.sql.txt
@@ -29,6 +29,7 @@ WHERE s.SingerId = 5 and s.AlbumInfo.title = "Fire is Hot"
       Rparen: 102,
       DML:    &ast.Insert{
         Insert:    22,
+        Or:        -1,
         TableName: &ast.Path{
           Idents: []*ast.Ident{
             &ast.Ident{

--- a/testdata/result/dml/nested_update_insert_string.sql.txt
+++ b/testdata/result/dml/nested_update_insert_string.sql.txt
@@ -28,6 +28,7 @@ WHERE s.SingerId = 5 AND s.AlbumInfo.title = "Fire is Hot"
       Rparen: 73,
       DML:    &ast.Insert{
         Insert:    22,
+        Or:        -1,
         TableName: &ast.Path{
           Idents: []*ast.Ident{
             &ast.Ident{

--- a/testdata/result/dml/nested_update_update_nested_insert.sql.txt
+++ b/testdata/result/dml/nested_update_update_nested_insert.sql.txt
@@ -63,6 +63,7 @@ WHERE s.SingerId = 5
             Rparen: 135,
             DML:    &ast.Insert{
               Insert:    58,
+              Or:        -1,
               TableName: &ast.Path{
                 Idents: []*ast.Ident{
                   &ast.Ident{

--- a/testdata/result/statement/!bad_insert.sql.txt
+++ b/testdata/result/statement/!bad_insert.sql.txt
@@ -10,6 +10,7 @@ syntax error: testdata/input/dml/!bad_insert.sql:2:1: expected beginning of simp
 
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/!bad_insert_with_hint.sql.txt
+++ b/testdata/result/statement/!bad_insert_with_hint.sql.txt
@@ -12,6 +12,7 @@ syntax error: testdata/input/dml/!bad_insert_with_hint.sql:3:1: expected beginni
 --- AST
 &ast.Insert{
   Insert: 26,
+  Or:     -1,
   Hint:   &ast.Hint{
     Rbrace:  24,
     Records: []*ast.HintRecord{

--- a/testdata/result/statement/insert_assert_rows_modified.sql.txt
+++ b/testdata/result/statement/insert_assert_rows_modified.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (x, y) VALUES (1, 2) ASSERT_ROWS_MODIFIED 1
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_cte_select.sql.txt
+++ b/testdata/result/statement/insert_cte_select.sql.txt
@@ -4,6 +4,7 @@ with cte AS (select 1 as foo, 2 as bar)
 select *
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_fqn_values.sql.txt
+++ b/testdata/result/statement/insert_fqn_values.sql.txt
@@ -4,6 +4,7 @@ values (1, 2, 3),
        (4, 5, 6)
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_ignore.sql.txt
+++ b/testdata/result/statement/insert_ignore.sql.txt
@@ -1,0 +1,61 @@
+--- insert_ignore.sql
+INSERT IGNORE INTO foo
+(foo, bar) VALUES (1, 2)
+
+--- AST
+&ast.Insert{
+  InsertOrType: "IGNORE",
+  TableName:    &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 22,
+        Name:    "foo",
+      },
+    },
+  },
+  Columns: []*ast.Ident{
+    &ast.Ident{
+      NamePos: 24,
+      NameEnd: 27,
+      Name:    "foo",
+    },
+    &ast.Ident{
+      NamePos: 29,
+      NameEnd: 32,
+      Name:    "bar",
+    },
+  },
+  Input: &ast.ValuesInput{
+    Values: 34,
+    Rows:   []*ast.ValuesRow{
+      &ast.ValuesRow{
+        Lparen: 41,
+        Rparen: 46,
+        Exprs:  []*ast.DefaultExpr{
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 42,
+              ValueEnd: 43,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 45,
+              ValueEnd: 46,
+              Base:     10,
+              Value:    "2",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+INSERT OR IGNORE INTO foo (foo, bar) VALUES (1, 2)

--- a/testdata/result/statement/insert_ignore.sql.txt
+++ b/testdata/result/statement/insert_ignore.sql.txt
@@ -4,6 +4,7 @@ INSERT IGNORE INTO foo
 
 --- AST
 &ast.Insert{
+  Or:           -1,
   InsertOrType: "IGNORE",
   TableName:    &ast.Path{
     Idents: []*ast.Ident{
@@ -58,4 +59,4 @@ INSERT IGNORE INTO foo
 }
 
 --- SQL
-INSERT OR IGNORE INTO foo (foo, bar) VALUES (1, 2)
+INSERT IGNORE INTO foo (foo, bar) VALUES (1, 2)

--- a/testdata/result/statement/insert_into_values.sql.txt
+++ b/testdata/result/statement/insert_into_values.sql.txt
@@ -4,6 +4,7 @@ values (1, 2, 3),
        (4, 5, 6)
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_on_conflict_assert_rows_modified.sql.txt
+++ b/testdata/result/statement/insert_on_conflict_assert_rows_modified.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (x, y) VALUES (1, 2) ON CONFLICT DO NOTHING ASSERT_ROWS_MODIFIED 1
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_on_conflict_do_nothing.sql.txt
+++ b/testdata/result/statement/insert_on_conflict_do_nothing.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar) VALUES (1, 2) ON CONFLICT DO NOTHING
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_on_conflict_do_nothing_columns.sql.txt
+++ b/testdata/result/statement/insert_on_conflict_do_nothing_columns.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar) VALUES (1, 2) ON CONFLICT (foo) DO NOTHING
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_on_conflict_do_nothing_on_constraint.sql.txt
+++ b/testdata/result/statement/insert_on_conflict_do_nothing_on_constraint.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar) VALUES (1, 2) ON CONFLICT ON UNIQUE CONSTRAINT bar_unique DO NOTHING
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_on_conflict_do_update.sql.txt
+++ b/testdata/result/statement/insert_on_conflict_do_update.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar) VALUES (1, 2) ON CONFLICT (foo) DO UPDATE SET bar = 3
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_on_conflict_do_update_alias.sql.txt
+++ b/testdata/result/statement/insert_on_conflict_do_update_alias.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo AS f (x, y) VALUES (1, 2) ON CONFLICT (x) DO UPDATE SET y = f.y + 1
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_on_conflict_do_update_then_return.sql.txt
+++ b/testdata/result/statement/insert_on_conflict_do_update_then_return.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar) VALUES (1, 2) ON CONFLICT (foo) DO UPDATE SET bar = 3 THEN RETURN *
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_on_conflict_do_update_where.sql.txt
+++ b/testdata/result/statement/insert_on_conflict_do_update_where.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar, baz) VALUES (1, 2, 3) ON CONFLICT (foo) DO UPDATE SET bar = 10, baz = DEFAULT WHERE foo > 0
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_on_conflict_subquery.sql.txt
+++ b/testdata/result/statement/insert_on_conflict_subquery.sql.txt
@@ -2,6 +2,7 @@
 INSERT INTO foo (foo, bar) (SELECT foo, bar FROM bar) ON CONFLICT DO NOTHING
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_or_ignore.sql.txt
+++ b/testdata/result/statement/insert_or_ignore.sql.txt
@@ -3,6 +3,7 @@ INSERT OR IGNORE INTO foo
 (foo, bar) VALUES (1, 2)
 --- AST
 &ast.Insert{
+  Or:           7,
   InsertOrType: "IGNORE",
   TableName:    &ast.Path{
     Idents: []*ast.Ident{

--- a/testdata/result/statement/insert_or_update.sql.txt
+++ b/testdata/result/statement/insert_or_update.sql.txt
@@ -3,6 +3,7 @@ INSERT OR UPDATE INTO foo
 (foo, bar) VALUES (1, 2)
 --- AST
 &ast.Insert{
+  Or:           7,
   InsertOrType: "UPDATE",
   TableName:    &ast.Path{
     Idents: []*ast.Ident{

--- a/testdata/result/statement/insert_or_update_then_return_with_action_as.sql.txt
+++ b/testdata/result/statement/insert_or_update_then_return_with_action_as.sql.txt
@@ -4,6 +4,7 @@ INSERT OR UPDATE INTO foo
 THEN RETURN WITH ACTION AS act *
 --- AST
 &ast.Insert{
+  Or:           7,
   InsertOrType: "UPDATE",
   TableName:    &ast.Path{
     Idents: []*ast.Ident{

--- a/testdata/result/statement/insert_select.sql.txt
+++ b/testdata/result/statement/insert_select.sql.txt
@@ -3,6 +3,7 @@ insert foo (foo, bar)
 select * from unnest([(1, 2), (3, 4)])
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_update.sql.txt
+++ b/testdata/result/statement/insert_update.sql.txt
@@ -1,0 +1,61 @@
+--- insert_update.sql
+INSERT UPDATE INTO foo
+(foo, bar) VALUES (1, 2)
+
+--- AST
+&ast.Insert{
+  InsertOrType: "UPDATE",
+  TableName:    &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 19,
+        NameEnd: 22,
+        Name:    "foo",
+      },
+    },
+  },
+  Columns: []*ast.Ident{
+    &ast.Ident{
+      NamePos: 24,
+      NameEnd: 27,
+      Name:    "foo",
+    },
+    &ast.Ident{
+      NamePos: 29,
+      NameEnd: 32,
+      Name:    "bar",
+    },
+  },
+  Input: &ast.ValuesInput{
+    Values: 34,
+    Rows:   []*ast.ValuesRow{
+      &ast.ValuesRow{
+        Lparen: 41,
+        Rparen: 46,
+        Exprs:  []*ast.DefaultExpr{
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 42,
+              ValueEnd: 43,
+              Base:     10,
+              Value:    "1",
+            },
+          },
+          &ast.DefaultExpr{
+            DefaultPos: -1,
+            Expr:       &ast.IntLiteral{
+              ValuePos: 45,
+              ValueEnd: 46,
+              Base:     10,
+              Value:    "2",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+INSERT OR UPDATE INTO foo (foo, bar) VALUES (1, 2)

--- a/testdata/result/statement/insert_update.sql.txt
+++ b/testdata/result/statement/insert_update.sql.txt
@@ -4,6 +4,7 @@ INSERT UPDATE INTO foo
 
 --- AST
 &ast.Insert{
+  Or:           -1,
   InsertOrType: "UPDATE",
   TableName:    &ast.Path{
     Idents: []*ast.Ident{
@@ -58,4 +59,4 @@ INSERT UPDATE INTO foo
 }
 
 --- SQL
-INSERT OR UPDATE INTO foo (foo, bar) VALUES (1, 2)
+INSERT UPDATE INTO foo (foo, bar) VALUES (1, 2)

--- a/testdata/result/statement/insert_values.sql.txt
+++ b/testdata/result/statement/insert_values.sql.txt
@@ -4,6 +4,7 @@ values (1, 2, 3),
        (4, 5, 6)
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_values_default.sql.txt
+++ b/testdata/result/statement/insert_values_default.sql.txt
@@ -3,6 +3,7 @@ insert foo (foo, bar)
 values (1, default)
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/insert_with_hint.sql.txt
+++ b/testdata/result/statement/insert_with_hint.sql.txt
@@ -6,6 +6,7 @@ values (1, 2, 3),
 --- AST
 &ast.Insert{
   Insert: 26,
+  Or:     -1,
   Hint:   &ast.Hint{
     Rbrace:  24,
     Records: []*ast.HintRecord{

--- a/testdata/result/statement/insert_with_sequence_function.sql.txt
+++ b/testdata/result/statement/insert_with_sequence_function.sql.txt
@@ -3,6 +3,7 @@ INSERT INTO foo(bar) VALUES (GET_NEXT_SEQUENCE_VALUE(SEQUENCE my_sequence))
 
 --- AST
 &ast.Insert{
+  Or:        -1,
   TableName: &ast.Path{
     Idents: []*ast.Ident{
       &ast.Ident{

--- a/testdata/result/statement/nested_update_delete_update_insert.sql.txt
+++ b/testdata/result/statement/nested_update_delete_update_insert.sql.txt
@@ -172,6 +172,7 @@ WHERE SingerId = 3 AND s.Albums.title = 'Go! Go! Go!'
       Rparen: 275,
       DML:    &ast.Insert{
         Insert:    210,
+        Or:        -1,
         TableName: &ast.Path{
           Idents: []*ast.Ident{
             &ast.Ident{

--- a/testdata/result/statement/nested_update_insert_song.sql.txt
+++ b/testdata/result/statement/nested_update_insert_song.sql.txt
@@ -28,6 +28,7 @@ WHERE s.SingerId = 5 AND s.AlbumInfo.title = "Fire is Hot"
       Rparen: 105,
       DML:    &ast.Insert{
         Insert:    22,
+        Or:        -1,
         TableName: &ast.Path{
           Idents: []*ast.Ident{
             &ast.Ident{

--- a/testdata/result/statement/nested_update_insert_song_paren_query_input.sql.txt
+++ b/testdata/result/statement/nested_update_insert_song_paren_query_input.sql.txt
@@ -30,6 +30,7 @@ WHERE TRUE
       Rparen: 338,
       DML:    &ast.Insert{
         Insert:    223,
+        Or:        -1,
         TableName: &ast.Path{
           Idents: []*ast.Ident{
             &ast.Ident{

--- a/testdata/result/statement/nested_update_insert_song_path.sql.txt
+++ b/testdata/result/statement/nested_update_insert_song_path.sql.txt
@@ -29,6 +29,7 @@ WHERE s.SingerId = 5 and s.AlbumInfo.title = "Fire is Hot"
       Rparen: 102,
       DML:    &ast.Insert{
         Insert:    22,
+        Or:        -1,
         TableName: &ast.Path{
           Idents: []*ast.Ident{
             &ast.Ident{

--- a/testdata/result/statement/nested_update_insert_string.sql.txt
+++ b/testdata/result/statement/nested_update_insert_string.sql.txt
@@ -28,6 +28,7 @@ WHERE s.SingerId = 5 AND s.AlbumInfo.title = "Fire is Hot"
       Rparen: 73,
       DML:    &ast.Insert{
         Insert:    22,
+        Or:        -1,
         TableName: &ast.Path{
           Idents: []*ast.Ident{
             &ast.Ident{

--- a/testdata/result/statement/nested_update_update_nested_insert.sql.txt
+++ b/testdata/result/statement/nested_update_update_nested_insert.sql.txt
@@ -63,6 +63,7 @@ WHERE s.SingerId = 5
             Rparen: 135,
             DML:    &ast.Insert{
               Insert:    58,
+              Or:        -1,
               TableName: &ast.Path{
                 Idents: []*ast.Ident{
                   &ast.Ident{


### PR DESCRIPTION
Support `INSERT IGNORE` and `INSERT UPDATE` without `OR`, preserving the presence and position of `OR` in `Insert.Or` when unparsing.

Closes #401.
