### PR TITLE
Reject braced constructor field without value

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -3171,6 +3171,8 @@ func (p *Parser) parseBracedNewConstructorField() *ast.BracedConstructorField {
 		fieldValue = &ast.BracedConstructorFieldValueExpr{Colon: colon, Expr: expr}
 	case "{":
 		fieldValue = p.parseBracedConstructor()
+	default:
+		p.panicfAtToken(&p.Token, "expected token: {, :, but: %s", p.Token.Kind)
 	}
 	return &ast.BracedConstructorField{Name: name, Value: fieldValue}
 }

--- a/parser.go
+++ b/parser.go
@@ -7001,7 +7001,7 @@ skip:
 		switch p.Token.Kind {
 		case ";":
 			break skip
-		case "(", "[", "CASE", "WHEN":
+		case "(", "[", "{", "CASE", "WHEN":
 			nesting += 1
 		case ")", "]", "}", "END", "THEN":
 			if nesting == 0 {

--- a/testdata/input/expr/!bad_new_braced_constructor_field_without_value.sql
+++ b/testdata/input/expr/!bad_new_braced_constructor_field_without_value.sql
@@ -1,0 +1,1 @@
+NEW foo { bar }

--- a/testdata/result/expr/!bad_new_braced_constructor_field_without_value.sql.txt
+++ b/testdata/result/expr/!bad_new_braced_constructor_field_without_value.sql.txt
@@ -1,0 +1,51 @@
+--- !bad_new_braced_constructor_field_without_value.sql
+NEW foo { bar }
+
+--- Error
+syntax error: testdata/input/expr/!bad_new_braced_constructor_field_without_value.sql:1:15: expected token: {, :, but: }
+  1|  NEW foo { bar }
+   |                ^
+syntax error: testdata/input/expr/!bad_new_braced_constructor_field_without_value.sql:1:15: expected token: <eof>, but: }
+  1|  NEW foo { bar }
+   |                ^
+
+
+--- AST
+&ast.BadExpr{
+  BadNode: &ast.BadNode{
+    NodeEnd: 13,
+    Tokens:  []*token.Token{
+      &token.Token{
+        Kind: "NEW",
+        Raw:  "NEW",
+        End:  3,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "foo",
+        AsString: "foo",
+        Pos:      4,
+        End:      7,
+      },
+      &token.Token{
+        Kind:  "{",
+        Space: " ",
+        Raw:   "{",
+        Pos:   8,
+        End:   9,
+      },
+      &token.Token{
+        Kind:     "<ident>",
+        Space:    " ",
+        Raw:      "bar",
+        AsString: "bar",
+        Pos:      10,
+        End:      13,
+      },
+    },
+  },
+}
+
+--- SQL
+NEW foo { bar

--- a/testdata/result/expr/!bad_new_braced_constructor_field_without_value.sql.txt
+++ b/testdata/result/expr/!bad_new_braced_constructor_field_without_value.sql.txt
@@ -5,15 +5,12 @@ NEW foo { bar }
 syntax error: testdata/input/expr/!bad_new_braced_constructor_field_without_value.sql:1:15: expected token: {, :, but: }
   1|  NEW foo { bar }
    |                ^
-syntax error: testdata/input/expr/!bad_new_braced_constructor_field_without_value.sql:1:15: expected token: <eof>, but: }
-  1|  NEW foo { bar }
-   |                ^
 
 
 --- AST
 &ast.BadExpr{
   BadNode: &ast.BadNode{
-    NodeEnd: 13,
+    NodeEnd: 15,
     Tokens:  []*token.Token{
       &token.Token{
         Kind: "NEW",
@@ -43,9 +40,16 @@ syntax error: testdata/input/expr/!bad_new_braced_constructor_field_without_valu
         Pos:      10,
         End:      13,
       },
+      &token.Token{
+        Kind:  "}",
+        Space: " ",
+        Raw:   "}",
+        Pos:   14,
+        End:   15,
+      },
     },
   },
 }
 
 --- SQL
-NEW foo { bar
+NEW foo { bar }

--- a/testdata/result/gql/!bad_exists_braced_match_continuation.sql.txt
+++ b/testdata/result/gql/!bad_exists_braced_match_continuation.sql.txt
@@ -15,9 +15,6 @@ syntax error: testdata/input/gql/!bad_exists_braced_match_continuation.sql:5:1: 
 syntax error: testdata/input/gql/!bad_exists_braced_match_continuation.sql:6:1: expected token: }, but: <eof>
   6|  
    |  ^
-syntax error: testdata/input/gql/!bad_exists_braced_match_continuation.sql:5:1: expected token: <eof>, but: }
-  5|  }
-   |  ^
 
 
 --- AST
