### PR TITLE
Update Go toolchain to `1.27.1` and golangci-lint to `v2.13.2`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
       with:
-        go-version: "1.26"
+        go-version-file: go.mod
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Get dependencies
       run: |

--- a/Makefile
+++ b/Makefile
@@ -64,4 +64,4 @@ update-mod:
 install-dep: bin/golangci-lint
 
 bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(CURDIR)/bin v2.11.4
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(CURDIR)/bin v2.13.2

--- a/Makefile
+++ b/Makefile
@@ -64,4 +64,4 @@ update-mod:
 install-dep: bin/golangci-lint
 
 bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(CURDIR)/bin v2.13.2
+	GOBIN=$(CURDIR)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"iter"
+	"slices"
 )
 
 //go:generate go run ../tools/gen-ast-walk/main.go -astfile ast.go -constfile ast_const.go -outfile walk_internal.go
@@ -43,8 +44,8 @@ func walkMain(stack []*stackItem) {
 
 		if last.nodes != nil {
 			v := last.visitor.VisitMany(last.nodes)
-			for i := len(last.nodes) - 1; i >= 0; i-- {
-				stack = append(stack, &stackItem{node: last.nodes[i], visitor: v.Index(i)})
+			for i, n := range slices.Backward(last.nodes) {
+				stack = append(stack, &stackItem{node: n, visitor: v.Index(i)})
 			}
 			continue
 		}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cloudspannerecosystem/memefish
 
 go 1.25.0
 
-toolchain go1.26.6
+toolchain go1.27.1
 
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1

--- a/tools/gen-ast-walk/main.go
+++ b/tools/gen-ast-walk/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 	"sort"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -70,9 +71,7 @@ func main() {
 
 		output := false
 
-		for i := len(structDef.Fields) - 1; i >= 0; i-- {
-			field := structDef.Fields[i]
-
+		for _, field := range slices.Backward(structDef.Fields) {
 			if _, ok := extractNodeStructPointer(field.Type); ok {
 				fmt.Fprintf(&buffer, "\t\tstack = append(stack, &stackItem{node: wrapNode(n.%s), visitor: v.Field(%q)})\n", field.Name, field.Name)
 				output = true

--- a/tools/parse/main.go
+++ b/tools/parse/main.go
@@ -126,7 +126,7 @@ func main() {
 			value = value.Elem().FieldByName(name)
 		}
 
-		if n, ok := value.Interface().(ast.Node); ok {
+		if n, ok := reflect.TypeAssert[ast.Node](value); ok {
 			node = n
 		} else {
 			log.Fatalf("invalid value: %#v", value)

--- a/tools/util/poslang/expr.go
+++ b/tools/util/poslang/expr.go
@@ -150,7 +150,7 @@ func (v *Var) EvalNode(x any) node {
 		return nil
 	}
 
-	node, ok := field.Interface().(node)
+	node, ok := reflect.TypeAssert[node](field)
 	if !ok {
 		panic("cannot convert the value to an AST node")
 	}
@@ -181,7 +181,7 @@ func (v *Var) EvalNodeSlice(x any) []node {
 		}
 
 		var ok bool
-		nodes[i], ok = item.Interface().(node)
+		nodes[i], ok = reflect.TypeAssert[node](item)
 		if !ok {
 			panic("cannot convert the value to an AST node")
 		}


### PR DESCRIPTION
Close #410.

Renovate's #410 bumps the Go toolchain, but its CI fails because `bin/golangci-lint` is pinned to v2.11.4 (built with go1.26), which refuses to analyze a `toolchain go1.27.1` module:

```
Error: can't load config: the Go language version (go1.26) used to build golangci-lint is lower than the targeted Go version (1.27.1)
```

Renovate can't fix this itself because the golangci-lint version lives inside a `curl` command in the Makefile. This PR updates both together, superseding #410 (Renovate should close it automatically once this merges):

- **go.mod**: `toolchain go1.26.6` → `go1.27.1`
- **Makefile**: golangci-lint v2.11.4 → v2.13.2 (go1.27 support landed in v2.13.0)
- **go.yml**: use `go-version-file: go.mod` instead of a hard-coded `go-version: "1.26"`, and move checkout before setup-go (required for `go-version-file`; also fixes the existing "Restore cache failed: go.mod not found" warning caused by the old step order). With this, future toolchain bumps only touch `go.mod`, so Renovate PRs no longer modify workflow files — which also keeps them clear of the zizmor changed-file checks.
- **Makefile**: install golangci-lint via `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2` instead of the `install.sh` curl script. The script from `master` currently fails checksum verification for all v2.13.x releases: their `checksums.txt` now also lists `*.tar.gz.sbom.json` entries, and the script's basename grep matches the sbom line. `go install` is deterministic (verified via the Go module checksum database) and has no such parsing issue.

- **Lint fixes**: golangci-lint v2.13.2's updated `modernize` linter reported 4 new findings (`slices.Backward` for backward loops in `ast/walk.go` / `tools/gen-ast-walk`, `reflect.TypeAssert` in `tools/parse` / `tools/util/poslang`); applied via `golangci-lint run --fix` with minor cleanups. `check-gen` confirms generated code is unchanged.

Verified locally: `make ci` (check-gen, lint with v2.13.2, tests) passes on go1.27.1.
