### PR TITLE
fix: preserve empty primary keys

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2664,7 +2664,7 @@ type DropProtoBundle struct {
 //	  {{.TableConstraints | sqlJoin ","}}{{if and .TableConstraints .Synonym}},{{end}}
 //	  {{.Synonym | sqlJoin ","}}
 //	)
-//	{{if .PrimaryKeys}}PRIMARY KEY ({{.PrimaryKeys | sqlJoin ","}}){{end}}
+//	{{if .PrimaryKeys | isnil | not}}PRIMARY KEY ({{.PrimaryKeys | sqlJoin ","}}){{end}}
 //	{{.Cluster | sqlOpt}}
 //	{{.CreateRowDeletionPolicy | sqlOpt}}
 //	{{if .Options}}, {{.Options | sqlOpt}}{{end}}
@@ -2684,7 +2684,7 @@ type CreateTable struct {
 	Name              *Path
 	Columns           []*ColumnDef
 	TableConstraints  []*TableConstraint
-	PrimaryKeys       []*IndexKey // when omitted, len(PrimaryKeys) = 0
+	PrimaryKeys       []*IndexKey // nil when omitted; non-nil empty slice for PRIMARY KEY ()
 	Synonyms          []*Synonym
 	Cluster           *Cluster                 // optional
 	RowDeletionPolicy *CreateRowDeletionPolicy // optional

--- a/ast/sql.go
+++ b/ast/sql.go
@@ -861,7 +861,7 @@ func (c *CreateTable) SQL() string {
 		strOpt(len(c.TableConstraints) > 0, indent) + sqlJoin(c.TableConstraints, ",\n"+indent) + strOpt(len(c.TableConstraints) > 0 && len(c.Synonyms) > 0, ",\n") +
 		strOpt(len(c.Synonyms) > 0, indent) + sqlJoin(c.Synonyms, ",\n") +
 		"\n)" +
-		strOpt(len(c.PrimaryKeys) > 0, " PRIMARY KEY ("+sqlJoin(c.PrimaryKeys, ", ")+")") +
+		strOpt(c.PrimaryKeys != nil, " PRIMARY KEY ("+sqlJoin(c.PrimaryKeys, ", ")+")") +
 		sqlOpt("", c.Cluster, "") +
 		sqlOpt("", c.RowDeletionPolicy, "") +
 		sqlOpt(", ", c.Options, "")

--- a/parser.go
+++ b/parser.go
@@ -3679,6 +3679,7 @@ func (p *Parser) parseCreateTable(pos token.Pos) *ast.CreateTable {
 	var keys []*ast.IndexKey
 	primaryKeyRparen := token.InvalidPos
 	if p.Token.IsKeywordLike("PRIMARY") {
+		// Keep the slice non-nil to distinguish PRIMARY KEY () from an omitted clause.
 		keys = []*ast.IndexKey{}
 		p.nextToken()
 		p.expectKeywordLike("KEY")

--- a/parser.go
+++ b/parser.go
@@ -3679,6 +3679,7 @@ func (p *Parser) parseCreateTable(pos token.Pos) *ast.CreateTable {
 	var keys []*ast.IndexKey
 	primaryKeyRparen := token.InvalidPos
 	if p.Token.IsKeywordLike("PRIMARY") {
+		keys = []*ast.IndexKey{}
 		p.nextToken()
 		p.expectKeywordLike("KEY")
 
@@ -3883,7 +3884,10 @@ func (p *Parser) parseTablePrimaryKey() *ast.TablePrimaryKey {
 	p.expectKeywordLike("KEY")
 
 	p.expect("(")
-	keys := parseCommaSeparatedList(p, p.parseIndexKey)
+	var keys []*ast.IndexKey
+	if p.Token.Kind != ")" {
+		keys = parseCommaSeparatedList(p, p.parseIndexKey)
+	}
 	rparen := p.expect(")").Pos
 
 	return &ast.TablePrimaryKey{

--- a/testdata/input/ddl/create_table_empty_primary_key.sql
+++ b/testdata/input/ddl/create_table_empty_primary_key.sql
@@ -1,0 +1,1 @@
+CREATE TABLE Singleton (Name STRING(MAX)) PRIMARY KEY ()

--- a/testdata/input/ddl/create_table_empty_primary_key_constraint.sql
+++ b/testdata/input/ddl/create_table_empty_primary_key_constraint.sql
@@ -1,0 +1,1 @@
+CREATE TABLE Singleton (Name STRING(MAX), PRIMARY KEY ())

--- a/testdata/input/ddl/create_table_omitted_primary_key.sql
+++ b/testdata/input/ddl/create_table_omitted_primary_key.sql
@@ -1,0 +1,1 @@
+CREATE TABLE GeneratedKey (Name STRING(MAX))

--- a/testdata/result/ddl/create_table_cluster.sql.txt
+++ b/testdata/result/ddl/create_table_cluster.sql.txt
@@ -48,7 +48,8 @@ create table foo (
       Hidden: -1,
     },
   },
-  Cluster: &ast.Cluster{
+  PrimaryKeys: []*ast.IndexKey{},
+  Cluster:     &ast.Cluster{
     Comma:       60,
     OnDeleteEnd: -1,
     TableName:   &ast.Path{
@@ -68,5 +69,5 @@ create table foo (
 CREATE TABLE foo (
   foo INT64,
   bar INT64
-),
+) PRIMARY KEY (),
   INTERLEAVE IN PARENT foobar

--- a/testdata/result/ddl/create_table_cluster_and_row_deletion_policy.sql.txt
+++ b/testdata/result/ddl/create_table_cluster_and_row_deletion_policy.sql.txt
@@ -64,7 +64,8 @@ create table foo (
       Hidden: -1,
     },
   },
-  Cluster: &ast.Cluster{
+  PrimaryKeys: []*ast.IndexKey{},
+  Cluster:     &ast.Cluster{
     Comma:       78,
     OnDeleteEnd: -1,
     TableName:   &ast.Path{
@@ -103,5 +104,5 @@ CREATE TABLE foo (
   foo INT64,
   bar INT64,
   baz TIMESTAMP
-),
+) PRIMARY KEY (),
   INTERLEAVE IN PARENT foobar, ROW DELETION POLICY ( OLDER_THAN ( baz, INTERVAL 30 DAY ))

--- a/testdata/result/ddl/create_table_empty_primary_key.sql.txt
+++ b/testdata/result/ddl/create_table_empty_primary_key.sql.txt
@@ -1,0 +1,41 @@
+--- create_table_empty_primary_key.sql
+CREATE TABLE Singleton (Name STRING(MAX)) PRIMARY KEY ()
+
+--- AST
+&ast.CreateTable{
+  Rparen:           40,
+  PrimaryKeyRparen: 55,
+  Name:             &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 22,
+        Name:    "Singleton",
+      },
+    },
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 24,
+        NameEnd: 28,
+        Name:    "Name",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 29,
+        Rparen:  39,
+        Name:    "STRING",
+        Max:     true,
+      },
+      Hidden: -1,
+    },
+  },
+  PrimaryKeys: []*ast.IndexKey{},
+}
+
+--- SQL
+CREATE TABLE Singleton (
+  Name STRING(MAX)
+) PRIMARY KEY ()

--- a/testdata/result/ddl/create_table_empty_primary_key_constraint.sql.txt
+++ b/testdata/result/ddl/create_table_empty_primary_key_constraint.sql.txt
@@ -1,0 +1,50 @@
+--- create_table_empty_primary_key_constraint.sql
+CREATE TABLE Singleton (Name STRING(MAX), PRIMARY KEY ())
+
+--- AST
+&ast.CreateTable{
+  Rparen:           56,
+  PrimaryKeyRparen: -1,
+  Name:             &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 22,
+        Name:    "Singleton",
+      },
+    },
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 24,
+        NameEnd: 28,
+        Name:    "Name",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 29,
+        Rparen:  39,
+        Name:    "STRING",
+        Max:     true,
+      },
+      Hidden: -1,
+    },
+  },
+  TableConstraints: []*ast.TableConstraint{
+    &ast.TableConstraint{
+      ConstraintPos: -1,
+      Constraint:    &ast.TablePrimaryKey{
+        Primary: 42,
+        Rparen:  55,
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE TABLE Singleton (
+  Name STRING(MAX),
+  PRIMARY KEY ()
+)

--- a/testdata/result/ddl/create_table_omitted_primary_key.sql.txt
+++ b/testdata/result/ddl/create_table_omitted_primary_key.sql.txt
@@ -1,0 +1,40 @@
+--- create_table_omitted_primary_key.sql
+CREATE TABLE GeneratedKey (Name STRING(MAX))
+
+--- AST
+&ast.CreateTable{
+  Rparen:           43,
+  PrimaryKeyRparen: -1,
+  Name:             &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 25,
+        Name:    "GeneratedKey",
+      },
+    },
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 27,
+        NameEnd: 31,
+        Name:    "Name",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 32,
+        Rparen:  42,
+        Name:    "STRING",
+        Max:     true,
+      },
+      Hidden: -1,
+    },
+  },
+}
+
+--- SQL
+CREATE TABLE GeneratedKey (
+  Name STRING(MAX)
+)

--- a/testdata/result/ddl/create_table_row_deletion_policy.sql.txt
+++ b/testdata/result/ddl/create_table_row_deletion_policy.sql.txt
@@ -63,6 +63,7 @@ create table foo (
       Hidden: -1,
     },
   },