@@ -45,7 +42,7 @@ syntax error: testdata/input/gql/!bad_exists_braced_match_continuation.sql:5:1: 
                 Expr: &ast.BadExpr{
                   BadNode: &ast.BadNode{
                     NodePos: 22,
-                    NodeEnd: 51,
+                    NodeEnd: 53,
                     Tokens:  []*token.Token{
                       &token.Token{
                         Kind:  "EXISTS",
@@ -97,6 +94,13 @@ syntax error: testdata/input/gql/!bad_exists_braced_match_continuation.sql:5:1: 
                         Pos:      45,
                         End:      51,
                       },
+                      &token.Token{
+                        Kind:  "}",
+                        Space: "\n",
+                        Raw:   "}",
+                        Pos:   52,
+                        End:   53,
+                      },
                     },
                   },
                 },
@@ -110,4 +114,4 @@ syntax error: testdata/input/gql/!bad_exists_braced_match_continuation.sql:5:1: 
 }
 
 --- SQL
-GRAPH FinGraph RETURN EXISTS { MATCH (a) FILTER
+GRAPH FinGraph RETURN EXISTS { MATCH (a) FILTER }

--- a/testdata/result/statement/!bad_exists_braced_match_continuation.sql.txt
+++ b/testdata/result/statement/!bad_exists_braced_match_continuation.sql.txt
@@ -15,9 +15,6 @@ syntax error: testdata/input/gql/!bad_exists_braced_match_continuation.sql:5:1: 
 syntax error: testdata/input/gql/!bad_exists_braced_match_continuation.sql:6:1: expected token: }, but: <eof>
   6|  
    |  ^
-syntax error: testdata/input/gql/!bad_exists_braced_match_continuation.sql:5:1: expected token: <eof>, but: }
-  5|  }
-   |  ^
 
 
 --- AST
@@ -45,7 +42,7 @@ syntax error: testdata/input/gql/!bad_exists_braced_match_continuation.sql:5:1: 
                 Expr: &ast.BadExpr{
                   BadNode: &ast.BadNode{
                     NodePos: 22,
-                    NodeEnd: 51,
+                    NodeEnd: 53,
                     Tokens:  []*token.Token{
                       &token.Token{
                         Kind:  "EXISTS",
@@ -97,6 +94,13 @@ syntax error: testdata/input/gql/!bad_exists_braced_match_continuation.sql:5:1: 
                         Pos:      45,
                         End:      51,
                       },
+                      &token.Token{
+                        Kind:  "}",
+                        Space: "\n",
+                        Raw:   "}",
+                        Pos:   52,
+                        End:   53,
+                      },
                     },
                   },
                 },
@@ -110,4 +114,4 @@ syntax error: testdata/input/gql/!bad_exists_braced_match_continuation.sql:5:1: 
 }
 
 --- SQL
-GRAPH FinGraph RETURN EXISTS { MATCH (a) FILTER
+GRAPH FinGraph RETURN EXISTS { MATCH (a) FILTER }


### PR DESCRIPTION
Fixes #418.

`parseBracedNewConstructorField` switched on `:` and `{` but had no `default` case, so a field followed by anything else (e.g. `NEW A00{A0}`, where the field is followed by `}`) produced a `BracedConstructorField` with a nil `Value` — and `err == nil`. `SQL()` and the position accessors then dereferenced the nil value and panicked.

A braced constructor field requires a value, so the parser now reports it as a syntax error:

```
syntax error: :1:15: expected token: {, :, but: }
  1|  NEW foo { bar }
   |                ^
```

Error recovery wraps the expression in an `ast.BadExpr` as usual.

## Tests

- New testdata case `testdata/input/expr/!bad_new_braced_constructor_field_without_value.sql` (`NEW foo { bar }`) with its generated result, alongside the existing `!bad_new_braced_constructor.sql`.
