### PR TITLE
fix: recognize carriage returns as lexer newline boundaries

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -605,7 +605,7 @@ func (l *Lexer) consumeQuotedContent(q string, raw, unicode bool, name string, n
 			continue
 		}
 
-		if c == '\n' && len(q) != 3 {
+		if (c == '\n' || c == '\r') && len(q) != 3 {
 			if noPanic {
 				hasError = true
 				i++
@@ -642,15 +642,27 @@ func (l *Lexer) skipComment(noPanic bool) bool {
 	r, _ := utf8.DecodeRuneInString(l.Buffer[l.pos:])
 	switch {
 	case r == '#' || r == '-' && l.peekIs(1, '-'):
-		return l.skipCommentUntil("\n", false, noPanic)
+		for !l.eof() {
+			switch l.skip() {
+			case '\r':
+				// Keep CRLF together in the comment's raw text.
+				if l.peekIs(0, '\n') {
+					l.skip()
+				}
+				return false
+			case '\n':
+				return false
+			}
+		}
+		return false
 	case r == '/' && l.peekIs(1, '*'):
-		return l.skipCommentUntil("*/", true, noPanic)
+		return l.skipCommentUntil("*/", noPanic)
 	default:
 		return false
 	}
 }
 
-func (l *Lexer) skipCommentUntil(end string, mustEnd bool, noPanic bool) bool {
+func (l *Lexer) skipCommentUntil(end string, noPanic bool) bool {
 	pos := token.Pos(l.pos)
 	for !l.eof() {
 		if l.slice(0, len(end)) == end {
@@ -659,12 +671,10 @@ func (l *Lexer) skipCommentUntil(end string, mustEnd bool, noPanic bool) bool {
 		}
 		l.skip()
 	}
-	if mustEnd {
-		if noPanic {
-			return true
-		}
-		l.panicfAtPosition(pos, token.Pos(l.pos), "unclosed comment")
+	if noPanic {
+		return true
 	}
+	l.panicfAtPosition(pos, token.Pos(l.pos), "unclosed comment")
 
 	return false
 }

--- a/lexer.go
+++ b/lexer.go
@@ -656,13 +656,14 @@ func (l *Lexer) skipComment(noPanic bool) bool {
 		}
 		return false
 	case r == '/' && l.peekIs(1, '*'):
-		return l.skipCommentUntil("*/", noPanic)
+		return l.skipBlockComment(noPanic)
 	default:
 		return false
 	}
 }
 
-func (l *Lexer) skipCommentUntil(end string, noPanic bool) bool {
+func (l *Lexer) skipBlockComment(noPanic bool) bool {
+	const end = "*/"
 	pos := token.Pos(l.pos)
 	for !l.eof() {
 		if l.slice(0, len(end)) == end {

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -150,6 +150,16 @@ var lexerWrongTestCase = []struct {
 	{`R"foo`, 1, 5, "unclosed raw string literal"},
 	{"'foo\n", 0, 4, "unclosed string literal: newline appears in non triple-quoted"},
 	{"R'foo\n", 1, 5, "unclosed raw string literal: newline appears in non triple-quoted"},
+	{"'foo\rbar'", 0, 4, "unclosed string literal: newline appears in non triple-quoted"},
+	{"\"foo\rbar\"", 0, 4, "unclosed string literal: newline appears in non triple-quoted"},
+	{"'foo\r\nbar'", 0, 4, "unclosed string literal: newline appears in non triple-quoted"},
+	{"R'foo\rbar'", 1, 5, "unclosed raw string literal: newline appears in non triple-quoted"},
+	{"R\"foo\rbar\"", 1, 5, "unclosed raw string literal: newline appears in non triple-quoted"},
+	{"B'foo\rbar'", 1, 5, "unclosed bytes literal: newline appears in non triple-quoted"},
+	{"B\"foo\rbar\"", 1, 5, "unclosed bytes literal: newline appears in non triple-quoted"},
+	{"RB'foo\rbar'", 2, 6, "unclosed raw bytes literal: newline appears in non triple-quoted"},
+	{"BR\"foo\rbar\"", 2, 6, "unclosed raw bytes literal: newline appears in non triple-quoted"},
+	{"`foo\rbar`", 0, 4, "unclosed identifier: newline appears in non triple-quoted"},
 	{"R'foo\\", 5, 6, "invalid escape sequence: \\<eof>"},
 	{`"\400"`, 1, 3, "invalid escape sequence: \\4"},
 	{`"\3xx"`, 1, 4, "invalid escape sequence: octal escape sequence must be follwed by 3 octal digits"},
@@ -214,6 +224,24 @@ func TestLexer(t *testing.T) {
 	for _, tc := range lexerTestCases {
 		t.Run(fmt.Sprintf("testcase/%q", tc.source), func(t *testing.T) {
 			testLexer(t, tc.source, tc.tokens)
+		})
+	}
+}
+
+func TestLexerLineCommentNewlines(t *testing.T) {
+	for _, prefix := range []string{"#", "--"} {
+		for _, newline := range []string{"\n", "\r", "\r\n"} {
+			comment := prefix + " comment" + newline
+			t.Run(fmt.Sprintf("%q", comment), func(t *testing.T) {
+				testLexer(t, comment+"0", []*Token{{
+					Kind: TokenInt, Raw: "0", Base: 10,
+					Comments: []TokenComment{{Raw: comment, End: Pos(len(comment))}},
+				}})
+				testLexer(t, comment, nil)
+			})
+		}
+		t.Run(prefix+"/EOF", func(t *testing.T) {
+			testLexer(t, prefix+" comment", nil)
 		})
 	}
 }


### PR DESCRIPTION
End `--`/`#` comments at CR as well as LF, preserving CRLF in comment text. Reject literal CR in non-triple-quoted strings, bytes literals, and identifiers, as already done for LF.

Add lexer regressions for newline forms, quote/prefix variants, error positions, and recovery.

- Closes #436