+  PrimaryKeys:       []*ast.IndexKey{},
   RowDeletionPolicy: &ast.CreateRowDeletionPolicy{
     Comma:             78,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
@@ -88,4 +89,4 @@ CREATE TABLE foo (
   foo INT64,
   bar INT64,
   baz TIMESTAMP
-), ROW DELETION POLICY ( OLDER_THAN ( baz, INTERVAL 30 DAY ))
+) PRIMARY KEY (), ROW DELETION POLICY ( OLDER_THAN ( baz, INTERVAL 30 DAY ))

--- a/testdata/result/statement/create_table_cluster.sql.txt
+++ b/testdata/result/statement/create_table_cluster.sql.txt
@@ -48,7 +48,8 @@ create table foo (
       Hidden: -1,
     },
   },
-  Cluster: &ast.Cluster{
+  PrimaryKeys: []*ast.IndexKey{},
+  Cluster:     &ast.Cluster{
     Comma:       60,
     OnDeleteEnd: -1,
     TableName:   &ast.Path{
@@ -68,5 +69,5 @@ create table foo (
 CREATE TABLE foo (
   foo INT64,
   bar INT64
-),
+) PRIMARY KEY (),
   INTERLEAVE IN PARENT foobar

--- a/testdata/result/statement/create_table_cluster_and_row_deletion_policy.sql.txt
+++ b/testdata/result/statement/create_table_cluster_and_row_deletion_policy.sql.txt
@@ -64,7 +64,8 @@ create table foo (
       Hidden: -1,
     },
   },
-  Cluster: &ast.Cluster{
+  PrimaryKeys: []*ast.IndexKey{},
+  Cluster:     &ast.Cluster{
     Comma:       78,
     OnDeleteEnd: -1,
     TableName:   &ast.Path{
@@ -103,5 +104,5 @@ CREATE TABLE foo (
   foo INT64,
   bar INT64,
   baz TIMESTAMP
-),
+) PRIMARY KEY (),
   INTERLEAVE IN PARENT foobar, ROW DELETION POLICY ( OLDER_THAN ( baz, INTERVAL 30 DAY ))

--- a/testdata/result/statement/create_table_empty_primary_key.sql.txt
+++ b/testdata/result/statement/create_table_empty_primary_key.sql.txt
@@ -1,0 +1,41 @@
+--- create_table_empty_primary_key.sql
+CREATE TABLE Singleton (Name STRING(MAX)) PRIMARY KEY ()
+
+--- AST
+&ast.CreateTable{
+  Rparen:           40,
+  PrimaryKeyRparen: 55,
+  Name:             &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 22,
+        Name:    "Singleton",
+      },
+    },
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 24,
+        NameEnd: 28,
+        Name:    "Name",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 29,
+        Rparen:  39,
+        Name:    "STRING",
+        Max:     true,
+      },
+      Hidden: -1,
+    },
+  },
+  PrimaryKeys: []*ast.IndexKey{},
+}
+
+--- SQL
+CREATE TABLE Singleton (
+  Name STRING(MAX)
+) PRIMARY KEY ()

