### PR TITLE
feat: add pipe LIMIT

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -155,6 +155,7 @@ type PipeOperator interface {
 func (PipeSelect) isPipeOperator() {}
 func (PipeWhere) isPipeOperator()  {}
 func (PipeAs) isPipeOperator()     {}
+func (PipeLimit) isPipeOperator()  {}
 
 // SelectItem represents expression in SELECT clause result columns list.
 type SelectItem interface {
@@ -1178,6 +1179,19 @@ type PipeAs struct {
 
 	Pipe  token.Pos // position of "|>"
 	Alias *Ident
+}
+
+// PipeLimit is LIMIT pipe operator node.
+//
+//	|> LIMIT {{.Count | sql}} {{.Offset | sqlOpt}}
+type PipeLimit struct {
+	// pos = Pipe
+	// end = (Offset ?? Count).end
+
+	Pipe token.Pos // position of "|>"
+
+	Count  IntValue
+	Offset *Offset // optional
 }
 
 // ================================================================================

--- a/ast/pos.go
+++ b/ast/pos.go
@@ -334,6 +334,14 @@ func (p *PipeAs) End() token.Pos {
 	return nodeEnd(wrapNode(p.Alias))
 }
 
+func (p *PipeLimit) Pos() token.Pos {
+	return p.Pipe
+}
+
+func (p *PipeLimit) End() token.Pos {
+	return nodeEnd(nodeChoice(wrapNode(p.Offset), wrapNode(p.Count)))
+}
+
 func (u *Unnest) Pos() token.Pos {
 	return u.Unnest
 }

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -332,6 +332,10 @@ func (p *PipeWhere) SQL() string {
 
 func (p *PipeAs) SQL() string { return "|> AS " + p.Alias.SQL() }
 
+func (p *PipeLimit) SQL() string {
+	return "|> LIMIT " + p.Count.SQL() + sqlOpt(" ", p.Offset, "")
+}
+
 // ================================================================================
 //
 // JOIN

--- a/ast/walk_internal.go
+++ b/ast/walk_internal.go
@@ -152,6 +152,10 @@ func walkInternal(node Node, v Visitor, stack []*stackItem) []*stackItem {
 	case *PipeAs:
 		stack = append(stack, &stackItem{node: wrapNode(n.Alias), visitor: v.Field("Alias")})
 
+	case *PipeLimit:
+		stack = append(stack, &stackItem{node: wrapNode(n.Offset), visitor: v.Field("Offset")})
+		stack = append(stack, &stackItem{node: wrapNode(n.Count), visitor: v.Field("Count")})
+
 	case *Unnest:
 		stack = append(stack, &stackItem{node: wrapNode(n.Sample), visitor: v.Field("Sample")})
 		stack = append(stack, &stackItem{node: wrapNode(n.WithOffset), visitor: v.Field("WithOffset")})

--- a/parser.go
+++ b/parser.go
@@ -431,6 +431,13 @@ func (p *Parser) parsePipeOperator() ast.PipeOperator {
 	case "AS":
 		p.nextToken()
 		return &ast.PipeAs{Pipe: pos, Alias: p.parseIdent()}
+	case "LIMIT":
+		p.nextToken()
+		return &ast.PipeLimit{
+			Pipe:   pos,
+			Count:  p.parseIntValue(),
+			Offset: p.tryParseOffset(),
+		}
 	default:
 		panic(p.errorfAtToken(&p.Token, "expected pipe operator name, but: %q", p.Token.AsString))
 	}

--- a/testdata/input/query/pipe_limit.sql
+++ b/testdata/input/query/pipe_limit.sql
@@ -1,0 +1,1 @@
+FROM t |> LIMIT 1 OFFSET 2

--- a/testdata/input/query/pipe_limit_minimal.sql
+++ b/testdata/input/query/pipe_limit_minimal.sql
@@ -1,0 +1,1 @@
+FROM t |> LIMIT 1

--- a/testdata/result/query/pipe_limit.sql.txt
+++ b/testdata/result/query/pipe_limit.sql.txt
@@ -1,0 +1,42 @@
+--- pipe_limit.sql
+FROM t |> LIMIT 1 OFFSET 2
+
+--- AST
+&ast.QueryStatement{
+  Query: &ast.Query{
+    Query: &ast.FromQuery{
+      From: &ast.From{
+        Source: &ast.TableName{
+          Table: &ast.Ident{
+            NamePos: 5,
+            NameEnd: 6,
+            Name:    "t",
+          },
+        },
+      },
+    },
+    PipeOperators: []ast.PipeOperator{
+      &ast.PipeLimit{
+        Pipe:  7,
+        Count: &ast.IntLiteral{
+          ValuePos: 16,
+          ValueEnd: 17,
+          Base:     10,
+          Value:    "1",
+        },
+        Offset: &ast.Offset{
+          Offset: 18,
+          Value:  &ast.IntLiteral{
+            ValuePos: 25,
+            ValueEnd: 26,
+            Base:     10,
+            Value:    "2",
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+FROM t |> LIMIT 1 OFFSET 2

--- a/testdata/result/query/pipe_limit_minimal.sql.txt
+++ b/testdata/result/query/pipe_limit_minimal.sql.txt
@@ -1,0 +1,33 @@
+--- pipe_limit_minimal.sql
+FROM t |> LIMIT 1
+
+--- AST
+&ast.QueryStatement{
+  Query: &ast.Query{
+    Query: &ast.FromQuery{
+      From: &ast.From{
+        Source: &ast.TableName{
+          Table: &ast.Ident{
+            NamePos: 5,
+            NameEnd: 6,
+            Name:    "t",
+          },
+        },
+      },
+    },
+    PipeOperators: []ast.PipeOperator{
+      &ast.PipeLimit{
+        Pipe:  7,
+        Count: &ast.IntLiteral{
+          ValuePos: 16,
+          ValueEnd: 17,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+FROM t |> LIMIT 1

--- a/testdata/result/statement/pipe_limit.sql.txt
+++ b/testdata/result/statement/pipe_limit.sql.txt
@@ -1,0 +1,42 @@
+--- pipe_limit.sql
+FROM t |> LIMIT 1 OFFSET 2
+
+--- AST
+&ast.QueryStatement{
+  Query: &ast.Query{
+    Query: &ast.FromQuery{
+      From: &ast.From{
+        Source: &ast.TableName{
+          Table: &ast.Ident{
+            NamePos: 5,
+            NameEnd: 6,
+            Name:    "t",
+          },
+        },
+      },
+    },
+    PipeOperators: []ast.PipeOperator{
+      &ast.PipeLimit{
+        Pipe:  7,
+        Count: &ast.IntLiteral{
+          ValuePos: 16,
+          ValueEnd: 17,
+          Base:     10,
+          Value:    "1",
+        },
+        Offset: &ast.Offset{
+          Offset: 18,
+          Value:  &ast.IntLiteral{
+            ValuePos: 25,
+            ValueEnd: 26,
+            Base:     10,
+            Value:    "2",
+          },
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+FROM t |> LIMIT 1 OFFSET 2

--- a/testdata/result/statement/pipe_limit_minimal.sql.txt
+++ b/testdata/result/statement/pipe_limit_minimal.sql.txt
@@ -1,0 +1,33 @@
+--- pipe_limit_minimal.sql
+FROM t |> LIMIT 1
+
+--- AST
+&ast.QueryStatement{
+  Query: &ast.Query{
+    Query: &ast.FromQuery{
+      From: &ast.From{
+        Source: &ast.TableName{
+          Table: &ast.Ident{
+            NamePos: 5,
+            NameEnd: 6,
+            Name:    "t",
+          },
+        },
+      },
+    },
+    PipeOperators: []ast.PipeOperator{
+      &ast.PipeLimit{
+        Pipe:  7,
+        Count: &ast.IntLiteral{
+          ValuePos: 16,
+          ValueEnd: 17,
+          Base:     10,
+          Value:    "1",
+        },
+      },
+    },
+  },
+}
+
+--- SQL
+FROM t |> LIMIT 1


### PR DESCRIPTION
This PR adds support for `LIMIT` pipe operator.
https://docs.cloud.google.com/spanner/docs/reference/standard-sql/pipe-syntax?hl=en#limit_pipe_operator
```
|> LIMIT count [OFFSET skip_rows]
```

- part of #408 