--- a/testdata/result/statement/create_table_empty_primary_key_constraint.sql.txt
+++ b/testdata/result/statement/create_table_empty_primary_key_constraint.sql.txt
@@ -1,0 +1,50 @@
+--- create_table_empty_primary_key_constraint.sql
+CREATE TABLE Singleton (Name STRING(MAX), PRIMARY KEY ())
+
+--- AST
+&ast.CreateTable{
+  Rparen:           56,
+  PrimaryKeyRparen: -1,
+  Name:             &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 22,
+        Name:    "Singleton",
+      },
+    },
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 24,
+        NameEnd: 28,
+        Name:    "Name",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 29,
+        Rparen:  39,
+        Name:    "STRING",
+        Max:     true,
+      },
+      Hidden: -1,
+    },
+  },
+  TableConstraints: []*ast.TableConstraint{
+    &ast.TableConstraint{
+      ConstraintPos: -1,
+      Constraint:    &ast.TablePrimaryKey{
+        Primary: 42,
+        Rparen:  55,
+      },
+    },
+  },
+}
+
+--- SQL
+CREATE TABLE Singleton (
+  Name STRING(MAX),
+  PRIMARY KEY ()
+)

--- a/testdata/result/statement/create_table_omitted_primary_key.sql.txt
+++ b/testdata/result/statement/create_table_omitted_primary_key.sql.txt
@@ -1,0 +1,40 @@
+--- create_table_omitted_primary_key.sql
+CREATE TABLE GeneratedKey (Name STRING(MAX))
+
+--- AST
+&ast.CreateTable{
+  Rparen:           43,
+  PrimaryKeyRparen: -1,
+  Name:             &ast.Path{
+    Idents: []*ast.Ident{
+      &ast.Ident{
+        NamePos: 13,
+        NameEnd: 25,
+        Name:    "GeneratedKey",
+      },
+    },
+  },
+  Columns: []*ast.ColumnDef{
+    &ast.ColumnDef{
+      Null: -1,
+      Key:  -1,
+      Name: &ast.Ident{
+        NamePos: 27,
+        NameEnd: 31,
+        Name:    "Name",
+      },
+      Type: &ast.SizedSchemaType{
+        NamePos: 32,
+        Rparen:  42,
+        Name:    "STRING",
+        Max:     true,
+      },
+      Hidden: -1,
+    },
+  },
+}
+
+--- SQL
+CREATE TABLE GeneratedKey (
+  Name STRING(MAX)
+)

--- a/testdata/result/statement/create_table_row_deletion_policy.sql.txt
+++ b/testdata/result/statement/create_table_row_deletion_policy.sql.txt
@@ -63,6 +63,7 @@ create table foo (
       Hidden: -1,
     },
   },
+  PrimaryKeys:       []*ast.IndexKey{},
   RowDeletionPolicy: &ast.CreateRowDeletionPolicy{
     Comma:             78,
     RowDeletionPolicy: &ast.RowDeletionPolicy{
@@ -88,4 +89,4 @@ CREATE TABLE foo (
   foo INT64,
   bar INT64,
   baz TIMESTAMP
-), ROW DELETION POLICY ( OLDER_THAN ( baz, INTERVAL 30 DAY ))
+) PRIMARY KEY (), ROW DELETION POLICY ( OLDER_THAN ( baz, INTERVAL 30 DAY ))


### PR DESCRIPTION
- Fixes #426.

Preserve `PRIMARY KEY ()` in `CreateTable.SQL()` and accept the empty table-constraint form. `CreateTable.PrimaryKeys` distinguishes nil (omitted) from a non-nil empty slice (explicit empty key).

Add golden coverage for both forms and omission.